### PR TITLE
Read SECRET_KEY from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,7 @@ Optionally set `FEDEX_BASE_URL` to override the default `https://apis-sandbox.fe
 
 The repository excludes `backend/.env` from version control. Store your secrets in `backend/.env.local` or set them as environment variables when running the application.
 
+`SECRET_KEY` must be provided in production. Define it in `backend/.env.local` or set the environment variable before starting the backend.
+
 `REDIS_URL` controls the Redis connection used for rate limiting. If omitted, the API defaults to `redis://localhost:6379/0`.
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,6 +12,7 @@ GOOGLE_REDIRECT_URI=http://localhost:8000/api/v1/auth/google/callback
 
 # JWT configuration
 ACCESS_TOKEN_EXPIRE_MINUTES=30
+SECRET_KEY=your-secret-key
 
 # Database connection
 DATABASE_URL=postgresql://user:password@localhost/tracking_app

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -22,7 +22,7 @@ class Settings(BaseSettings):
     REDIS_URL: str = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
     
     # Security
-    SECRET_KEY: str = "your-secret-key-here"  # Change this in production!
+    SECRET_KEY: Optional[str] = os.environ.get("SECRET_KEY")
     ALGORITHM: str = "HS256"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
     REFRESH_TOKEN_EXPIRE_DAYS: int = 7


### PR DESCRIPTION
## Summary
- load SECRET_KEY from the runtime environment
- add SECRET_KEY to backend/.env.example
- document SECRET_KEY requirement for production deployments

## Testing
- `python -m py_compile backend/app/config.py`
- `python -m py_compile backend/app/services/auth.py`

------
https://chatgpt.com/codex/tasks/task_e_6844b18bccc8832e99b3624b87e50263