### PR TITLE
Implement email verification page

### DIFF
--- a/Frontend/src/app/app.routes.ts
+++ b/Frontend/src/app/app.routes.ts
@@ -3,6 +3,7 @@ import { HomeComponent } from './features/home/home.component';
 import { RegisterComponent } from './features/auth/register/register.component';
 import { LoginComponent } from './features/auth/login/login.component';
 import { TrackResultComponent } from './features/tracking/track-result/track-result.component';
+import { VerifyEmailComponent } from './features/auth/verify-email/verify-email.component';
 
 // Assuming you might have other standalone components or lazy-loaded routes
 // import { HomeComponent } from './features/home/home.component';
@@ -22,4 +23,5 @@ export const routes: Routes = [
   // Add other routes here, including for other standalone components
   { path: 'track/:identifier', component: TrackResultComponent },
   { path: 'auth/login', component: LoginComponent },
+  { path: 'verify-email', component: VerifyEmailComponent },
 ];

--- a/Frontend/src/app/core/services/auth.service.ts
+++ b/Frontend/src/app/core/services/auth.service.ts
@@ -25,5 +25,9 @@ export class AuthService {
     window.location.href = `${this.apiUrl}/google/login`;
   }
 
+  verifyEmail(token: string): Observable<any> {
+    return this.http.post(`${this.apiUrl}/verify-email`, { token });
+  }
+
   // Vous pourriez ajouter d'autres méthodes ici, comme logout, getUserInfo, etc.
 } 

--- a/Frontend/src/app/features/auth/verify-email/verify-email.component.html
+++ b/Frontend/src/app/features/auth/verify-email/verify-email.component.html
@@ -1,0 +1,5 @@
+<div class="verify-email-container">
+  <p *ngIf="status === 'loading'">Vérification en cours...</p>
+  <p *ngIf="status === 'success'" class="success">{{ message }}</p>
+  <p *ngIf="status === 'error'" class="error">{{ message }}</p>
+</div>

--- a/Frontend/src/app/features/auth/verify-email/verify-email.component.scss
+++ b/Frontend/src/app/features/auth/verify-email/verify-email.component.scss
@@ -1,0 +1,13 @@
+.verify-email-container {
+  max-width: 400px;
+  margin: 50px auto;
+  text-align: center;
+}
+
+.success {
+  color: green;
+}
+
+.error {
+  color: red;
+}

--- a/Frontend/src/app/features/auth/verify-email/verify-email.component.ts
+++ b/Frontend/src/app/features/auth/verify-email/verify-email.component.ts
@@ -1,0 +1,44 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute } from '@angular/router';
+import { AuthService } from '../../../core/services/auth.service';
+import { catchError } from 'rxjs/operators';
+import { of } from 'rxjs';
+
+@Component({
+  selector: 'app-verify-email',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './verify-email.component.html',
+  styleUrls: ['./verify-email.component.scss']
+})
+export class VerifyEmailComponent implements OnInit {
+  status: 'loading' | 'success' | 'error' = 'loading';
+  message = '';
+
+  constructor(private route: ActivatedRoute, private authService: AuthService) {}
+
+  ngOnInit() {
+    this.route.queryParams.subscribe(params => {
+      const token = params['token'];
+      if (token) {
+        this.authService.verifyEmail(token).pipe(
+          catchError(err => {
+            console.error('Verification failed', err);
+            this.status = 'error';
+            this.message = 'La vérification a échoué.';
+            return of(null);
+          })
+        ).subscribe(res => {
+          if (res) {
+            this.status = 'success';
+            this.message = 'Votre email a été vérifié avec succès.';
+          }
+        });
+      } else {
+        this.status = 'error';
+        this.message = 'Token manquant.';
+      }
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add Angular component to verify email address
- expose `AuthService.verifyEmail` to post token
- mount VerifyEmailComponent on `/verify-email`

## Testing
- `npm test` *(fails: ng not found)*
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684499c4cdd0832ea28854fd168bf7b3