### PR TITLE
Send verification emails on registration

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -31,8 +31,8 @@ class Settings(BaseSettings):
     # Email Configuration
     SMTP_SERVER: str = "smtp.gmail.com"
     SMTP_PORT: int = 587
-    SMTP_USERNAME: str = ""  # Votre adresse Gmail
-    SMTP_PASSWORD: str = ""  # Votre mot de passe d'application Gmail
+    SMTP_USERNAME: str = os.environ.get("SMTP_USERNAME", "")  # Votre adresse Gmail
+    SMTP_PASSWORD: str = os.environ.get("SMTP_PASSWORD", "")  # Votre mot de passe d'application Gmail
     
     # TrackingMore API
     TRACKINGMORE_API_KEY: Optional[str] = None

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -15,6 +15,7 @@ from ..services.auth import (
 )
 from ..config import settings
 from ..database import get_db
+from ..services.email import send_verification_email
 
 router = APIRouter(
     prefix="/auth",
@@ -38,8 +39,11 @@ async def register(user: UserCreate, db: Session = Depends(get_db)):
     db_user = create_user(db, user)
     db_user.verification_token = verification_token
     db.commit()
-    
-    # Retourner le lien de vérification
+
+    # Envoyer l'email de vérification
+    send_verification_email(db_user.email, verification_token)
+
+    # Retourner l'utilisateur nouvellement créé
     verification_link = f"http://localhost:4200/verify-email?token={verification_token}"
     return db_user
 


### PR DESCRIPTION
## Summary
- send verification email after user creation
- read SMTP credentials from environment

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q` *(fails: fixture `tracking_id` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844884a14f8832ebc43f9eb1911c0a9