### PR TITLE
Use environment variables for FedEx credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # AppTracking
+
+## Environment Variables
+
+The backend requires several FedEx credentials to be provided via environment variables.
+Create a `.env` file in the `backend` directory or export them in your shell:
+
+```
+FEDEX_AUTH_URL=<FedEx OAuth URL>
+FEDEX_CLIENT_ID=<your FedEx client id>
+FEDEX_CLIENT_SECRET=<your FedEx client secret>
+FEDEX_ACCOUNT_NUMBER=<your FedEx account number>
+```
+
+Optionally set `FEDEX_BASE_URL` to override the default `https://apis-sandbox.fedex.com`.
+

--- a/backend/app/config/fedex.yaml
+++ b/backend/app/config/fedex.yaml
@@ -1,5 +1,5 @@
 prod:
-  api_url: "https://apis-sandbox.fedex.com/oauth/token"
-  client_id: "l713d722ef2f2d48269e1d33f7cade563c"
-  client_secret: "4a99540fcd654b4393e9c3dd11432850"
-  account_number: "740561073" 
+  api_url: "${FEDEX_AUTH_URL}"
+  client_id: "${FEDEX_CLIENT_ID}"
+  client_secret: "${FEDEX_CLIENT_SECRET}"
+  account_number: "${FEDEX_ACCOUNT_NUMBER}"

--- a/backend/app/services/fedex_service.py
+++ b/backend/app/services/fedex_service.py
@@ -24,13 +24,13 @@ class FedExService:
             logger.info(f"Loading FedEx configuration from {config_path}")
             with open(config_path, 'r') as file:
                 config = yaml.safe_load(file)['prod']
-            
-            self.base_url = "https://apis-sandbox.fedex.com"
-            self.auth_url = config['api_url']
+
+            self.base_url = os.getenv("FEDEX_BASE_URL", "https://apis-sandbox.fedex.com")
+            self.auth_url = os.path.expandvars(config['api_url'])
             self.cdict = {
-                'client_id': config['client_id'],
-                'client_secret': config['client_secret'],
-                'account_number': config['account_number']
+                'client_id': os.path.expandvars(config['client_id']),
+                'client_secret': os.path.expandvars(config['client_secret']),
+                'account_number': os.path.expandvars(config['account_number'])
             }
             self.payload = {
                 "grant_type": "client_credentials",


### PR DESCRIPTION
## Summary
- avoid storing FedEx secrets in source by using env vars in `fedex.yaml`
- read env vars in `FedExService`
- document required environment variables

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q` *(fails: fixture `tracking_id` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68449380c664832e96409cf9405ecb14