### PR TITLE
Update refresh token call for credentials

### DIFF
--- a/Frontend/src/app/core/services/auth.service.ts
+++ b/Frontend/src/app/core/services/auth.service.ts
@@ -52,7 +52,11 @@ export class AuthService {
   }
 
   refreshToken(): Observable<any> {
-    return this.http.post(`${this.apiUrl}/refresh-token`, {});
+    return this.http.post(
+      `${this.apiUrl}/refresh-token`,
+      {},
+      { withCredentials: true }
+    );
   }
 
   // Vous pourriez ajouter d'autres méthodes ici, comme logout, getUserInfo, etc.


### PR DESCRIPTION
## Summary
- enable credentials when refreshing tokens

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844b19706f4832e974d8a11dca07116