### PR TITLE
Add notification service

### DIFF
--- a/Frontend/src/app/core/services/notification.service.ts
+++ b/Frontend/src/app/core/services/notification.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, of } from 'rxjs';
+import { map, catchError } from 'rxjs/operators';
+import { environment } from '../../../environments/environment';
+
+export interface Notification {
+  id: string;
+  title: string;
+  message: string;
+  is_read: boolean;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class NotificationService {
+  private baseUrl = `${environment.apiUrl}/notifications`;
+
+  constructor(private http: HttpClient) {}
+
+  getUnreadNotifications(): Observable<Notification[]> {
+    return this.http.get<Notification[]>(`${this.baseUrl}?unread_only=true`);
+  }
+
+  getUnreadCount(): Observable<number> {
+    return this.getUnreadNotifications().pipe(
+      map((notifications) => notifications.length),
+      catchError(() => of(0))
+    );
+  }
+}

--- a/Frontend/src/app/shared/components/navbar/navbar.component.ts
+++ b/Frontend/src/app/shared/components/navbar/navbar.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
+import { NotificationService } from '../../../core/services/notification.service';
 
 @Component({
   selector: 'app-navbar',
@@ -13,9 +14,12 @@ export class NavbarComponent implements OnInit {
   showSearch = false;
   notificationCount = 0;
 
+  constructor(private notificationService: NotificationService) {}
+
   ngOnInit(): void {
-    // TODO: Intégrer NotificationService pour récupérer le vrai count
-    this.notificationCount = 3; // simulation temporaire
+    this.notificationService.getUnreadCount().subscribe((count) => {
+      this.notificationCount = count;
+    });
   }
 
   toggleSearch(): void {


### PR DESCRIPTION
## Summary
- create `NotificationService` to call API
- display real notification count in navbar

## Testing
- `npm test` *(fails: Chrome browser missing)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844e47b38a4832ea1770fae5b53a7cc