### PR TITLE
Add Google OAuth env variables

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,25 @@
+# Example environment configuration for the backend
+
+# FedEx API credentials
+FEDEX_CLIENT_ID=your-fedex-client-id
+FEDEX_CLIENT_SECRET=your-fedex-client-secret
+FEDEX_ACCOUNT_NUMBER=your-fedex-account-number
+
+# Google OAuth credentials
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+GOOGLE_REDIRECT_URI=http://localhost:8000/api/v1/auth/google/callback
+
+# JWT configuration
+ACCESS_TOKEN_EXPIRE_MINUTES=30
+
+# Database connection
+DATABASE_URL=postgresql://user:password@localhost/tracking_app
+
+# Server configuration
+HOST=0.0.0.0
+PORT=8000
+DEBUG=True
+
+# CORS configuration
+FRONTEND_URL=http://localhost:4200

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -26,9 +26,9 @@ class Settings(BaseSettings):
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
     
     # Google OAuth2 Configuration
-    GOOGLE_CLIENT_ID: Optional[str] = None
-    GOOGLE_CLIENT_SECRET: Optional[str] = None
-    GOOGLE_REDIRECT_URI: Optional[str] = None
+    GOOGLE_CLIENT_ID: Optional[str] = os.environ.get("GOOGLE_CLIENT_ID")
+    GOOGLE_CLIENT_SECRET: Optional[str] = os.environ.get("GOOGLE_CLIENT_SECRET")
+    GOOGLE_REDIRECT_URI: Optional[str] = os.environ.get("GOOGLE_REDIRECT_URI")
 
     # Email Configuration
     SMTP_SERVER: str = "smtp.gmail.com"

--- a/backend/app/routers/google_auth.py
+++ b/backend/app/routers/google_auth.py
@@ -27,7 +27,7 @@ oauth.register(
 
 @router.get("/login")
 async def google_login(request: Request):
-    redirect_uri = request.url_for('google_auth_callback')
+    redirect_uri = settings.GOOGLE_REDIRECT_URI or request.url_for('google_auth_callback')
     return await oauth.google.authorize_redirect(request, redirect_uri)
 
 @router.get("/callback")


### PR DESCRIPTION
## Summary
- load Google OAuth credentials from environment
- allow overriding OAuth redirect URI
- provide `.env.example` with placeholders

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: fixture 'tracking_id' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68449381cc64832eb42a8d9e97f04cbf