### PR TITLE
Merge tracking submit flows

### DIFF
--- a/Frontend/src/app/features/home/home.component.html
+++ b/Frontend/src/app/features/home/home.component.html
@@ -29,7 +29,7 @@
 
       <!-- Default tracking form (TRACK) -->
       <div *ngIf="selectedHeroFeature === null" class="tracking-form">
-        <form [formGroup]="trackingForm" (ngSubmit)="onSubmit()">
+        <form [formGroup]="trackingForm" (ngSubmit)="trackPackage()">
           <div class="tracking-form__input-group">
             <input type="text" formControlName="trackingNumber" class="tracking-form__input" placeholder="Enter your tracking number">
             <button type="submit" class="tracking-form__btn">
@@ -55,7 +55,7 @@
       <!-- Obtain Your Proof Option -->
       <div *ngIf="selectedHeroFeature === 'obtain_proof'" class="obtain-proof-option">
         <p>Enter tracking ID to download your proof of delivery.</p>
-        <form [formGroup]="trackingForm" (ngSubmit)="onSubmit()">
+        <form [formGroup]="trackingForm" (ngSubmit)="trackPackage()">
           <div class="tracking-form__input-group">
             <input type="text" formControlName="trackingNumber" class="tracking-form__input" placeholder="Enter tracking ID">
             <button type="submit" class="tracking-form__btn">

--- a/Frontend/src/app/features/home/home.component.ts
+++ b/Frontend/src/app/features/home/home.component.ts
@@ -324,15 +324,11 @@ export class HomeComponent implements OnInit, OnDestroy {
     }
   }
 
-  onSubmit() {
-    if (this.trackingForm.valid) {
-      const trackingNumber = this.trackingForm.get('trackingNumber')?.value;
-      this.router.navigate(['/tracking', trackingNumber]);
-    }
-  }
-
   // === TRAITEMENT TRACKING
   trackPackage(): void {
+    if (this.trackingForm.invalid) {
+      return;
+    }
     const identifier = this.trackingForm.get('trackingNumber')?.value.trim();
     if (!identifier) return;
 
@@ -345,7 +341,7 @@ export class HomeComponent implements OnInit, OnDestroy {
     this.trackingService.trackPackage(identifier).subscribe({
       next: (response) => {
         if (response.success && response.data) {
-          this.router.navigate(['/tracking/result', identifier]);
+          this.router.navigate(['/track', identifier]);
         } else {
           this.addNotification('error', 'Erreur', response.error || 'Erreur inconnue');
         }


### PR DESCRIPTION
## Summary
- unify tracking search logic in home component
- point navigation to `/track/:identifier`
- update forms to call `trackPackage()`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844e47faccc832eb9f4d7a92e6286f2