### PR TITLE
Add auth guard for protected routes

### DIFF
--- a/Frontend/src/app/app.routes.ts
+++ b/Frontend/src/app/app.routes.ts
@@ -1,4 +1,5 @@
 import { Routes } from '@angular/router';
+import { AuthGuard } from './core/guards/auth.guard';
 import { HomeComponent } from './features/home/home.component';
 import { RegisterComponent } from './features/auth/register/register.component';
 import { LoginComponent } from './features/auth/login/login.component';
@@ -13,7 +14,7 @@ export const routes: Routes = [
   { path: '', redirectTo: '/', pathMatch: 'full' },
   
   // Route vers la page d'accueil
-  { path: 'home', component: HomeComponent },
+  { path: 'home', component: HomeComponent, canActivate: [AuthGuard] },
 
   // Route vers la page d'enregistrement
   { path: 'auth/register', component: RegisterComponent },
@@ -21,7 +22,7 @@ export const routes: Routes = [
   // { path: 'home', component: HomeComponent }, // If you still have a home component
 
   // Add other routes here, including for other standalone components
-  { path: 'track/:identifier', component: TrackResultComponent },
+  { path: 'track/:identifier', component: TrackResultComponent, canActivate: [AuthGuard] },
   { path: 'auth/login', component: LoginComponent },
   { path: 'auth/callback', component: GoogleCallbackComponent },
 ];

--- a/Frontend/src/app/core/guards/auth.guard.ts
+++ b/Frontend/src/app/core/guards/auth.guard.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, Router, UrlTree } from '@angular/router';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AuthGuard implements CanActivate {
+  constructor(private router: Router) {}
+
+  canActivate(): boolean | UrlTree {
+    const token = localStorage.getItem('token');
+    return token ? true : this.router.parseUrl('/auth/login');
+  }
+}


### PR DESCRIPTION
## Summary
- implement `AuthGuard` checking JWT presence
- protect `home` and `track/:identifier` routes with the guard

## Testing
- `npm test -- --watch=false` *(fails: Chrome browser not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a2f1849c832ebc50ed2996f4f9ee