### PR TITLE
Fix registration redirect

### DIFF
--- a/Frontend/src/app/features/auth/register/register.component.ts
+++ b/Frontend/src/app/features/auth/register/register.component.ts
@@ -61,7 +61,7 @@ export class RegisterComponent {
         (response: any) => {
           if (response) {
             console.log('Registration successful', response);
-            this.router.navigate(['/login']);
+            this.router.navigate(['/auth/login']);
           }
         }
       );


### PR DESCRIPTION
## Summary
- update redirect path after registration to point to `/auth/login`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844cce3f1e8832eb85daacd2ffa217d