### PR TITLE
Add email verification page

### DIFF
--- a/Frontend/src/app/app.routes.ts
+++ b/Frontend/src/app/app.routes.ts
@@ -4,6 +4,7 @@ import { RegisterComponent } from './features/auth/register/register.component';
 import { LoginComponent } from './features/auth/login/login.component';
 import { TrackResultComponent } from './features/tracking/track-result/track-result.component';
 import { GoogleCallbackComponent } from './features/auth/google-callback/google-callback.component';
+import { VerifyEmailComponent } from './features/auth/verify-email/verify-email.component';
 
 // Assuming you might have other standalone components or lazy-loaded routes
 // import { HomeComponent } from './features/home/home.component';
@@ -23,5 +24,6 @@ export const routes: Routes = [
   // Add other routes here, including for other standalone components
   { path: 'track/:identifier', component: TrackResultComponent },
   { path: 'auth/login', component: LoginComponent },
+  { path: 'verify-email', component: VerifyEmailComponent },
   { path: 'auth/callback', component: GoogleCallbackComponent },
 ];

--- a/Frontend/src/app/core/services/auth.service.ts
+++ b/Frontend/src/app/core/services/auth.service.ts
@@ -38,6 +38,10 @@ export class AuthService {
     window.location.href = `${this.apiUrl}/google/login`;
   }
 
+  verifyEmail(token: string): Observable<any> {
+    return this.http.post(`${this.apiUrl}/verify-email`, { token });
+  }
+
   logout(): void {
     localStorage.removeItem('token');
     localStorage.removeItem('tokenType');

--- a/Frontend/src/app/features/auth/verify-email/verify-email.component.html
+++ b/Frontend/src/app/features/auth/verify-email/verify-email.component.html
@@ -1,0 +1,6 @@
+<div class="verify-container">
+  <h2>Vérification de l'email</h2>
+  <p *ngIf="success === true" class="success-message">{{ message }}</p>
+  <p *ngIf="success === false" class="error-message">{{ message }}</p>
+  <p *ngIf="success === null">Traitement en cours...</p>
+</div>

--- a/Frontend/src/app/features/auth/verify-email/verify-email.component.scss
+++ b/Frontend/src/app/features/auth/verify-email/verify-email.component.scss
@@ -1,0 +1,13 @@
+.verify-container {
+  max-width: 400px;
+  margin: 50px auto;
+  text-align: center;
+}
+
+.success-message {
+  color: green;
+}
+
+.error-message {
+  color: red;
+}

--- a/Frontend/src/app/features/auth/verify-email/verify-email.component.ts
+++ b/Frontend/src/app/features/auth/verify-email/verify-email.component.ts
@@ -1,0 +1,39 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute } from '@angular/router';
+import { AuthService } from '../../../core/services/auth.service';
+
+@Component({
+  selector: 'app-verify-email',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './verify-email.component.html',
+  styleUrls: ['./verify-email.component.scss']
+})
+export class VerifyEmailComponent implements OnInit {
+  success: boolean | null = null;
+  message: string = '';
+
+  constructor(private route: ActivatedRoute, private authService: AuthService) {}
+
+  ngOnInit(): void {
+    this.route.queryParams.subscribe(params => {
+      const token = params['token'];
+      if (token) {
+        this.authService.verifyEmail(token).subscribe({
+          next: () => {
+            this.success = true;
+            this.message = 'Votre email a été vérifié avec succès.';
+          },
+          error: () => {
+            this.success = false;
+            this.message = 'La vérification de l\'email a échoué.';
+          }
+        });
+      } else {
+        this.success = false;
+        this.message = 'Jeton de vérification manquant.';
+      }
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add verify-email component
- handle query token and call backend
- expose verifyEmail API in AuthService
- declare route for email verification

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6844a2ef8524832e9d713cb40cf28a7d