### PR TITLE
Adjust auth url to use environment

### DIFF
--- a/Frontend/src/app/core/services/auth.service.ts
+++ b/Frontend/src/app/core/services/auth.service.ts
@@ -1,13 +1,14 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
 
 @Injectable({
   providedIn: 'root'
 })
 export class AuthService {
-  // Utilisation de l'URL complète de l'API backend
-  private apiUrl = 'http://127.0.0.1:8000/api/v1/auth'; // URL de base de votre API backend
+  // Utilisation de l'URL adaptée à l'environnement
+  private apiUrl = `${environment.apiUrl}/auth`;
 
   constructor(private http: HttpClient) { }
 


### PR DESCRIPTION
## Summary
- configure AuthService to build its base URL from the environment settings

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68449d4d6adc832ebab73a9bc5ee2bd0