### PR TITLE
Add frontend tests for barcode and proof download

### DIFF
--- a/Frontend/src/app/features/home/home.component.spec.ts
+++ b/Frontend/src/app/features/home/home.component.spec.ts
@@ -1,7 +1,8 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { of } from 'rxjs';
+import { BrowserMultiFormatReader } from '@zxing/browser';
 
 import { HomeComponent } from './home.component';
 import { AuthService } from '../../core/services/auth.service';
@@ -44,5 +45,54 @@ describe('HomeComponent', () => {
     component.trackingForm.setValue({ trackingNumber: 'XYZ789' });
     component.trackPackage();
     expect(spy).toHaveBeenCalledWith(['/track', 'XYZ789']);
+  });
+
+  it('should decode barcode file and populate form', fakeAsync(() => {
+    const decodeSpy = spyOn(BrowserMultiFormatReader.prototype, 'decodeFromImageUrl')
+      .and.returnValue(Promise.resolve({ getText: () => 'DECODED123' } as any));
+
+    const fakeReader: any = {
+      onload: () => {},
+      readAsDataURL: function () {
+        this.result = 'data:image/png;base64,FAKE';
+        this.onload();
+      },
+      result: ''
+    };
+
+    spyOn(window as any, 'FileReader').and.returnValue(fakeReader);
+
+    const file = new File(['dummy'], 'code.png', { type: 'image/png' });
+    const event = { target: { files: [file] } } as any;
+
+    component.onBarcodeFileSelected(event);
+    tick();
+
+    expect(decodeSpy).toHaveBeenCalled();
+    expect(component.trackingForm.get('trackingNumber')?.value).toBe('DECODED123');
+  }));
+
+  it('should call TrackingService.downloadProof when downloading', () => {
+    const trackingService = TestBed.inject(TrackingService);
+    const spy = spyOn(trackingService, 'downloadProof').and.returnValue(of(new Blob()));
+    component.trackingForm.setValue({ trackingNumber: 'ABC999' });
+    component.downloadProof();
+    expect(spy).toHaveBeenCalledWith('ABC999');
+  });
+
+  it('should display correct hero feature section', () => {
+    component.selectedHeroFeature = 'barcode_scan';
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.barcode-scan-option')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('.obtain-proof-option')).toBeNull();
+
+    component.selectedHeroFeature = 'obtain_proof';
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.obtain-proof-option')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('.barcode-scan-option')).toBeNull();
+
+    component.selectedHeroFeature = null;
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.tracking-form')).toBeTruthy();
   });
 });

--- a/Frontend/src/styles.scss
+++ b/Frontend/src/styles.scss
@@ -1,6 +1,6 @@
+@use '@angular/material' as mat;
 /* You can add global styles to this file, and also import other style files */
 @import url('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css');
-@use '@angular/material' as mat;
 
 html, body {
   height: 100%;

--- a/Frontend/tsconfig.spec.json
+++ b/Frontend/tsconfig.spec.json
@@ -5,7 +5,8 @@
   "compilerOptions": {
     "outDir": "./out-tsc/spec",
     "types": [
-      "jasmine"
+      "jasmine",
+      "node"
     ]
   },
   "include": [


### PR DESCRIPTION
## Summary
- expand HomeComponent unit tests
- fix angular build warnings in styles
- enable Node types for specs

## Testing
- `npm test --silent` *(fails: Chrome not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6844e99f8350832e859481aad34028ad