### PR TITLE
Add Google Maps to tracking results

### DIFF
--- a/Frontend/src/app/features/tracking/models/tracking.ts
+++ b/Frontend/src/app/features/tracking/models/tracking.ts
@@ -10,6 +10,8 @@ export interface Location {
   state?: string;
   postal_code?: string;
   country?: string;
+  latitude?: number;
+  longitude?: number;
 }
 
 export interface TrackingEvent {

--- a/Frontend/src/app/features/tracking/track-result/track-result.component.html
+++ b/Frontend/src/app/features/tracking/track-result/track-result.component.html
@@ -39,18 +39,24 @@
       </div>
     </div>
 
-    <div *ngIf="trackingInfo.tracking_history?.length">
-      <h3 class="font-bold mb-2">Historique</h3>
-      <ul class="space-y-4">
-        <li *ngFor="let event of trackingInfo.tracking_history" class="border-l-2 pl-4">
-          <div class="font-medium">{{ event.status }}</div>
-          <div class="text-sm text-gray-600">{{ event.timestamp | date:'medium' }}</div>
-          <div class="text-sm" *ngIf="event.description">{{ event.description }}</div>
-          <div class="text-sm text-gray-500" *ngIf="event.location">
-            {{ event.location.city }} {{ event.location.state }} {{ event.location.country }}
-          </div>
-        </li>
-      </ul>
+    <div *ngIf="trackingInfo.tracking_history?.length" class="results-grid">
+      <div>
+        <h3 class="font-bold mb-2">Historique</h3>
+        <ul class="space-y-4">
+          <li *ngFor="let event of trackingInfo.tracking_history" class="border-l-2 pl-4 timeline-item">
+            <i class="fas" [ngClass]="getEventIcon(event.status)"></i>
+            <div>
+              <div class="font-medium">{{ event.status }}</div>
+              <div class="text-sm text-gray-600">{{ event.timestamp | date:'medium' }}</div>
+              <div class="text-sm" *ngIf="event.description">{{ event.description }}</div>
+              <div class="text-sm text-gray-500" *ngIf="event.location">
+                {{ event.location.city }} {{ event.location.state }} {{ event.location.country }}
+              </div>
+            </div>
+          </li>
+        </ul>
+      </div>
+      <div id="map" class="map-container"></div>
     </div>
   </div>
 </div>

--- a/Frontend/src/app/features/tracking/track-result/track-result.component.scss
+++ b/Frontend/src/app/features/tracking/track-result/track-result.component.scss
@@ -137,4 +137,35 @@
 
 .pl-4 {
   padding-left: 1rem;
-} 
+}
+
+.map-container {
+  width: 100%;
+  height: 400px;
+  background: #e9e9e9;
+}
+
+.results-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.timeline-item {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.timeline-item i {
+  color: #4d148c;
+  margin-top: 0.25rem;
+}
+
+@media (max-width: 768px) {
+  .results-grid {
+    grid-template-columns: 1fr;
+  }
+  .map-container {
+    height: 300px;
+  }
+}

--- a/Frontend/src/app/features/tracking/track-result/track-result.component.ts
+++ b/Frontend/src/app/features/tracking/track-result/track-result.component.ts
@@ -2,6 +2,13 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute } from '@angular/router';
 import { TrackingService, TrackingInfo } from '../services/tracking.service';
+import { Location, TrackingEvent } from '../models/tracking';
+
+declare global {
+  interface Window {
+    google: any;
+  }
+}
 
 @Component({
   selector: 'app-track-result',
@@ -14,6 +21,9 @@ export class TrackResultComponent implements OnInit {
   trackingInfo: TrackingInfo | null = null;
   loading = true;
   error: string | null = null;
+  private map: any = null;
+  private markers: any[] = [];
+  private polyline: any = null;
 
   constructor(
     private route: ActivatedRoute,
@@ -29,6 +39,85 @@ export class TrackResultComponent implements OnInit {
     });
   }
 
+  private waitForGoogleMaps(): Promise<void> {
+    return new Promise(resolve => {
+      const check = () => {
+        if (typeof window !== 'undefined' && window.google && window.google.maps) {
+          resolve();
+        } else {
+          setTimeout(check, 100);
+        }
+      };
+      check();
+    });
+  }
+
+  private formatLocation(loc?: Location): string | null {
+    if (!loc) return null;
+    const parts = [loc.address, loc.city, loc.state, loc.postal_code, loc.country]
+      .filter(p => !!p);
+    return parts.length ? parts.join(', ') : null;
+  }
+
+  private geocodeAddress(address: string): Promise<{ lat: number; lng: number } | null> {
+    return new Promise(resolve => {
+      const geocoder = new window.google.maps.Geocoder();
+      geocoder.geocode({ address }, (results: any, status: any) => {
+        if (status === 'OK' && results[0]) {
+          const loc = results[0].geometry.location;
+          resolve({ lat: loc.lat(), lng: loc.lng() });
+        } else {
+          resolve(null);
+        }
+      });
+    });
+  }
+
+  private async initializeMap() {
+    if (!this.trackingInfo) return;
+
+    const originAddress = this.formatLocation(this.trackingInfo.origin);
+    const destAddress = this.formatLocation(this.trackingInfo.destination);
+    const lastEvent: TrackingEvent | undefined =
+      this.trackingInfo.tracking_history?.[0];
+    const currentAddress = this.formatLocation(lastEvent?.location);
+
+    const coords = await Promise.all([
+      originAddress ? this.geocodeAddress(originAddress) : Promise.resolve(null),
+      destAddress ? this.geocodeAddress(destAddress) : Promise.resolve(null),
+      currentAddress ? this.geocodeAddress(currentAddress) : Promise.resolve(null)
+    ]);
+
+    const valid = coords.filter(c => c) as { lat: number; lng: number }[];
+    if (!valid.length) {
+      return;
+    }
+
+    const mapEl = document.getElementById('map') as HTMLElement;
+    this.map = new window.google.maps.Map(mapEl, {
+      zoom: 4,
+      center: valid[valid.length - 1]
+    });
+
+    const labels = ['O', 'D', 'C'];
+    valid.forEach((coord, idx) => {
+      const marker = new window.google.maps.Marker({ position: coord, map: this.map, label: labels[idx] });
+      this.markers.push(marker);
+    });
+
+    this.polyline = new window.google.maps.Polyline({
+      path: valid,
+      strokeColor: '#4d148c',
+      strokeOpacity: 1.0,
+      strokeWeight: 2
+    });
+    this.polyline.setMap(this.map);
+
+    const bounds = new window.google.maps.LatLngBounds();
+    valid.forEach(c => bounds.extend(c));
+    this.map.fitBounds(bounds);
+  }
+
   private loadTrackingInfo(identifier: string) {
     this.loading = true;
     this.error = null;
@@ -37,6 +126,7 @@ export class TrackResultComponent implements OnInit {
       next: (response) => {
         if (response.success && response.data) {
           this.trackingInfo = response.data;
+          this.waitForGoogleMaps().then(() => this.initializeMap());
         } else {
           this.error = response.error || 'Impossible de récupérer les informations de suivi';
         }
@@ -49,4 +139,18 @@ export class TrackResultComponent implements OnInit {
       }
     });
   }
-} 
+
+  getEventIcon(status: string): string {
+    const normalized = status.toLowerCase();
+    if (normalized.includes('deliver')) {
+      return 'fa-check-circle';
+    }
+    if (normalized.includes('transit') || normalized.includes('depart')) {
+      return 'fa-truck-moving';
+    }
+    if (normalized.includes('pickup')) {
+      return 'fa-box';
+    }
+    return 'fa-circle';
+  }
+}


### PR DESCRIPTION
## Summary
- extend Tracking `Location` model with coordinates
- show package event timeline with icons and map side-by-side
- initialize Google Map and draw route between origin, current location and destination

## Testing
- `pytest -q`
- `npx ng test --watch=false --progress=false --browsers=ChromeHeadless` *(fails: Cannot find module 'src/environments/environment')*

------
https://chatgpt.com/codex/tasks/task_e_6844da495604832e9474e23ff04e068e