### PR TITLE
Fix backend auth and cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ __pycache__/
 *.pyc
 .env
 venv/
+
+# Ignore backend dependencies
+backend/node_modules/
+backend/venv/

--- a/backend/app/services/fedex_auth.py
+++ b/backend/app/services/fedex_auth.py
@@ -5,54 +5,52 @@ from datetime import datetime, timedelta
 
 load_dotenv()
 
-class FedExAuth:
-   def __init__(self):
-    #    self.client_id = os.getenv('FEDEX_CLIENT_ID', 'l7a3be758bf3b24fe487c2c2fcbf63800a')
-     #   self.client_secret = os.getenv('FEDEX_CLIENT_SECRET', '0f50edb9d00b4076baefbce8eddc93a1')
-     #   self.account_number = os.getenv('FEDEX_ACCOUNT_NUMBER', '740561073')
-        # Forcer l'utilisation de l'environnement sandbox pour le développement
-        self.base_url = "https://apis-sandbox.fedex.com"
-        self._access_token = None
-        self._token_expiry = None
-        # Clés FedEx (à déplacer dans .env)
-        # FEDEX_CLIENT_ID=l7a3be758bf3b24fe487c2c2fcbf63800a
-        # FEDEX_CLIENT_SECRET=0f50edb9d00b4076baefbce8eddc93a1
-        
-        self.client_id = os.getenv('FEDEX_CLIENT_ID')
-        self.client_secret = os.getenv('FEDEX_CLIENT_SECRET')
 
-    def get_access_token(self):
-        """Get a new access token or return existing valid token"""
-        if self._access_token and self._token_expiry and datetime.now() < self._token_expiry:
+class FedExAuth:
+    def __init__(self):
+        # Force use of the sandbox environment for development
+        self.base_url = "https://apis-sandbox.fedex.com"
+        self._access_token: str | None = None
+        self._token_expiry: datetime | None = None
+
+        # Credentials are read from environment variables
+        self.client_id = os.getenv("FEDEX_CLIENT_ID")
+        self.client_secret = os.getenv("FEDEX_CLIENT_SECRET")
+
+    def get_access_token(self) -> str:
+        """Return a valid FedEx access token."""
+        if (
+            self._access_token
+            and self._token_expiry
+            and datetime.now() < self._token_expiry
+        ):
             return self._access_token
 
         url = f"{self.base_url}/oauth/token"
-        headers = {
-            'Content-Type': 'application/x-www-form-urlencoded'
-        }
+        headers = {"Content-Type": "application/x-www-form-urlencoded"}
         data = {
-            'grant_type': 'client_credentials',
-            'client_id': self.client_id,
-            'client_secret': self.client_secret
+            "grant_type": "client_credentials",
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
         }
 
         try:
             response = requests.post(url, headers=headers, data=data)
             response.raise_for_status()
             token_data = response.json()
-            
-            self._access_token = token_data['access_token']
-            # Set token expiry to 30 minutes from now (FedEx tokens typically last 30 minutes)
+
+            self._access_token = token_data["access_token"]
+            # FedEx tokens typically last 30 minutes
             self._token_expiry = datetime.now() + timedelta(minutes=30)
-            
+
             return self._access_token
         except requests.exceptions.RequestException as e:
-            raise Exception(f"Failed to get FedEx access token: {str(e)}")
+            raise Exception(f"Failed to get FedEx access token: {e}") from e
 
-    def get_headers(self):
-        """Get headers with authentication token for API requests"""
+    def get_headers(self) -> dict[str, str]:
+        """Return headers including the authentication token."""
         return {
-            'Authorization': f'Bearer {self.get_access_token()}',
-            'Content-Type': 'application/json',
-            'X-locale': 'en_US'
-        } 
+            "Authorization": f"Bearer {self.get_access_token()}",
+            "Content-Type": "application/json",
+            "X-locale": "en_US",
+        }

--- a/backend/scripts/api_test_client.py
+++ b/backend/scripts/api_test_client.py
@@ -1,11 +1,13 @@
-import requests
 import json
-from typing import List, Dict, Any
+from typing import Any, Dict, List
+
+import requests
 
 BASE_URL = "http://localhost:8000/api/v1"
 
+
 def test_single_tracking(tracking_id: str) -> Dict[str, Any]:
-    """Test le suivi d'un seul colis"""
+    """Test le suivi d'un seul colis."""
     url = f"{BASE_URL}/track/{tracking_id}"
     response = requests.get(url)
     print(f"\n=== Test suivi colis {tracking_id} ===")
@@ -13,50 +15,56 @@ def test_single_tracking(tracking_id: str) -> Dict[str, Any]:
     print("Response:", json.dumps(response.json(), indent=2, ensure_ascii=False))
     return response.json()
 
+
 def test_batch_tracking(tracking_ids: List[str]) -> Dict[str, Any]:
-    """Test le suivi de plusieurs colis"""
+    """Test le suivi de plusieurs colis."""
     url = f"{BASE_URL}/track/batch"
     data = {"tracking_numbers": tracking_ids}
     response = requests.post(url, json=data)
-    print(f"\n=== Test suivi multiple colis ===")
+    print("\n=== Test suivi multiple colis ===")
     print(f"Status Code: {response.status_code}")
     print("Response:", json.dumps(response.json(), indent=2, ensure_ascii=False))
     return response.json()
 
-def test_update_tracking(tracking_id: str, customer_name: str = None, note: str = None) -> Dict[str, Any]:
-    """Test la mise à jour des informations d'un colis"""
+
+def test_update_tracking(
+    tracking_id: str, customer_name: str | None = None, note: str | None = None
+) -> Dict[str, Any]:
+    """Test la mise à jour des informations d'un colis."""
     url = f"{BASE_URL}/track/{tracking_id}"
-    data = {}
+    data: Dict[str, str] = {}
     if customer_name:
         data["customer_name"] = customer_name
     if note:
         data["note"] = note
-    
+
     response = requests.put(url, json=data)
     print(f"\n=== Test mise à jour colis {tracking_id} ===")
     print(f"Status Code: {response.status_code}")
     print("Response:", json.dumps(response.json(), indent=2, ensure_ascii=False))
     return response.json()
 
-def main():
+
+def main() -> None:
     # Liste des IDs de tracking à tester
     tracking_ids = [
         "1234567890",  # Remplacez par vos IDs réels
-        "0987654321"
+        "0987654321",
     ]
-    
+
     # Test 1: Suivi d'un seul colis
     test_single_tracking(tracking_ids[0])
-    
+
     # Test 2: Suivi de plusieurs colis
     test_batch_tracking(tracking_ids)
-    
+
     # Test 3: Mise à jour d'un colis
     test_update_tracking(
         tracking_ids[0],
         customer_name="John Doe",
-        note="Fragile package"
+        note="Fragile package",
     )
 
+
 if __name__ == "__main__":
-    main() 
+    main()


### PR DESCRIPTION
## Summary
- clean up `FedExAuth` to avoid indentation problems
- move tracking API test script out of pytest path
- ignore backend dependencies

## Testing
- `black --check backend/app backend/scripts/api_test_client.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684495c64a38832ebe9704362a013cfb