### PR TITLE
Implement password reset flow

### DIFF
--- a/backend/app/models/password_reset.py
+++ b/backend/app/models/password_reset.py
@@ -1,0 +1,17 @@
+from sqlalchemy import Column, Integer, String, ForeignKey, DateTime, Boolean
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from ..database import Base
+
+class PasswordResetTokenDB(Base):
+    __tablename__ = "password_reset_tokens"
+
+    id = Column(Integer, primary_key=True, index=True)
+    token = Column(String, unique=True, index=True, nullable=False)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    expires_at = Column(DateTime(timezone=True))
+    revoked = Column(Boolean, default=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    user = relationship("UserDB", backref="password_reset_tokens")

--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -44,4 +44,43 @@ def send_verification_email(email: str, token: str):
         return True
     except Exception as e:
         print(f"Erreur lors de l'envoi de l'email: {str(e)}")
-        return False 
+        return False
+
+
+def send_password_reset_email(email: str, token: str) -> bool:
+    """Send a password reset email with the given token."""
+    sender_email = settings.SMTP_USERNAME
+    sender_password = settings.SMTP_PASSWORD
+    smtp_server = settings.SMTP_SERVER
+    smtp_port = settings.SMTP_PORT
+
+    message = MIMEMultipart()
+    message["From"] = sender_email
+    message["To"] = email
+    message["Subject"] = "Réinitialisation de votre mot de passe"
+
+    reset_link = f"{settings.FRONTEND_URL}/reset-password?token={token}"
+    body = f"""
+    Bonjour,
+
+    Vous avez demandé la réinitialisation de votre mot de passe. Pour définir un nouveau mot de passe, veuillez cliquer sur le lien suivant :
+
+    {reset_link}
+
+    Si vous n'avez pas demandé cette réinitialisation, vous pouvez ignorer cet email.
+
+    Cordialement,
+    L'équipe de Tracking App
+    """
+    message.attach(MIMEText(body, "plain"))
+
+    try:
+        server = smtplib.SMTP(smtp_server, smtp_port)
+        server.starttls()
+        server.login(sender_email, sender_password)
+        server.send_message(message)
+        server.quit()
+        return True
+    except Exception as e:
+        print(f"Erreur lors de l'envoi de l'email: {str(e)}")
+        return False


### PR DESCRIPTION
## Summary
- add DB model for storing password reset tokens
- send password reset emails
- implement token creation and verification services
- expose `/auth/request-reset` and `/auth/reset-password` endpoints
- cover the password reset flow in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844d3463aa8832eaa9e0b80f17b55ec