### PR TITLE
Update home tracking navigation

### DIFF
--- a/Frontend/src/app/features/home/home.component.spec.ts
+++ b/Frontend/src/app/features/home/home.component.spec.ts
@@ -1,23 +1,48 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs';
 
 import { HomeComponent } from './home.component';
+import { AuthService } from '../../core/services/auth.service';
+import { TrackingService } from '../tracking/services/tracking.service';
 
 describe('HomeComponent', () => {
   let component: HomeComponent;
   let fixture: ComponentFixture<HomeComponent>;
+  let router: Router;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HomeComponent]
+      imports: [HomeComponent, RouterTestingModule],
+      providers: [
+        { provide: AuthService, useValue: { isLoggedIn: () => of(true) } },
+        { provide: TrackingService, useValue: { trackPackage: () => of({ success: true, data: {} }) } }
+      ]
     })
-    .compileComponents();
+      .compileComponents();
 
     fixture = TestBed.createComponent(HomeComponent);
     component = fixture.componentInstance;
+    router = TestBed.inject(Router);
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should navigate to /track/:id on form submit', () => {
+    const spy = spyOn(router, 'navigate');
+    component.trackingForm.setValue({ trackingNumber: 'ABC123' });
+    component.onSubmit();
+    expect(spy).toHaveBeenCalledWith(['/track', 'ABC123']);
+  });
+
+  it('should navigate to /track/:id after tracking', () => {
+    const spy = spyOn(router, 'navigate');
+    component.trackingForm.setValue({ trackingNumber: 'XYZ789' });
+    component.trackPackage();
+    expect(spy).toHaveBeenCalledWith(['/track', 'XYZ789']);
   });
 });

--- a/Frontend/src/app/features/home/home.component.ts
+++ b/Frontend/src/app/features/home/home.component.ts
@@ -327,7 +327,7 @@ export class HomeComponent implements OnInit, OnDestroy {
   onSubmit() {
     if (this.trackingForm.valid) {
       const trackingNumber = this.trackingForm.get('trackingNumber')?.value;
-      this.router.navigate(['/tracking', trackingNumber]);
+      this.router.navigate(['/track', trackingNumber]);
     }
   }
 
@@ -345,8 +345,8 @@ export class HomeComponent implements OnInit, OnDestroy {
     this.trackingService.trackPackage(identifier).subscribe({
       next: (response) => {
         if (response.success && response.data) {
-          this.router.navigate(['/tracking/result', identifier]);
-        } else {
+          this.router.navigate(['/track', identifier]);
+          } else {
           this.addNotification('error', 'Erreur', response.error || 'Erreur inconnue');
         }
       },

--- a/Frontend/src/app/features/tracking/services/tracking.service.ts
+++ b/Frontend/src/app/features/tracking/services/tracking.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { environment } from 'src/environments/environment';
+import { environment } from '../../../../environments/environment';
 import { TrackingInfo } from '../models/tracking';
 
 export interface TrackingResponse {


### PR DESCRIPTION
## Summary
- fix tracking service import path
- update home component to use `/track/:id` routes
- add unit tests for navigation

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless --progress=false` *(fails: Chromium not installed)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844e46bf704832e88a973026f3a2819