### PR TITLE
Fix OAuth2 token URL in auth service

### DIFF
--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -14,7 +14,7 @@ from ..database import get_db
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 # OAuth2 scheme
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl=f"{settings.API_V1_STR}/auth/token")
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
     return pwd_context.verify(plain_password, hashed_password)


### PR DESCRIPTION
## Summary
- use the API version prefix for `tokenUrl` when creating `OAuth2PasswordBearer`

## Testing
- `python - <<'PY'
from app.main import app
spec = app.openapi()
print(spec['components']['securitySchemes']['OAuth2PasswordBearer']['flows']['password']['tokenUrl'])
PY`

------
https://chatgpt.com/codex/tasks/task_e_684499b9cfb0832ea5f1e622696d7845