### PR TITLE
Implement token storage and logout

### DIFF
--- a/Frontend/src/app/core/services/auth.service.ts
+++ b/Frontend/src/app/core/services/auth.service.ts
@@ -25,5 +25,10 @@ export class AuthService {
     window.location.href = `${this.apiUrl}/google/login`;
   }
 
+  logout(): void {
+    localStorage.removeItem('token');
+    localStorage.removeItem('tokenType');
+  }
+
   // Vous pourriez ajouter d'autres méthodes ici, comme logout, getUserInfo, etc.
 } 

--- a/Frontend/src/app/features/auth/login/login.component.ts
+++ b/Frontend/src/app/features/auth/login/login.component.ts
@@ -34,6 +34,8 @@ export class LoginComponent {
         })
       ).subscribe(response => {
         if (response) {
+          localStorage.setItem('token', response.access_token);
+          localStorage.setItem('tokenType', response.token_type);
           this.router.navigate(['/home']);
         }
       });


### PR DESCRIPTION
## Summary
- save login tokens into local storage in the login flow
- add logout helper in `AuthService`

## Testing
- `npm test --prefix Frontend` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68449d2cd4d0832e988f5be9a31ca348