### PR TITLE
Ensure SECRET_KEY is required

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,6 +12,7 @@ GOOGLE_REDIRECT_URI=http://localhost:8000/api/v1/auth/google/callback
 
 # JWT configuration
 ACCESS_TOKEN_EXPIRE_MINUTES=30
+# SECRET_KEY must be set for the application to start
 SECRET_KEY=your-secret-key
 
 # Database connection

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -23,6 +23,8 @@ class Settings(BaseSettings):
     
     # Security
     SECRET_KEY: Optional[str] = os.environ.get("SECRET_KEY")
+    if not SECRET_KEY:
+        raise ValueError("SECRET_KEY must be set")
     ALGORITHM: str = "HS256"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
     REFRESH_TOKEN_EXPIRE_DAYS: int = 7


### PR DESCRIPTION
## Summary
- enforce `SECRET_KEY` requirement in settings
- document requirement in `.env.example`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844c1054f98832eb1928b88f231e94a