### PR TITLE
Implement POD download in home component

### DIFF
--- a/Frontend/src/app/features/home/home.component.html
+++ b/Frontend/src/app/features/home/home.component.html
@@ -55,7 +55,7 @@
       <!-- Obtain Your Proof Option -->
       <div *ngIf="selectedHeroFeature === 'obtain_proof'" class="obtain-proof-option">
         <p>Enter tracking ID to download your proof of delivery.</p>
-        <form [formGroup]="trackingForm" (ngSubmit)="onSubmit()">
+        <form [formGroup]="trackingForm" (ngSubmit)="downloadProof()">
           <div class="tracking-form__input-group">
             <input type="text" formControlName="trackingNumber" class="tracking-form__input" placeholder="Enter tracking ID">
             <button type="submit" class="tracking-form__btn">

--- a/Frontend/src/app/features/home/home.component.ts
+++ b/Frontend/src/app/features/home/home.component.ts
@@ -358,6 +358,27 @@ export class HomeComponent implements OnInit, OnDestroy {
     });
   }
 
+  downloadProof(): void {
+    const identifier = this.trackingForm.get('trackingNumber')?.value.trim();
+    if (!identifier) return;
+
+    this.trackingService.downloadProof(identifier).subscribe({
+      next: (blob) => {
+        const url = window.URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `proof_${identifier}.pdf`;
+        a.click();
+        window.URL.revokeObjectURL(url);
+      },
+      error: (err) => {
+        const msg = err.error?.error || 'Erreur lors du téléchargement de la preuve';
+        this.addNotification('error', 'Erreur', msg);
+        console.error('Erreur de preuve:', err);
+      }
+    });
+  }
+
   // === AJOUTER NOTIFICATION FLOTTANTE
   addNotification(type: 'success' | 'warning' | 'error', title: string, message: string): void {
     const notification: Notification = {

--- a/Frontend/src/app/features/tracking/services/tracking.service.ts
+++ b/Frontend/src/app/features/tracking/services/tracking.service.ts
@@ -22,6 +22,11 @@ export class TrackingService {
   trackPackage(identifier: string): Observable<TrackingResponse> {
     return this.http.get<TrackingResponse>(`${this.baseUrl}/${identifier}`);
   }
+
+  downloadProof(trackingNumber: string): Observable<Blob> {
+    const url = `${this.baseUrl}/${trackingNumber}/proof`;
+    return this.http.get(url, { responseType: 'blob' });
+  }
 }
 
 export type { TrackingInfo } from '../models/tracking';


### PR DESCRIPTION
## Summary
- add downloadProof API in `TrackingService`
- implement `downloadProof` method in `HomeComponent`
- hook download button to new method

## Testing
- `npm test --prefix Frontend` *(fails: ng not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6844e46fc7ac832ea20eda3a2c23150f