### PR TITLE
Add SQLAlchemy TrackingDB model and update service

### DIFF
--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -95,4 +95,21 @@ class DeliveryDetailsDB(Base):
 
     # Relations
     colis = relationship("ColisDB", back_populates="delivery_details")
-    delivery_location = relationship("LocationDB") 
+    delivery_location = relationship("LocationDB")
+
+
+class TrackingDB(Base):
+    __tablename__ = "trackings"
+
+    id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
+    tracking_number = Column(String, unique=True, index=True)
+    status = Column(String, default="PENDING")
+    carrier = Column(String)
+    meta_data = Column(JSON, default=dict)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+    # Relations
+    events = relationship("TrackingEventDB")
+    package_details = relationship("PackageDetailsDB", uselist=False)
+    delivery_details = relationship("DeliveryDetailsDB", uselist=False)


### PR DESCRIPTION
## Summary
- allow `TrackingService` to be constructed with a SQLAlchemy `Session`
- create `TrackingDB` model in `backend/app/models/database.py`
- use the new model in `TrackingService`

## Testing
- `pytest -q` *(fails: fixture errors)*

------
https://chatgpt.com/codex/tasks/task_e_68449385b7ac832e8f483d81f3022733