### PR TITLE
Add password reset flow to frontend

### DIFF
--- a/Frontend/src/app/app.routes.ts
+++ b/Frontend/src/app/app.routes.ts
@@ -4,6 +4,8 @@ import { HomeComponent } from './features/home/home.component';
 import { RegisterComponent } from './features/auth/register/register.component';
 import { LoginComponent } from './features/auth/login/login.component';
 import { VerifyEmailComponent } from './features/auth/verify-email/verify-email.component';
+import { ForgotPasswordComponent } from './features/auth/forgot-password/forgot-password.component';
+import { ResetPasswordComponent } from './features/auth/reset-password/reset-password.component';
 import { TrackResultComponent } from './features/tracking/track-result/track-result.component';
 import { GoogleCallbackComponent } from './features/auth/google-callback/google-callback.component';
 
@@ -27,4 +29,6 @@ export const routes: Routes = [
   { path: 'auth/login', component: LoginComponent },
   { path: 'verify-email', component: VerifyEmailComponent },
   { path: 'auth/callback', component: GoogleCallbackComponent },
+  { path: 'auth/forgot-password', component: ForgotPasswordComponent },
+  { path: 'auth/reset-password', component: ResetPasswordComponent },
 ];

--- a/Frontend/src/app/core/services/auth.service.ts
+++ b/Frontend/src/app/core/services/auth.service.ts
@@ -70,5 +70,16 @@ export class AuthService {
     );
   }
 
+  requestPasswordReset(email: string): Observable<any> {
+    return this.http.post(`${this.apiUrl}/request-reset`, { email });
+  }
+
+  resetPassword(token: string, newPassword: string): Observable<any> {
+    return this.http.post(`${this.apiUrl}/reset-password`, {
+      token,
+      new_password: newPassword,
+    });
+  }
+
   // Vous pourriez ajouter d'autres méthodes ici, comme logout, getUserInfo, etc.
 } 

--- a/Frontend/src/app/features/auth/forgot-password/forgot-password.component.html
+++ b/Frontend/src/app/features/auth/forgot-password/forgot-password.component.html
@@ -1,0 +1,14 @@
+<div class="forgot-password-container">
+  <h2>Réinitialiser le mot de passe</h2>
+  <form [formGroup]="form" (ngSubmit)="onSubmit()">
+    <div class="form-group">
+      <label for="email">Email</label>
+      <input id="email" type="email" formControlName="email" />
+      <div class="error-message" *ngIf="form.get('email')?.invalid && form.get('email')?.touched">
+        Adresse email invalide
+      </div>
+    </div>
+    <button type="submit">Envoyer</button>
+  </form>
+  <div class="message" *ngIf="message">{{ message }}</div>
+</div>

--- a/Frontend/src/app/features/auth/forgot-password/forgot-password.component.scss
+++ b/Frontend/src/app/features/auth/forgot-password/forgot-password.component.scss
@@ -1,0 +1,4 @@
+.forgot-password-container {
+  max-width: 400px;
+  margin: 0 auto;
+}

--- a/Frontend/src/app/features/auth/forgot-password/forgot-password.component.ts
+++ b/Frontend/src/app/features/auth/forgot-password/forgot-password.component.ts
@@ -1,0 +1,33 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { AuthService } from '../../../core/services/auth.service';
+
+@Component({
+  selector: 'app-forgot-password',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, FormsModule],
+  templateUrl: './forgot-password.component.html',
+  styleUrls: ['./forgot-password.component.scss']
+})
+export class ForgotPasswordComponent {
+  form: FormGroup;
+  message: string | null = null;
+
+  constructor(private fb: FormBuilder, private authService: AuthService) {
+    this.form = this.fb.group({
+      email: ['', [Validators.required, Validators.email]]
+    });
+  }
+
+  onSubmit() {
+    if (this.form.valid) {
+      this.authService.requestPasswordReset(this.form.value.email).subscribe({
+        next: res => this.message = res.message,
+        error: () => this.message = 'Erreur lors de la demande'
+      });
+    } else {
+      this.form.markAllAsTouched();
+    }
+  }
+}

--- a/Frontend/src/app/features/auth/reset-password/reset-password.component.html
+++ b/Frontend/src/app/features/auth/reset-password/reset-password.component.html
@@ -1,0 +1,14 @@
+<div class="reset-password-container">
+  <h2>Nouveau mot de passe</h2>
+  <form [formGroup]="form" (ngSubmit)="onSubmit()">
+    <div class="form-group">
+      <label for="password">Mot de passe</label>
+      <input id="password" type="password" formControlName="newPassword" />
+      <div class="error-message" *ngIf="form.get('newPassword')?.invalid && form.get('newPassword')?.touched">
+        Mot de passe requis
+      </div>
+    </div>
+    <button type="submit">Valider</button>
+  </form>
+  <div class="message" *ngIf="message">{{ message }}</div>
+</div>

--- a/Frontend/src/app/features/auth/reset-password/reset-password.component.scss
+++ b/Frontend/src/app/features/auth/reset-password/reset-password.component.scss
@@ -1,0 +1,4 @@
+.reset-password-container {
+  max-width: 400px;
+  margin: 0 auto;
+}

--- a/Frontend/src/app/features/auth/reset-password/reset-password.component.ts
+++ b/Frontend/src/app/features/auth/reset-password/reset-password.component.ts
@@ -1,0 +1,45 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { ActivatedRoute } from '@angular/router';
+import { AuthService } from '../../../core/services/auth.service';
+
+@Component({
+  selector: 'app-reset-password',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, FormsModule],
+  templateUrl: './reset-password.component.html',
+  styleUrls: ['./reset-password.component.scss']
+})
+export class ResetPasswordComponent implements OnInit {
+  form: FormGroup;
+  token: string | null = null;
+  message: string | null = null;
+
+  constructor(
+    private route: ActivatedRoute,
+    private fb: FormBuilder,
+    private authService: AuthService
+  ) {
+    this.form = this.fb.group({
+      newPassword: ['', [Validators.required, Validators.minLength(6)]]
+    });
+  }
+
+  ngOnInit(): void {
+    this.route.queryParams.subscribe(params => {
+      this.token = params['token'] || null;
+    });
+  }
+
+  onSubmit() {
+    if (this.form.valid && this.token) {
+      this.authService.resetPassword(this.token, this.form.value.newPassword).subscribe({
+        next: res => this.message = res.message,
+        error: () => this.message = 'Erreur lors de la réinitialisation'
+      });
+    } else {
+      this.form.markAllAsTouched();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `requestPasswordReset` and `resetPassword` helpers
- create `forgot-password` and `reset-password` components
- wire up new pages in the router

## Testing
- `pytest -q`
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844e226090c832e82cdf5186d98f80d