### PR TITLE
Implement refresh token handling

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -25,6 +25,7 @@ class Settings(BaseSettings):
     SECRET_KEY: str = "your-secret-key-here"  # Change this in production!
     ALGORITHM: str = "HS256"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
+    REFRESH_TOKEN_EXPIRE_DAYS: int = 7
     
     # Google OAuth2 Configuration
     GOOGLE_CLIENT_ID: Optional[str] = os.environ.get("GOOGLE_CLIENT_ID")

--- a/backend/app/models/refresh_token.py
+++ b/backend/app/models/refresh_token.py
@@ -1,0 +1,17 @@
+from sqlalchemy import Column, Integer, String, ForeignKey, DateTime, Boolean
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from ..database import Base
+
+class RefreshTokenDB(Base):
+    __tablename__ = "refresh_tokens"
+
+    id = Column(Integer, primary_key=True, index=True)
+    token = Column(String, unique=True, index=True, nullable=False)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    expires_at = Column(DateTime(timezone=True))
+    revoked = Column(Boolean, default=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    user = relationship("UserDB", backref="refresh_tokens")

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 import secrets
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status, Response, Request
 from fastapi.security import OAuth2PasswordRequestForm
 from fastapi_limiter.depends import RateLimiter
 from sqlalchemy.orm import Session
@@ -12,7 +12,10 @@ from ..services.auth import (
     create_access_token,
     get_current_active_user,
     create_user,
-    authenticate_user
+    authenticate_user,
+    create_refresh_token,
+    verify_refresh_token,
+    revoke_refresh_token,
 )
 from ..config import settings
 from ..database import get_db
@@ -69,8 +72,9 @@ async def verify_email(verification: EmailVerification, db: Session = Depends(ge
     dependencies=[Depends(RateLimiter(times=5, minutes=1))],
 )
 async def login(
+    response: Response,
     form_data: OAuth2PasswordRequestForm = Depends(),
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
 ):
     user = authenticate_user(db, form_data.username, form_data.password)
     if not user:
@@ -92,7 +96,49 @@ async def login(
         data={"sub": user.email},
         expires_delta=access_token_expires
     )
+    refresh_token = create_refresh_token(db, user)
+    response.set_cookie(
+        "refresh_token",
+        refresh_token,
+        httponly=True,
+        samesite="strict",
+        secure=not settings.DEBUG,
+    )
     return Token(access_token=access_token, token_type="bearer")
+
+
+@router.post("/refresh-token", response_model=Token)
+async def refresh_token(request: Request, response: Response, db: Session = Depends(get_db)):
+    existing = request.cookies.get("refresh_token")
+    if not existing:
+        raise HTTPException(status_code=401, detail="Refresh token missing")
+    user = verify_refresh_token(db, existing)
+    if not user:
+        raise HTTPException(status_code=401, detail="Invalid refresh token")
+
+    revoke_refresh_token(db, existing)
+    new_refresh = create_refresh_token(db, user)
+    response.set_cookie(
+        "refresh_token",
+        new_refresh,
+        httponly=True,
+        samesite="strict",
+        secure=not settings.DEBUG,
+    )
+    access = create_access_token(
+        data={"sub": user.email},
+        expires_delta=timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES),
+    )
+    return Token(access_token=access, token_type="bearer")
+
+
+@router.post("/logout")
+async def logout(request: Request, response: Response, db: Session = Depends(get_db)):
+    token = request.cookies.get("refresh_token")
+    if token:
+        revoke_refresh_token(db, token)
+    response.delete_cookie("refresh_token")
+    return {"message": "Logged out"}
 
 @router.get("/me", response_model=User)
 async def read_users_me(current_user: User = Depends(get_current_active_user)):


### PR DESCRIPTION
## Summary
- add `RefreshTokenDB` model for persisting refresh tokens
- include refresh token expiry setting
- generate, verify and revoke refresh tokens in auth service
- set and rotate refresh tokens via new API endpoints

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6844adf4fd34832ead8363ea2f5cd4a3