### PR TITLE
Fix redirect URL generation

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -45,7 +45,6 @@ async def register(user: UserCreate, db: Session = Depends(get_db)):
     send_verification_email(db_user.email, verification_token)
 
     # Retourner l'utilisateur nouvellement créé
-    verification_link = f"http://localhost:4200/verify-email?token={verification_token}"
     return db_user
 
 @router.post("/verify-email")

--- a/backend/app/routers/google_auth.py
+++ b/backend/app/routers/google_auth.py
@@ -71,7 +71,7 @@ async def google_auth_callback(request: Request, db: Session = Depends(get_db)):
         
         # Rediriger vers le frontend avec le token
         return RedirectResponse(
-            url=f"http://localhost:4200/auth/callback?token={access_token}"
+            url=f"{settings.FRONTEND_URL}/auth/callback?token={access_token}"
         )
         
     except OAuthError as e:


### PR DESCRIPTION
## Summary
- use `FRONTEND_URL` for google auth callback
- remove unused `verification_link` variable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844adea39f8832ead9deecf6232f15f