### PR TITLE
Add tracking summary card

### DIFF
--- a/Frontend/src/app/features/tracking/track-result/track-result.component.html
+++ b/Frontend/src/app/features/tracking/track-result/track-result.component.html
@@ -14,6 +14,38 @@
 
   <!-- Tracking information -->
   <div *ngIf="!loading && trackingInfo">
+    <div class="summary-card mb-4">
+      <div class="summary-header">
+        <h3>#{{ trackingInfo.tracking_number }}</h3>
+        <span>{{ trackingInfo.carrier }} {{ trackingInfo.service_type }}</span>
+      </div>
+      <div class="summary-details">
+        <p *ngIf="trackingInfo.key_dates?.ship">
+          Expédié le : {{ trackingInfo.key_dates.ship | date:'mediumDate' }}
+        </p>
+        <p *ngIf="trackingInfo.delivery_details">
+          Livraison prévue :
+          {{
+            (trackingInfo.delivery_details.actual_delivery ||
+            trackingInfo.delivery_details.estimated_delivery) |
+            date:'mediumDate'
+          }}
+        </p>
+        <p>
+          {{ trackingInfo.origin?.city }} → {{ trackingInfo.destination?.city }}
+        </p>
+        <p *ngIf="trackingInfo.delivery_details?.received_by_name">
+          Signé par : {{ trackingInfo.delivery_details.received_by_name }}
+        </p>
+      </div>
+      <div class="summary-actions">
+        <button (click)="copyTracking()">Copier</button>
+        <button (click)="shareTracking()">Partager</button>
+        <button (click)="downloadProof()">Télécharger la preuve</button>
+        <button (click)="contactSupport()">Contacter le support</button>
+      </div>
+    </div>
+
     <div class="mb-4">
       <h2 class="text-2xl font-bold">Statut</h2>
       <p class="text-lg font-semibold">{{ trackingInfo.status.status }}</p>

--- a/Frontend/src/app/features/tracking/track-result/track-result.component.scss
+++ b/Frontend/src/app/features/tracking/track-result/track-result.component.scss
@@ -137,4 +137,42 @@
 
 .pl-4 {
   padding-left: 1rem;
-} 
+}
+
+/* Summary card styling */
+.summary-card {
+  background: #ffffff;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+}
+
+.summary-header {
+  background: #4d148c;
+  color: #ffffff;
+  padding: 0.75rem 1rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.summary-details {
+  padding: 1rem;
+  color: #333;
+}
+
+.summary-actions {
+  padding: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.summary-actions button {
+  background: #ff6600;
+  color: #ffffff;
+  border: none;
+  padding: 0.5rem 0.75rem;
+  border-radius: 4px;
+  cursor: pointer;
+}

--- a/Frontend/src/app/features/tracking/track-result/track-result.component.ts
+++ b/Frontend/src/app/features/tracking/track-result/track-result.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute } from '@angular/router';
 import { TrackingService, TrackingInfo } from '../services/tracking.service';
+import { environment } from '../../../../environments/environment';
 
 @Component({
   selector: 'app-track-result',
@@ -49,4 +50,33 @@ export class TrackResultComponent implements OnInit {
       }
     });
   }
-} 
+
+  copyTracking() {
+    if (this.trackingInfo?.tracking_number) {
+      navigator.clipboard.writeText(this.trackingInfo.tracking_number);
+    }
+  }
+
+  shareTracking() {
+    if (navigator.share && this.trackingInfo) {
+      navigator.share({
+        title: 'Suivi de colis',
+        text: `Suivi ${this.trackingInfo.tracking_number}`,
+        url: window.location.href,
+      });
+    } else {
+      this.copyTracking();
+    }
+  }
+
+  downloadProof() {
+    if (this.trackingInfo) {
+      const url = `${environment.apiUrl}/tracking/${this.trackingInfo.tracking_number}/proof`;
+      window.open(url, '_blank');
+    }
+  }
+
+  contactSupport() {
+    window.location.href = '/support';
+  }
+}


### PR DESCRIPTION
## Summary
- show a purple FedEx style summary card on tracking results
- provide actions to copy, share, download proof or contact support

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844da4a5584832e8e5467e56ced9b01