### PR TITLE
Add global FontAwesome import

### DIFF
--- a/Frontend/src/app/shared/components/navbar/navbar.component.scss
+++ b/Frontend/src/app/shared/components/navbar/navbar.component.scss
@@ -1,5 +1,3 @@
-@import url('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css');
-
 .header {
   background-color: #4d148c;
   color: white;

--- a/Frontend/src/styles.scss
+++ b/Frontend/src/styles.scss
@@ -1,4 +1,5 @@
 /* You can add global styles to this file, and also import other style files */
+@import url('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css');
 @use '@angular/material' as mat;
 
 html, body {


### PR DESCRIPTION
## Summary
- add FontAwesome CSS import globally
- remove per-component FontAwesome import from Navbar

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844e4755f44832e8820e6f81f9fa5a8