### PR TITLE
Fix verification email link

### DIFF
--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -17,7 +17,7 @@ def send_verification_email(email: str, token: str):
     message["Subject"] = "Vérification de votre adresse email"
 
     # Corps du message
-    verification_link = f"http://localhost:4200/verify-email?token={token}"
+    verification_link = f"{settings.FRONTEND_URL}/verify-email?token={token}"
     body = f"""
     Bonjour,
 


### PR DESCRIPTION
## Summary
- use `settings.FRONTEND_URL` for email verification link

## Testing
- `python3 -m py_compile backend/app/services/email.py`

------
https://chatgpt.com/codex/tasks/task_e_6844a9980c60832e93fbf71c66a261c3