### PR TITLE
Add package details UI

### DIFF
--- a/Frontend/src/app/features/tracking/models/tracking.ts
+++ b/Frontend/src/app/features/tracking/models/tracking.ts
@@ -24,6 +24,8 @@ export interface PackageDetails {
   dimensions?: string;
   pieces?: number;
   insurance?: string;
+  service_type?: string;
+  packaging_description?: string;
 }
 
 export interface DeliveryDetails {
@@ -31,6 +33,7 @@ export interface DeliveryDetails {
   actual_delivery_date?: string;
   signed_by?: string;
   options?: string[]; // Example: ['Schedule Delivery', 'Change Address']
+  delivery_location?: Location;
 }
 
 export interface TrackingInfo {

--- a/Frontend/src/app/features/tracking/track-result/track-result.component.html
+++ b/Frontend/src/app/features/tracking/track-result/track-result.component.html
@@ -39,6 +39,29 @@
       </div>
     </div>
 
+    <div class="grid md:grid-cols-2 gap-4 mb-4">
+      <div id="map" class="h-64 w-full bg-gray-200 rounded" *ngIf="false">
+        <!-- Map placeholder -->
+      </div>
+      <div>
+        <h3 class="font-bold mb-2">Détails du colis</h3>
+        <p *ngIf="trackingInfo.package_details?.weight">Poids: {{ trackingInfo.package_details.weight }}</p>
+        <p *ngIf="trackingInfo.package_details?.dimensions">Dimensions: {{ trackingInfo.package_details.dimensions }}</p>
+        <p *ngIf="trackingInfo.package_details?.service_type || trackingInfo.package_details?.packaging_description">
+          Type: {{ trackingInfo.package_details?.service_type || trackingInfo.package_details?.packaging_description }}
+        </p>
+        <p *ngIf="trackingInfo.metadata?.reference">Référence client: {{ trackingInfo.metadata.reference }}</p>
+        <div *ngIf="trackingInfo.delivery_details?.delivery_location" class="mt-2 text-sm text-gray-500">
+          <p class="font-bold mb-1 text-black">Adresse complète</p>
+          <p>
+            {{ trackingInfo.delivery_details.delivery_location.address }}<br>
+            {{ trackingInfo.delivery_details.delivery_location.city }} {{ trackingInfo.delivery_details.delivery_location.state }} {{ trackingInfo.delivery_details.delivery_location.postal_code }}<br>
+            {{ trackingInfo.delivery_details.delivery_location.country }}
+          </p>
+        </div>
+      </div>
+    </div>
+
     <div *ngIf="trackingInfo.tracking_history?.length">
       <h3 class="font-bold mb-2">Historique</h3>
       <ul class="space-y-4">


### PR DESCRIPTION
## Summary
- extend tracking models with service_type, packaging_description and delivery_location
- display package and delivery details next to tracking history

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844da4c7400832e978914c2b1907d04