### PR TITLE
Add tracking service

### DIFF
--- a/Frontend/src/app/features/tracking/services/tracking.service.ts
+++ b/Frontend/src/app/features/tracking/services/tracking.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../../environments/environment';
+import { TrackingInfo, TrackingResponse } from '../models/tracking';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class TrackingService {
+  constructor(private http: HttpClient) {}
+
+  trackPackage(id: string): Observable<TrackingResponse> {
+    return this.http.get<TrackingResponse>(`${environment.apiUrl}/tracking/${id}`);
+  }
+}
+
+export { TrackingInfo, TrackingResponse } from '../models/tracking';


### PR DESCRIPTION
## Summary
- add a tracking service in Angular
- re-export interfaces from tracking models

## Testing
- `pytest -q`
- `npm test --silent` *(fails: Chrome not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844d5c8b448832e87f33e5631dd5e4e