### PR TITLE
Add verify email component and routing

### DIFF
--- a/Frontend/src/app/app.routes.ts
+++ b/Frontend/src/app/app.routes.ts
@@ -4,6 +4,7 @@ import { RegisterComponent } from './features/auth/register/register.component';
 import { LoginComponent } from './features/auth/login/login.component';
 import { TrackResultComponent } from './features/tracking/track-result/track-result.component';
 import { GoogleCallbackComponent } from './features/auth/google-callback/google-callback.component';
+import { VerifyEmailComponent } from './features/auth/verify-email/verify-email.component';
 
 // Assuming you might have other standalone components or lazy-loaded routes
 // import { HomeComponent } from './features/home/home.component';
@@ -24,4 +25,5 @@ export const routes: Routes = [
   { path: 'track/:identifier', component: TrackResultComponent },
   { path: 'auth/login', component: LoginComponent },
   { path: 'auth/callback', component: GoogleCallbackComponent },
+  { path: 'verify-email', component: VerifyEmailComponent },
 ];

--- a/Frontend/src/app/core/services/auth.service.ts
+++ b/Frontend/src/app/core/services/auth.service.ts
@@ -25,5 +25,9 @@ export class AuthService {
     window.location.href = `${this.apiUrl}/google/login`;
   }
 
+  verifyEmail(token: string): Observable<any> {
+    return this.http.post(`${this.apiUrl}/verify-email`, { token });
+  }
+
   // Vous pourriez ajouter d'autres méthodes ici, comme logout, getUserInfo, etc.
 } 

--- a/Frontend/src/app/features/auth/verify-email/verify-email.component.html
+++ b/Frontend/src/app/features/auth/verify-email/verify-email.component.html
@@ -1,0 +1,4 @@
+<div class="verify-email">
+  <p *ngIf="message" class="success">{{ message }}</p>
+  <p *ngIf="error" class="error">{{ error }}</p>
+</div>

--- a/Frontend/src/app/features/auth/verify-email/verify-email.component.scss
+++ b/Frontend/src/app/features/auth/verify-email/verify-email.component.scss
@@ -1,0 +1,12 @@
+.verify-email {
+  text-align: center;
+  margin-top: 2rem;
+}
+
+.success {
+  color: green;
+}
+
+.error {
+  color: red;
+}

--- a/Frontend/src/app/features/auth/verify-email/verify-email.component.ts
+++ b/Frontend/src/app/features/auth/verify-email/verify-email.component.ts
@@ -1,0 +1,32 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute } from '@angular/router';
+import { AuthService } from '../../../core/services/auth.service';
+
+@Component({
+  selector: 'app-verify-email',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './verify-email.component.html',
+  styleUrls: ['./verify-email.component.scss']
+})
+export class VerifyEmailComponent implements OnInit {
+  message: string | null = null;
+  error: string | null = null;
+
+  constructor(private route: ActivatedRoute, private authService: AuthService) {}
+
+  ngOnInit(): void {
+    this.route.queryParams.subscribe(params => {
+      const token = params['token'];
+      if (token) {
+        this.authService.verifyEmail(token).subscribe({
+          next: () => (this.message = 'Email vérifié avec succès'),
+          error: () => (this.error = "Échec de la vérification de l'email")
+        });
+      } else {
+        this.error = 'Token manquant';
+      }
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add new VerifyEmailComponent to confirm registration
- call backend `POST /api/v1/auth/verify-email`
- expose new `verifyEmail` method in AuthService
- register component route `/verify-email`

## Testing
- `npm test --silent -- --watch=false` *(fails: No Chrome binary found)*

------
https://chatgpt.com/codex/tasks/task_e_68449d4fa918832e8c36facdb97d7387