### PR TITLE
Add notifications feature module

### DIFF
--- a/Frontend/src/app/app.routes.ts
+++ b/Frontend/src/app/app.routes.ts
@@ -8,6 +8,7 @@ import { ForgotPasswordComponent } from './features/auth/forgot-password/forgot-
 import { ResetPasswordComponent } from './features/auth/reset-password/reset-password.component';
 import { TrackResultComponent } from './features/tracking/track-result/track-result.component';
 import { GoogleCallbackComponent } from './features/auth/google-callback/google-callback.component';
+import { NotificationsComponent } from './features/notifications/notifications.component';
 
 // Assuming you might have other standalone components or lazy-loaded routes
 // import { HomeComponent } from './features/home/home.component';
@@ -26,6 +27,7 @@ export const routes: Routes = [
 
   // Add other routes here, including for other standalone components
   { path: 'track/:identifier', component: TrackResultComponent, canActivate: [AuthGuard] },
+  { path: 'notifications', component: NotificationsComponent, canActivate: [AuthGuard] },
   { path: 'auth/login', component: LoginComponent },
   { path: 'verify-email', component: VerifyEmailComponent },
   { path: 'auth/callback', component: GoogleCallbackComponent },

--- a/Frontend/src/app/core/services/notification.service.ts
+++ b/Frontend/src/app/core/services/notification.service.ts
@@ -29,4 +29,8 @@ export class NotificationService {
       catchError(() => of(0))
     );
   }
+
+  markAllAsRead(): Observable<any> {
+    return this.http.post(`${this.baseUrl}/mark-all-read`, {});
+  }
 }

--- a/Frontend/src/app/features/notifications/notifications.component.html
+++ b/Frontend/src/app/features/notifications/notifications.component.html
@@ -1,0 +1,12 @@
+<div class="notifications">
+  <h2>Notifications</h2>
+  <button (click)="markAllAsRead()" [disabled]="notifications.length === 0">Mark all as read</button>
+  <div *ngIf="loading">Loading...</div>
+  <ul *ngIf="!loading && notifications.length">
+    <li *ngFor="let notif of notifications">
+      <h3>{{ notif.title }}</h3>
+      <p>{{ notif.message }}</p>
+    </li>
+  </ul>
+  <p *ngIf="!loading && notifications.length === 0">No unread notifications.</p>
+</div>

--- a/Frontend/src/app/features/notifications/notifications.component.scss
+++ b/Frontend/src/app/features/notifications/notifications.component.scss
@@ -1,0 +1,18 @@
+.notifications {
+  padding: 1rem;
+}
+
+.notifications h2 {
+  margin-bottom: 1rem;
+}
+
+.notifications ul {
+  list-style: none;
+  padding: 0;
+}
+
+.notifications li {
+  margin-bottom: 1rem;
+  border-bottom: 1px solid #ccc;
+  padding-bottom: 0.5rem;
+}

--- a/Frontend/src/app/features/notifications/notifications.component.ts
+++ b/Frontend/src/app/features/notifications/notifications.component.ts
@@ -1,0 +1,40 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { NotificationService, Notification } from '../../core/services/notification.service';
+
+@Component({
+  selector: 'app-notifications',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './notifications.component.html',
+  styleUrls: ['./notifications.component.scss']
+})
+export class NotificationsComponent implements OnInit {
+  notifications: Notification[] = [];
+  loading = false;
+
+  constructor(private notificationService: NotificationService) {}
+
+  ngOnInit() {
+    this.fetchNotifications();
+  }
+
+  fetchNotifications() {
+    this.loading = true;
+    this.notificationService.getUnreadNotifications().subscribe({
+      next: (notifs) => {
+        this.notifications = notifs;
+        this.loading = false;
+      },
+      error: () => {
+        this.loading = false;
+      }
+    });
+  }
+
+  markAllAsRead() {
+    this.notificationService.markAllAsRead().subscribe(() => {
+      this.fetchNotifications();
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- create notifications feature with standalone component
- display unread notifications and allow marking them as read
- expose `markAllAsRead` on NotificationService
- route `/notifications` to the new component

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6844eee81a94832e8610c6c67bbc15ce