### PR TITLE
Implement token refresh on auth interceptor

### DIFF
--- a/Frontend/src/app/core/interceptors/auth.interceptor.ts
+++ b/Frontend/src/app/core/interceptors/auth.interceptor.ts
@@ -1,17 +1,46 @@
 import { Injectable } from '@angular/core';
-import { HttpEvent, HttpInterceptor, HttpHandler, HttpRequest } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { HttpEvent, HttpInterceptor, HttpHandler, HttpRequest, HttpErrorResponse } from '@angular/common/http';
+import { Observable, throwError, switchMap, catchError } from 'rxjs';
+import { AuthService } from '../services/auth.service';
+import { Router } from '@angular/router';
 
 @Injectable()
 export class AuthInterceptor implements HttpInterceptor {
+  constructor(private authService: AuthService, private router: Router) {}
+
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     const token = localStorage.getItem('token');
-    if (token) {
-      const authReq = req.clone({
-        setHeaders: { Authorization: `Bearer ${token}` }
-      });
-      return next.handle(authReq);
-    }
-    return next.handle(req);
+    const authReq = token
+      ? req.clone({ setHeaders: { Authorization: `Bearer ${token}` } })
+      : req;
+
+    return next.handle(authReq).pipe(
+      catchError((error: HttpErrorResponse) => {
+        if (error.status === 401) {
+          return this.authService.refreshToken().pipe(
+            switchMap((resp: any) => {
+              if (resp && resp.access_token) {
+                localStorage.setItem('token', resp.access_token);
+                if (resp.token_type) {
+                  localStorage.setItem('tokenType', resp.token_type);
+                }
+                const retryReq = req.clone({
+                  setHeaders: { Authorization: `Bearer ${resp.access_token}` }
+                });
+                return next.handle(retryReq);
+              } else {
+                this.router.navigate(['/auth/login']);
+                return throwError(() => error);
+              }
+            }),
+            catchError(refreshErr => {
+              this.router.navigate(['/auth/login']);
+              return throwError(() => refreshErr);
+            })
+          );
+        }
+        return throwError(() => error);
+      })
+    );
   }
 }

--- a/Frontend/src/app/core/services/auth.service.ts
+++ b/Frontend/src/app/core/services/auth.service.ts
@@ -51,5 +51,9 @@ export class AuthService {
     return !!localStorage.getItem('token');
   }
 
+  refreshToken(): Observable<any> {
+    return this.http.post(`${this.apiUrl}/refresh-token`, {});
+  }
+
   // Vous pourriez ajouter d'autres méthodes ici, comme logout, getUserInfo, etc.
 } 


### PR DESCRIPTION
## Summary
- support token refresh in `AuthService`
- retry requests after 401 by refreshing JWT in `AuthInterceptor`

## Testing
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a99f0160832e8653b53b9668422b