### PR TITLE
Handle token storage and send credentials

### DIFF
--- a/Frontend/src/app/core/interceptors/auth.interceptor.ts
+++ b/Frontend/src/app/core/interceptors/auth.interceptor.ts
@@ -8,15 +8,11 @@ import { Router } from '@angular/router';
 export class AuthInterceptor implements HttpInterceptor {
   constructor(private authService: AuthService, private router: Router) {}
 
-  private getCookie(name: string): string | null {
-    const match = document.cookie.match(new RegExp('(^|; )' + name + '=([^;]+)'));
-    return match ? decodeURIComponent(match[2]) : null;
-  }
-
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-    const token = this.getCookie('access_token');
+    const token = localStorage.getItem('token');
+    const tokenType = localStorage.getItem('tokenType') || 'Bearer';
     const authReq = token
-      ? req.clone({ setHeaders: { Authorization: `Bearer ${token}` } })
+      ? req.clone({ setHeaders: { Authorization: `${tokenType} ${token}` } })
       : req;
 
     return next.handle(authReq).pipe(

--- a/Frontend/src/app/core/services/auth.service.ts
+++ b/Frontend/src/app/core/services/auth.service.ts
@@ -30,7 +30,7 @@ export class AuthService {
     return this.http.post(
       `${this.apiUrl}/token`,
       params.toString(),
-      { headers }
+      { headers, withCredentials: true }
     );
   }
 

--- a/Frontend/src/app/features/auth/google-callback/google-callback.component.ts
+++ b/Frontend/src/app/features/auth/google-callback/google-callback.component.ts
@@ -15,6 +15,10 @@ export class GoogleCallbackComponent implements OnInit {
   ngOnInit(): void {
     this.route.queryParams.subscribe(params => {
       const token = params['token'];
+      if (token) {
+        localStorage.setItem('token', token);
+        localStorage.setItem('tokenType', 'Bearer');
+      }
       this.router.navigate(['/home']);
     });
   }

--- a/Frontend/src/app/features/auth/login/login.component.ts
+++ b/Frontend/src/app/features/auth/login/login.component.ts
@@ -34,6 +34,8 @@ export class LoginComponent {
         })
       ).subscribe(response => {
         if (response) {
+          localStorage.setItem('token', response.access_token);
+          localStorage.setItem('tokenType', response.token_type);
           this.router.navigate(['/home']);
         }
       });


### PR DESCRIPTION
## Summary
- store login tokens in localStorage before redirect
- persist tokens after Google auth callback
- include credentials when performing login requests
- read tokens from localStorage in interceptor

## Testing
- `npm test --silent --unsafe-perm` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844b4723b60832eaf6781d265873b79