### PR TITLE
Add Google auth callback component

### DIFF
--- a/Frontend/src/app/app.routes.ts
+++ b/Frontend/src/app/app.routes.ts
@@ -3,6 +3,7 @@ import { HomeComponent } from './features/home/home.component';
 import { RegisterComponent } from './features/auth/register/register.component';
 import { LoginComponent } from './features/auth/login/login.component';
 import { TrackResultComponent } from './features/tracking/track-result/track-result.component';
+import { GoogleCallbackComponent } from './features/auth/google-callback/google-callback.component';
 
 // Assuming you might have other standalone components or lazy-loaded routes
 // import { HomeComponent } from './features/home/home.component';
@@ -22,4 +23,5 @@ export const routes: Routes = [
   // Add other routes here, including for other standalone components
   { path: 'track/:identifier', component: TrackResultComponent },
   { path: 'auth/login', component: LoginComponent },
+  { path: 'auth/callback', component: GoogleCallbackComponent },
 ];

--- a/Frontend/src/app/features/auth/google-callback/google-callback.component.html
+++ b/Frontend/src/app/features/auth/google-callback/google-callback.component.html
@@ -1,0 +1,1 @@
+<p>Connexion en cours...</p>

--- a/Frontend/src/app/features/auth/google-callback/google-callback.component.scss
+++ b/Frontend/src/app/features/auth/google-callback/google-callback.component.scss
@@ -1,0 +1,1 @@
+/* Style vide pour le composant de rappel Google */

--- a/Frontend/src/app/features/auth/google-callback/google-callback.component.ts
+++ b/Frontend/src/app/features/auth/google-callback/google-callback.component.ts
@@ -1,0 +1,24 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute, Router } from '@angular/router';
+
+@Component({
+  selector: 'app-google-callback',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './google-callback.component.html',
+  styleUrls: ['./google-callback.component.scss']
+})
+export class GoogleCallbackComponent implements OnInit {
+  constructor(private route: ActivatedRoute, private router: Router) {}
+
+  ngOnInit(): void {
+    this.route.queryParams.subscribe(params => {
+      const token = params['token'];
+      if (token) {
+        localStorage.setItem('token', token);
+      }
+      this.router.navigate(['/home']);
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- create GoogleCallbackComponent to process token
- route user to `/home` after storing token in localStorage
- wire new component into routes

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684499bd5e88832eb1112a1ea5ff1f19