### PR TITLE
Add TrackingDB model

### DIFF
--- a/backend/app/init_db.py
+++ b/backend/app/init_db.py
@@ -1,5 +1,5 @@
 from sqlalchemy import create_engine
-from .models.database import Base
+from .models.database import Base, TrackingDB
 from .config import settings
 
 def init_db():


### PR DESCRIPTION
## Summary
- create a new `TrackingDB` ORM model with links to events and details
- allow `TrackingEventDB`, `PackageDetailsDB` and `DeliveryDetailsDB` to reference `TrackingDB`
- expose the model through `init_db.py`

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: fixture not found)*

------
https://chatgpt.com/codex/tasks/task_e_68448847e928832eba41e08fe01f593c