### PR TITLE
Add cookie-based auth

### DIFF
--- a/Frontend/src/app/core/interceptors/auth.interceptor.ts
+++ b/Frontend/src/app/core/interceptors/auth.interceptor.ts
@@ -8,8 +8,13 @@ import { Router } from '@angular/router';
 export class AuthInterceptor implements HttpInterceptor {
   constructor(private authService: AuthService, private router: Router) {}
 
+  private getCookie(name: string): string | null {
+    const match = document.cookie.match(new RegExp('(^|; )' + name + '=([^;]+)'));
+    return match ? decodeURIComponent(match[2]) : null;
+  }
+
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-    const token = localStorage.getItem('token');
+    const token = this.getCookie('access_token');
     const authReq = token
       ? req.clone({ setHeaders: { Authorization: `Bearer ${token}` } })
       : req;
@@ -20,10 +25,6 @@ export class AuthInterceptor implements HttpInterceptor {
           return this.authService.refreshToken().pipe(
             switchMap((resp: any) => {
               if (resp && resp.access_token) {
-                localStorage.setItem('token', resp.access_token);
-                if (resp.token_type) {
-                  localStorage.setItem('tokenType', resp.token_type);
-                }
                 const retryReq = req.clone({
                   setHeaders: { Authorization: `Bearer ${resp.access_token}` }
                 });

--- a/Frontend/src/app/features/auth/google-callback/google-callback.component.ts
+++ b/Frontend/src/app/features/auth/google-callback/google-callback.component.ts
@@ -15,9 +15,6 @@ export class GoogleCallbackComponent implements OnInit {
   ngOnInit(): void {
     this.route.queryParams.subscribe(params => {
       const token = params['token'];
-      if (token) {
-        localStorage.setItem('token', token);
-      }
       this.router.navigate(['/home']);
     });
   }

--- a/Frontend/src/app/features/auth/login/login.component.ts
+++ b/Frontend/src/app/features/auth/login/login.component.ts
@@ -34,8 +34,6 @@ export class LoginComponent {
         })
       ).subscribe(response => {
         if (response) {
-          localStorage.setItem('token', response.access_token);
-          localStorage.setItem('tokenType', response.token_type);
           this.router.navigate(['/home']);
         }
       });

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -97,6 +97,13 @@ async def login(
     )
     refresh_token = create_refresh_token(db, user)
     response.set_cookie(
+        "access_token",
+        access_token,
+        httponly=True,
+        samesite="strict",
+        secure=not settings.DEBUG,
+    )
+    response.set_cookie(
         "refresh_token",
         refresh_token,
         httponly=True,
@@ -128,6 +135,13 @@ async def refresh_token(request: Request, response: Response, db: Session = Depe
         data={"sub": user.email},
         expires_delta=timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES),
     )
+    response.set_cookie(
+        "access_token",
+        access,
+        httponly=True,
+        samesite="strict",
+        secure=not settings.DEBUG,
+    )
     return Token(access_token=access, token_type="bearer")
 
 
@@ -137,6 +151,7 @@ async def logout(request: Request, response: Response, db: Session = Depends(get
     if token:
         revoke_refresh_token(db, token)
     response.delete_cookie("refresh_token")
+    response.delete_cookie("access_token")
     return {"message": "Logged out"}
 
 @router.get("/me", response_model=User)


### PR DESCRIPTION
## Summary
- store access token in cookie when logging in or refreshing
- read auth token from cookies in the interceptor
- stop using localStorage in login and callback components

## Testing
- `npm test --silent` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6844b19b37d8832e804201ce24138682