### PR TITLE
Add 2FA support

### DIFF
--- a/Frontend/src/app/app.routes.ts
+++ b/Frontend/src/app/app.routes.ts
@@ -6,6 +6,7 @@ import { LoginComponent } from './features/auth/login/login.component';
 import { VerifyEmailComponent } from './features/auth/verify-email/verify-email.component';
 import { TrackResultComponent } from './features/tracking/track-result/track-result.component';
 import { GoogleCallbackComponent } from './features/auth/google-callback/google-callback.component';
+import { Setup2faComponent } from './features/auth/setup-2fa/setup-2fa.component';
 
 // Assuming you might have other standalone components or lazy-loaded routes
 // import { HomeComponent } from './features/home/home.component';
@@ -27,4 +28,5 @@ export const routes: Routes = [
   { path: 'auth/login', component: LoginComponent },
   { path: 'verify-email', component: VerifyEmailComponent },
   { path: 'auth/callback', component: GoogleCallbackComponent },
+  { path: 'auth/setup-2fa', component: Setup2faComponent, canActivate: [AuthGuard] },
 ];

--- a/Frontend/src/app/core/services/auth.service.ts
+++ b/Frontend/src/app/core/services/auth.service.ts
@@ -20,9 +20,13 @@ export class AuthService {
 
   login(credentials: any): Observable<any> {
     // Endpoint pour la connexion avec envoi en x-www-form-urlencoded
-    const params = new HttpParams()
+    let params = new HttpParams()
       .set('username', credentials.email)
       .set('password', credentials.password);
+
+    if (credentials.totp) {
+      params = params.set('totp', credentials.totp);
+    }
 
     const headers = new HttpHeaders({
       'Content-Type': 'application/x-www-form-urlencoded'
@@ -68,6 +72,14 @@ export class AuthService {
       {},
       { withCredentials: true }
     );
+  }
+
+  setup2fa(): Observable<any> {
+    return this.http.post(`${this.apiUrl}/setup-2fa`, {}, { withCredentials: true });
+  }
+
+  verify2fa(token: string): Observable<any> {
+    return this.http.post(`${this.apiUrl}/verify-2fa`, { token }, { withCredentials: true });
   }
 
   // Vous pourriez ajouter d'autres méthodes ici, comme logout, getUserInfo, etc.

--- a/Frontend/src/app/features/auth/login/login.component.html
+++ b/Frontend/src/app/features/auth/login/login.component.html
@@ -17,6 +17,11 @@
       </div>
     </div>
 
+    <div class="form-group">
+      <label for="totp">Code 2FA</label>
+      <input id="totp" type="text" formControlName="totp" />
+    </div>
+
     <button type="submit">Connexion</button>
   </form>
 

--- a/Frontend/src/app/features/auth/login/login.component.ts
+++ b/Frontend/src/app/features/auth/login/login.component.ts
@@ -20,7 +20,8 @@ export class LoginComponent {
   constructor(private fb: FormBuilder, private authService: AuthService, private router: Router) {
     this.loginForm = this.fb.group({
       email: ['', [Validators.required, Validators.email]],
-      password: ['', Validators.required]
+      password: ['', Validators.required],
+      totp: ['']
     });
   }
 

--- a/Frontend/src/app/features/auth/setup-2fa/setup-2fa.component.html
+++ b/Frontend/src/app/features/auth/setup-2fa/setup-2fa.component.html
@@ -1,0 +1,10 @@
+<div class="setup-2fa">
+  <div *ngIf="qrData">
+    <img [src]="qrData" alt="QR Code" />
+  </div>
+  <form [formGroup]="codeForm" (ngSubmit)="verify()">
+    <label for="code">Code</label>
+    <input id="code" type="text" formControlName="code" />
+    <button type="submit">Activer</button>
+  </form>
+</div>

--- a/Frontend/src/app/features/auth/setup-2fa/setup-2fa.component.ts
+++ b/Frontend/src/app/features/auth/setup-2fa/setup-2fa.component.ts
@@ -1,0 +1,37 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { AuthService } from '../../../core/services/auth.service';
+import { Router } from '@angular/router';
+
+@Component({
+  selector: 'app-setup-2fa',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './setup-2fa.component.html',
+  styleUrls: ['./setup-2fa.component.scss']
+})
+export class Setup2faComponent implements OnInit {
+  qrData: string | null = null;
+  codeForm: FormGroup;
+
+  constructor(private authService: AuthService, private fb: FormBuilder, private router: Router) {
+    this.codeForm = this.fb.group({
+      code: ['', Validators.required]
+    });
+  }
+
+  ngOnInit(): void {
+    this.authService.setup2fa().subscribe(res => {
+      this.qrData = 'data:image/png;base64,' + res.qr;
+    });
+  }
+
+  verify() {
+    if (this.codeForm.valid) {
+      this.authService.verify2fa(this.codeForm.value.code).subscribe(() => {
+        this.router.navigate(['/home']);
+      });
+    }
+  }
+}

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -29,6 +29,8 @@ class UserDB(Base):
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     role = Column(SQLEnum(UserRole), default=UserRole.client, nullable=False)
     last_login_at = Column(DateTime(timezone=True), nullable=True)
+    twofa_secret = Column(String, nullable=True)
+    is_twofa_enabled = Column(Boolean, default=False)
 
 # Modèles Pydantic pour l'API
 class UserBase(BaseModel):
@@ -47,6 +49,7 @@ class User(UserBase):
     is_active: bool = True
     is_verified: bool = False
     is_google_user: bool = False
+    is_twofa_enabled: bool = False
     created_at: datetime
     role: UserRole = UserRole.client
     last_login_at: Optional[datetime] = None

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -19,3 +19,5 @@ pytz==2024.1
 itsdangerous==2.2.0
 fastapi-limiter==0.1.6
 redis>=4.2.0
+pyotp==2.9.0
+qrcode==7.4.2


### PR DESCRIPTION
## Summary
- extend `UserDB` with two-factor fields
- add 2FA utilities using `pyotp` and create QR code
- expose `/auth/setup-2fa` and `/auth/verify-2fa` endpoints and secure login with TOTP
- update Angular auth service and login component
- add Angular component for 2FA setup
- cover new flows in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844d3465154832eb46057826bc5869c