### PR TITLE
Add navbar tracking input

### DIFF
--- a/Frontend/src/app/shared/components/navbar/navbar.component.html
+++ b/Frontend/src/app/shared/components/navbar/navbar.component.html
@@ -9,8 +9,8 @@
         <a href="#">Tracking <i class="fas fa-chevron-down"></i></a>
         <div class="dropdown__menu">
           <h4>Tracking ID</h4>
-          <input type="text" placeholder="Insert Tracking ID Number" />
-          <button class="btn-track">TRACK <i class="fas fa-arrow-right"></i></button>
+          <input type="text" placeholder="Insert Tracking ID Number" [(ngModel)]="trackingId" />
+          <button class="btn-track" (click)="trackFromNavbar()">TRACK <i class="fas fa-arrow-right"></i></button>
           <hr />
           <a routerLink="/advanced-shipment-tracking">Advanced Shipment Tracking</a>
           <a routerLink="/mobile-tracking">Track by Mobile</a>

--- a/Frontend/src/app/shared/components/navbar/navbar.component.ts
+++ b/Frontend/src/app/shared/components/navbar/navbar.component.ts
@@ -1,20 +1,25 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { RouterModule } from '@angular/router';
+import { RouterModule, Router } from '@angular/router';
+import { FormsModule } from '@angular/forms';
 import { NotificationService } from '../../../core/services/notification.service';
 
 @Component({
   selector: 'app-navbar',
   standalone: true,
-  imports: [CommonModule, RouterModule],
+  imports: [CommonModule, RouterModule, FormsModule],
   templateUrl: './navbar.component.html',
   styleUrls: ['./navbar.component.scss']
 })
 export class NavbarComponent implements OnInit {
+  trackingId = '';
   showSearch = false;
   notificationCount = 0;
 
-  constructor(private notificationService: NotificationService) {}
+  constructor(
+    private notificationService: NotificationService,
+    private router: Router
+  ) {}
 
   ngOnInit(): void {
     this.notificationService.getUnreadCount().subscribe((count) => {
@@ -24,5 +29,12 @@ export class NavbarComponent implements OnInit {
 
   toggleSearch(): void {
     this.showSearch = !this.showSearch;
+  }
+
+  trackFromNavbar(): void {
+    const id = this.trackingId.trim();
+    if (id) {
+      this.router.navigate(['/track', id]);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- allow tracking packages directly from the navbar
- bind `trackingId` input with `ngModel`
- navigate to tracking page when clicking the navbar button
- include `FormsModule` imports

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844eeedc498832eb0c95974a9c12f98