### PR TITLE
Run ruff and fix lint errors

### DIFF
--- a/backend/app/api/v1/endpoints/__init__.py
+++ b/backend/app/api/v1/endpoints/__init__.py
@@ -1,1 +1,3 @@
-from . import notifications, tracking 
+from . import notifications, tracking
+
+__all__ = ["notifications", "tracking"]

--- a/backend/app/api/v1/endpoints/colis.py
+++ b/backend/app/api/v1/endpoints/colis.py
@@ -1,7 +1,7 @@
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any
 from ....models.colis import ColisCreate, ColisUpdate, ColisOut, ColisFilter, ColisSearchResponse
 from ....services.colis_service import ColisService
 from ....database import get_db

--- a/backend/app/api/v1/endpoints/tracking.py
+++ b/backend/app/api/v1/endpoints/tracking.py
@@ -3,7 +3,7 @@ from typing import List, Dict, Any, Optional
 from sqlalchemy.orm import Session
 from pydantic import BaseModel
 from ....models.tracking import (
-    TrackingResponse, TrackingFilter, TrackingInfo
+    TrackingResponse, TrackingFilter
 )
 from ....services.tracking_service import TrackingService
 from ....database import get_db

--- a/backend/app/init_db.py
+++ b/backend/app/init_db.py
@@ -1,5 +1,5 @@
 from sqlalchemy import create_engine
-from .models.database import Base, TrackingDB
+from .models.database import Base
 from .config import settings
 
 def init_db():

--- a/backend/app/models/colis.py
+++ b/backend/app/models/colis.py
@@ -1,7 +1,6 @@
 from pydantic import BaseModel, Field
 from typing import Optional, List, Dict, Any
 from datetime import datetime
-from .tracking import PackageStatus # Assuming PackageStatus is used or might be needed for status consistency
 
 class ColisBase(BaseModel):
     description: str

--- a/backend/app/models/tracking.py
+++ b/backend/app/models/tracking.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 from typing import List, Optional, Dict, Any
 from datetime import datetime
 from enum import Enum

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -7,8 +7,6 @@ from sqlalchemy.orm import Session
 
 from ..models.user import User, UserCreate, Token, EmailVerification, UserDB
 from ..services.auth import (
-    verify_password,
-    get_password_hash,
     create_access_token,
     get_current_active_user,
     create_user,

--- a/backend/app/routers/tracking.py
+++ b/backend/app/routers/tracking.py
@@ -1,18 +1,20 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
-from typing import List, Optional, Dict, Any
+from typing import List, Optional
 from pydantic import BaseModel
 from datetime import datetime
+import logging
 
 # Corrected absolute imports
 from app.models.tracking import (
-    TrackingResponse, TrackingFilter, TrackingInfo
+    TrackingResponse
 )
 from app.database import get_db
 from app.services.colis_service import ColisService
 from app.services.fedex_service import FedExService
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 class TrackingRequest(BaseModel):
     tracking_number: str

--- a/backend/app/scripts/manage_colis.py
+++ b/backend/app/scripts/manage_colis.py
@@ -13,9 +13,9 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..',
 # Correct import for settings
 from app.config import settings
 
-from app.models.database import Base, ColisDB
+from app.models.database import ColisDB
 from app.services.colis_service import ColisService
-from app.models.colis import ColisCreate, ColisUpdate
+from app.models.colis import ColisCreate, ColisUpdate, ColisFilter
 
 # Database setup
 engine = create_engine(settings.DATABASE_URL)

--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -9,6 +9,8 @@ from sqlalchemy.orm import Session
 from ..models.user import User, UserCreate, TokenData, UserDB, UserRole
 from ..config import settings
 from ..database import get_db
+from secrets import token_urlsafe
+from ..models.refresh_token import RefreshTokenDB
 
 # Password hashing
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
@@ -99,8 +101,6 @@ def authenticate_user(db: Session, email: str, password: str) -> Optional[UserDB
     db.refresh(user)
     return user
 
-from secrets import token_urlsafe
-from ..models.refresh_token import RefreshTokenDB
 
 
 def create_refresh_token(db: Session, user: UserDB) -> str:

--- a/backend/app/services/colis_service.py
+++ b/backend/app/services/colis_service.py
@@ -6,7 +6,6 @@ from datetime import datetime
 import barcode
 from barcode.writer import ImageWriter
 from sqlalchemy.orm import Session
-from sqlalchemy import and_, or_, desc, asc
 from typing import List, Dict, Any, Tuple, Optional
 from ..models.colis import ColisCreate, ColisUpdate, ColisFilter
 from ..models.database import ColisDB

--- a/backend/app/services/fedex_service.py
+++ b/backend/app/services/fedex_service.py
@@ -1,13 +1,10 @@
 import os
-import sys
-import time
 import requests
 import json
 import yaml
 import logging
-from typing import Dict, Any, Optional
-from datetime import datetime, timedelta
-import pytz
+from typing import Dict, Any
+from datetime import datetime
 from ..models.tracking import (
     TrackingInfo, TrackingEvent, TrackingResponse, Location,
     PackageDetails, DeliveryDetails, PackageStatus, PackageType,
@@ -165,7 +162,6 @@ class FedExService:
             tracking_number = tracking_details.get('trackingNumberInfo', {}).get('trackingNumber', '')
             latest_status = tracking_details.get('latestStatusDetail', {})
             status = latest_status.get('code', 'UNKNOWN')
-            description = latest_status.get('description', '')
             service_detail = tracking_details.get('serviceDetail', {})
             service_type = self._get_service_type(service_detail.get('type', ''))
 

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime
-from typing import List, Optional, Dict, Any
+from typing import List, Optional
 from uuid import uuid4
 from sqlalchemy.orm import Session
 from ..models.notification import (
@@ -8,8 +8,7 @@ from ..models.notification import (
     NotificationCreate,
     NotificationUpdate,
     NotificationResponse,
-    NotificationType,
-    NotificationPriority
+    NotificationType
 )
 from ..models.database import NotificationDB
 
@@ -118,7 +117,7 @@ class NotificationService:
             query = self.db.query(NotificationDB)
             
             if unread_only:
-                query = query.filter(NotificationDB.is_read == False)
+                query = query.filter(NotificationDB.is_read.is_(False))
             if notification_type:
                 query = query.filter(NotificationDB.type == notification_type)
             
@@ -234,7 +233,7 @@ class NotificationService:
         try:
             now = datetime.now()
             self.db.query(NotificationDB).filter(
-                NotificationDB.is_read == False
+                NotificationDB.is_read.is_(False)
             ).update({
                 "is_read": True,
                 "read_at": now

--- a/backend/app/services/tracking_service.py
+++ b/backend/app/services/tracking_service.py
@@ -1,14 +1,15 @@
-import os
 import logging
 from typing import List, Dict, Any, Optional, Tuple
 from datetime import datetime
-from uuid import uuid4
 from .fedex_service import FedExService
 from ..models.tracking import (
-    TrackingInfo, TrackingEvent, TrackingResponse, Location,
-    PackageDetails, DeliveryDetails, TrackingFilter
+    TrackingInfo,
+    TrackingResponse,
+    TrackingFilter,
 )
+from ..models.database import TrackingDB, TrackingEventDB
 from sqlalchemy.orm import Session
+from sqlalchemy import and_, asc, desc
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
## Summary
- fix module re-exports in api endpoints
- clean up unused imports after ruff
- add missing imports and logger setup
- correct SQLAlchemy boolean comparisons

## Testing
- `ruff check backend/app`
- `pytest -q` *(fails: ModuleNotFoundError for sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_6844c8a975d0832eb226c5d9257b9827