### PR TITLE
Implement logout endpoint

### DIFF
--- a/Frontend/src/app/core/services/auth.service.ts
+++ b/Frontend/src/app/core/services/auth.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams, HttpHeaders } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
 import { environment } from '../../../environments/environment';
 
 @Injectable({
@@ -42,9 +43,17 @@ export class AuthService {
     return this.http.post(`${this.apiUrl}/verify-email`, { token });
   }
 
-  logout(): void {
-    localStorage.removeItem('token');
-    localStorage.removeItem('tokenType');
+  logout(): Observable<any> {
+    return this.http.post(
+      `${this.apiUrl}/logout`,
+      {},
+      { withCredentials: true }
+    ).pipe(
+      tap(() => {
+        localStorage.removeItem('token');
+        localStorage.removeItem('tokenType');
+      })
+    );
   }
 
   isLoggedIn(): boolean {

--- a/Frontend/src/app/features/home/home.component.ts
+++ b/Frontend/src/app/features/home/home.component.ts
@@ -460,6 +460,6 @@ export class HomeComponent implements OnInit, OnDestroy {
   }
 
   logout(): void {
-    this.authService.logout();
+    this.authService.logout().subscribe();
   }
 }


### PR DESCRIPTION
## Summary
- post to the logout endpoint through `AuthService`
- trigger `AuthService.logout()` from `HomeComponent`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844b7339ab4832ea1b8bef7e62a9990