### PR TITLE
Use env vars for Google Maps API key

### DIFF
--- a/Frontend/src/environments/environment.prod.ts
+++ b/Frontend/src/environments/environment.prod.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: true,
   apiUrl: 'https://api.example.com/api/v1',
-  googleMapsApiKey: 'YOUR_GOOGLE_MAPS_API_KEY' // Remplacez par votre clé API Google Maps
+  googleMapsApiKey: (process as any).env.GOOGLE_MAPS_API_KEY || ''
 };

--- a/Frontend/src/environments/environment.ts
+++ b/Frontend/src/environments/environment.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: false,
   apiUrl: 'http://127.0.0.1:8000/api/v1',
-  googleMapsApiKey: 'YOUR_GOOGLE_MAPS_API_KEY' // Remplacez par votre clé API Google Maps
-}; 
+  googleMapsApiKey: (process as any).env.GOOGLE_MAPS_API_KEY || ''
+};

--- a/README.md
+++ b/README.md
@@ -20,3 +20,5 @@ The repository excludes `backend/.env` from version control. Store your secrets 
 
 `REDIS_URL` controls the Redis connection used for rate limiting. If omitted, the API defaults to `redis://localhost:6379/0`.
 
+The frontend needs a Google Maps API key. Set `GOOGLE_MAPS_API_KEY` in a `.env` file at the project root or export it in your shell before running the Angular app.
+


### PR DESCRIPTION
## Summary
- load Google Maps key from `GOOGLE_MAPS_API_KEY` in the Angular environments
- document the new variable in the README

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844e47370c8832e9e9e216512b26495