### PR TITLE
Use TrackingService in HomeComponent

### DIFF
--- a/Frontend/src/app/features/tracking/services/tracking.service.ts
+++ b/Frontend/src/app/features/tracking/services/tracking.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
+import { TrackingInfo } from '../models/tracking';
+
+export interface TrackingResponse {
+  success: boolean;
+  data?: TrackingInfo;
+  error?: string;
+  metadata?: { [key: string]: any };
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class TrackingService {
+  private baseUrl = `${environment.apiUrl}/tracking`;
+
+  constructor(private http: HttpClient) {}
+
+  trackPackage(identifier: string): Observable<TrackingResponse> {
+    return this.http.get<TrackingResponse>(`${this.baseUrl}/${identifier}`);
+  }
+}
+
+export type { TrackingInfo } from '../models/tracking';


### PR DESCRIPTION
## Summary
- create a TrackingService for the Angular app
- use the new service in HomeComponent.trackPackage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test --silent` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844d5cf8014832ebe0dcc70fdb0afd5