### PR TITLE
feat: add email verification

### DIFF
--- a/Frontend/src/app/app.routes.ts
+++ b/Frontend/src/app/app.routes.ts
@@ -2,6 +2,7 @@ import { Routes } from '@angular/router';
 import { HomeComponent } from './features/home/home.component';
 import { RegisterComponent } from './features/auth/register/register.component';
 import { LoginComponent } from './features/auth/login/login.component';
+import { VerifyEmailComponent } from './features/auth/verify-email/verify-email.component';
 import { TrackResultComponent } from './features/tracking/track-result/track-result.component';
 import { GoogleCallbackComponent } from './features/auth/google-callback/google-callback.component';
 
@@ -23,5 +24,6 @@ export const routes: Routes = [
   // Add other routes here, including for other standalone components
   { path: 'track/:identifier', component: TrackResultComponent },
   { path: 'auth/login', component: LoginComponent },
+  { path: 'verify-email', component: VerifyEmailComponent },
   { path: 'auth/callback', component: GoogleCallbackComponent },
 ];

--- a/Frontend/src/app/core/services/auth.service.ts
+++ b/Frontend/src/app/core/services/auth.service.ts
@@ -38,6 +38,10 @@ export class AuthService {
     window.location.href = `${this.apiUrl}/google/login`;
   }
 
+  verifyEmail(token: string): Observable<any> {
+    return this.http.post(`${this.apiUrl}/verify-email`, { token });
+  }
+
   logout(): void {
     localStorage.removeItem('token');
     localStorage.removeItem('tokenType');

--- a/Frontend/src/app/features/auth/verify-email/verify-email.component.html
+++ b/Frontend/src/app/features/auth/verify-email/verify-email.component.html
@@ -1,0 +1,3 @@
+<div class="verify-email-container">
+  <p>{{ message }}</p>
+</div>

--- a/Frontend/src/app/features/auth/verify-email/verify-email.component.scss
+++ b/Frontend/src/app/features/auth/verify-email/verify-email.component.scss
@@ -1,0 +1,5 @@
+.verify-email-container {
+  max-width: 400px;
+  margin: 50px auto;
+  text-align: center;
+}

--- a/Frontend/src/app/features/auth/verify-email/verify-email.component.ts
+++ b/Frontend/src/app/features/auth/verify-email/verify-email.component.ts
@@ -1,0 +1,39 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute, Router } from '@angular/router';
+import { AuthService } from '../../../core/services/auth.service';
+
+@Component({
+  selector: 'app-verify-email',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './verify-email.component.html',
+  styleUrls: ['./verify-email.component.scss']
+})
+export class VerifyEmailComponent implements OnInit {
+  message: string | null = null;
+
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router,
+    private authService: AuthService
+  ) {}
+
+  ngOnInit(): void {
+    this.route.queryParams.subscribe(params => {
+      const token = params['token'];
+      if (token) {
+        this.authService.verifyEmail(token).subscribe({
+          next: () => {
+            this.message = 'Email vérifié avec succès';
+          },
+          error: () => {
+            this.message = "Échec de la vérification de l'email";
+          }
+        });
+      } else {
+        this.message = 'Token manquant';
+      }
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add `verifyEmail` API call in `AuthService`
- implement new `VerifyEmailComponent`
- register new verification route

## Testing
- `npm test` *(fails: ng not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844a2f01f2c832ebb6fe55cb3ec0604