### PR TITLE
Implement refresh token system

### DIFF
--- a/backend/app/models/refresh_token.py
+++ b/backend/app/models/refresh_token.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+from sqlalchemy import Column, Integer, String, Boolean, DateTime, ForeignKey
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from ..database import Base
+from .user import UserDB
+
+class RefreshTokenDB(Base):
+    __tablename__ = "refresh_tokens"
+
+    id = Column(Integer, primary_key=True, index=True)
+    token = Column(String, unique=True, index=True, nullable=False)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    revoked = Column(Boolean, default=False)
+    expires_at = Column(DateTime(timezone=True))
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    user = relationship("UserDB", backref="refresh_tokens")

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -51,3 +51,9 @@ class TokenData(BaseModel):
 
 class EmailVerification(BaseModel):
     token: str 
+
+class RefreshTokenRequest(BaseModel):
+    refresh_token: str
+
+class TokenWithRefresh(Token):
+    refresh_token: str


### PR DESCRIPTION
## Summary
- create `RefreshTokenDB` model for storing refresh tokens
- extend user models with refresh token schemas
- add refresh token utilities in auth service
- update auth router to issue and manage refresh tokens

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844a99a7e60832e81e88240376e19e4