### PR TITLE
Fix env file references

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Environment Variables
 
 The backend requires several FedEx credentials to be provided via environment variables.
-Create an **untracked** file named `.env.local` in the `backend` directory or export them in your shell:
+Copy `backend/.env.example` to `.env.local` in the same directory or export the variables in your shell:
 
 ```
 FEDEX_AUTH_URL=<FedEx OAuth URL>
@@ -12,9 +12,13 @@ FEDEX_CLIENT_SECRET=<your FedEx client secret>
 FEDEX_ACCOUNT_NUMBER=<your FedEx account number>
 ```
 
+The `.env.local` file should include values for `FEDEX_CLIENT_ID`,
+`FEDEX_CLIENT_SECRET`, `FEDEX_ACCOUNT_NUMBER`, `SECRET_KEY` and any other
+required secrets.
+
 Optionally set `FEDEX_BASE_URL` to override the default `https://apis-sandbox.fedex.com`.
 
-The repository excludes `backend/.env` from version control. Store your secrets in `backend/.env.local` or set them as environment variables when running the application.
+Both `backend/.env` and `backend/.env.local` are ignored by Git. Store your secrets in `backend/.env.local` so they are not committed and are automatically loaded by the backend.
 
 `SECRET_KEY` must be provided in production. Define it in `backend/.env.local` or set the environment variable before starting the backend.
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -50,7 +50,9 @@ class Settings(BaseSettings):
     
     class Config:
         case_sensitive = True
-        env_file = ".env"
+        # Load environment variables from `.env.local` by default so local
+        # credentials don't need to be exported in the shell.
+        env_file = ".env.local"
 
 @lru_cache()
 def get_settings():


### PR DESCRIPTION
## Summary
- default to `.env.local` in configuration
- clarify `.env.local` usage in README

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844e570b580832eb69d39a90096691e