### PR TITLE
Implement frontend auth guard

### DIFF
--- a/Frontend/src/app/app.routes.ts
+++ b/Frontend/src/app/app.routes.ts
@@ -3,6 +3,7 @@ import { HomeComponent } from './features/home/home.component';
 import { RegisterComponent } from './features/auth/register/register.component';
 import { LoginComponent } from './features/auth/login/login.component';
 import { TrackResultComponent } from './features/tracking/track-result/track-result.component';
+import { authGuard } from './core/guards/auth.guard';
 
 // Assuming you might have other standalone components or lazy-loaded routes
 // import { HomeComponent } from './features/home/home.component';
@@ -12,7 +13,7 @@ export const routes: Routes = [
   { path: '', redirectTo: '/', pathMatch: 'full' },
   
   // Route vers la page d'accueil
-  { path: 'home', component: HomeComponent },
+  { path: 'home', component: HomeComponent, canActivate: [authGuard] },
 
   // Route vers la page d'enregistrement
   { path: 'auth/register', component: RegisterComponent },
@@ -20,6 +21,6 @@ export const routes: Routes = [
   // { path: 'home', component: HomeComponent }, // If you still have a home component
 
   // Add other routes here, including for other standalone components
-  { path: 'track/:identifier', component: TrackResultComponent },
+  { path: 'track/:identifier', component: TrackResultComponent, canActivate: [authGuard] },
   { path: 'auth/login', component: LoginComponent },
 ];

--- a/Frontend/src/app/core/guards/auth.guard.ts
+++ b/Frontend/src/app/core/guards/auth.guard.ts
@@ -1,0 +1,12 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { AuthService } from '../services/auth.service';
+
+export const authGuard: CanActivateFn = () => {
+  const authService = inject(AuthService);
+  const router = inject(Router);
+  if (authService.isLoggedIn()) {
+    return true;
+  }
+  return router.parseUrl('/auth/login');
+};


### PR DESCRIPTION
## Summary
- add a simple JWT-based `authGuard`
- save token on login and expose helpers in `AuthService`
- protect `/home` and tracking result routes with the guard

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684499c697f0832e8bb330d144510549