### PR TITLE
Fix TrackingService initialization with db session

### DIFF
--- a/backend/app/api/v1/endpoints/tracking.py
+++ b/backend/app/api/v1/endpoints/tracking.py
@@ -174,7 +174,7 @@ async def track_multiple_packages(
     """
     Track multiple packages (max 40)
     """
-    tracking_service = TrackingService(db)
+    tracking_service = TrackingService(db=db)
     response = await tracking_service.track_multiple_packages(tracking_numbers)
     if not response:
         raise HTTPException(status_code=400, detail="Failed to track packages")
@@ -188,7 +188,7 @@ async def search_trackings(
     """
     Search and filter tracking records
     """
-    tracking_service = TrackingService(db)
+    tracking_service = TrackingService(db=db)
     try:
         results, total_count = await tracking_service.search_trackings(filters)
         return {
@@ -209,7 +209,7 @@ async def get_tracking_stats(
     """
     Get tracking statistics
     """
-    tracking_service = TrackingService(db)
+    tracking_service = TrackingService(db=db)
     try:
         stats = await tracking_service.get_tracking_stats()
         return {

--- a/backend/app/services/tracking_service.py
+++ b/backend/app/services/tracking_service.py
@@ -8,13 +8,15 @@ from ..models.tracking import (
     TrackingInfo, TrackingEvent, TrackingResponse, Location,
     PackageDetails, DeliveryDetails, TrackingFilter
 )
+from sqlalchemy.orm import Session
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 class TrackingService:
-    def __init__(self):
+    def __init__(self, db: Session):
+        self.db = db
         self.fedex_service = FedExService()
 
     def _validate_tracking_number(self, tracking_number: str) -> bool:


### PR DESCRIPTION
## Summary
- inject SQLAlchemy Session into `TrackingService`
- update service usage in tracking endpoints

## Testing
- `python -m py_compile backend/app/services/tracking_service.py backend/app/api/v1/endpoints/tracking.py`

------
https://chatgpt.com/codex/tasks/task_e_68448846f258832eb9843a3e1497c8a9