### PR TITLE
Implement barcode generation via backend

### DIFF
--- a/Frontend/src/app/features/home/home.component.ts
+++ b/Frontend/src/app/features/home/home.component.ts
@@ -118,6 +118,7 @@ export class HomeComponent implements OnInit, OnDestroy {
 
   // Form for barcode generation
   barcodeForm: FormGroup;
+  barcodeImageUrl: string | null = null;
 
   constructor(
     private fb: FormBuilder,
@@ -479,13 +480,28 @@ export class HomeComponent implements OnInit, OnDestroy {
   generateBarcode(): void {
     if (this.barcodeForm.valid) {
       const trackingId = this.barcodeForm.get('trackingId')?.value;
-      // TODO: Implement actual barcode generation logic
-      // For now, just show a notification
-      this.addNotification(
-        'success',
-        'Barcode Generated',
-        `Barcode for tracking ID ${trackingId} has been generated.`
-      );
+      this.trackingService.getBarcodeImage(trackingId).subscribe({
+        next: (blob) => {
+          const url = window.URL.createObjectURL(blob);
+          this.barcodeImageUrl = url;
+
+          const link = document.createElement('a');
+          link.href = url;
+          link.download = `${trackingId}.png`;
+          link.click();
+          window.URL.revokeObjectURL(url);
+
+          this.addNotification(
+            'success',
+            'Barcode Generated',
+            `Barcode for tracking ID ${trackingId} has been generated.`
+          );
+        },
+        error: (err) => {
+          const msg = err.error?.detail || 'Failed to generate barcode';
+          this.addNotification('error', 'Error', msg);
+        }
+      });
     } else {
       this.addNotification(
         'error',

--- a/Frontend/src/app/features/tracking/services/tracking.service.ts
+++ b/Frontend/src/app/features/tracking/services/tracking.service.ts
@@ -27,6 +27,11 @@ export class TrackingService {
     const url = `${this.baseUrl}/${trackingNumber}/proof`;
     return this.http.get(url, { responseType: 'blob' });
   }
+
+  getBarcodeImage(value: string): Observable<Blob> {
+    const url = `${environment.apiUrl}/colis/codebar-image/${value}`;
+    return this.http.get(url, { responseType: 'blob' });
+  }
 }
 
 export type { TrackingInfo } from '../models/tracking';


### PR DESCRIPTION
## Summary
- store generated barcode image URLs in `HomeComponent`
- add actual barcode generation flow calling the backend
- expose `getBarcodeImage` in `TrackingService`

## Testing
- `npm test --silent` *(fails: ng not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6844e99bfc80832e8aa330d4a075d50b