### PR TITLE
Add tests for tracking and notifications

### DIFF
--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,61 @@
+import os
+import sys
+import asyncio
+import pytest
+
+# Set required env vars before importing the app modules
+os.environ.setdefault('DATABASE_URL', 'sqlite:///:memory:')
+os.environ.setdefault('FEDEX_CLIENT_ID', 'dummy')
+os.environ.setdefault('FEDEX_CLIENT_SECRET', 'dummy')
+os.environ.setdefault('FEDEX_ACCOUNT_NUMBER', 'dummy')
+os.environ.setdefault('SECRET_KEY', 'testsecret')
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from backend.app.database import Base, engine, SessionLocal
+from backend.app.models.database import Base as ModelsBase, NotificationDB
+from backend.app.api.v1.endpoints import notifications as notifications_router
+from backend.app.models.notification import NotificationCreate, NotificationUpdate, NotificationType
+
+
+@pytest.fixture
+def db_session():
+    Base.metadata.drop_all(bind=engine)
+    ModelsBase.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    ModelsBase.metadata.create_all(bind=engine)
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def test_create_and_mark_notification(db_session):
+    create = NotificationCreate(
+        type=NotificationType.CUSTOM,
+        title="hello",
+        message="msg"
+    )
+    resp = asyncio.run(notifications_router.create_notification(create, db_session))
+    assert resp.success is True
+    notif_id = resp.data.id
+
+    update = NotificationUpdate(is_read=True)
+    updated = asyncio.run(notifications_router.update_notification(notif_id, update, db_session))
+    assert updated.success is True
+    assert updated.data.is_read is True
+    assert updated.data.read_at is not None
+
+
+def test_mark_all_as_read(db_session):
+    create = NotificationCreate(type=NotificationType.CUSTOM, title="one", message="1")
+    resp1 = asyncio.run(notifications_router.create_notification(create, db_session))
+    resp2 = asyncio.run(notifications_router.create_notification(create, db_session))
+    assert resp1.success and resp2.success
+
+    res = asyncio.run(notifications_router.mark_all_as_read(db_session))
+    assert res.success is True
+
+    all_notifs = asyncio.run(notifications_router.get_notifications(db=db_session))
+    assert all(n.is_read for n in all_notifs)

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -1,0 +1,57 @@
+import os
+import sys
+import asyncio
+import pytest
+
+# Set required env vars before importing the app modules
+os.environ.setdefault('DATABASE_URL', 'sqlite:///:memory:')
+os.environ.setdefault('FEDEX_CLIENT_ID', 'dummy')
+os.environ.setdefault('FEDEX_CLIENT_SECRET', 'dummy')
+os.environ.setdefault('FEDEX_ACCOUNT_NUMBER', 'dummy')
+os.environ.setdefault('SECRET_KEY', 'testsecret')
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from backend.app.database import Base, engine, SessionLocal
+from backend.app.models.database import Base as ModelsBase, ColisDB
+from backend.app.services.colis_service import ColisService
+from backend.app.models.colis import ColisCreate
+from backend.app.models.tracking import TrackingResponse
+from backend.app.api.v1.endpoints import tracking as tracking_router
+
+@pytest.fixture
+def db_session():
+    Base.metadata.drop_all(bind=engine)
+    ModelsBase.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    ModelsBase.metadata.create_all(bind=engine)
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def setup_colis(db, monkeypatch, colis_id="TEST123"):
+    # Avoid actual barcode generation
+    monkeypatch.setattr(ColisService, "generate_codebar_image", lambda self, val: "dummy.png")
+    service = ColisService(db)
+    asyncio.run(service.create_colis(ColisCreate(id=colis_id, description="test")))
+    return colis_id
+
+
+class DummyFedExService:
+    def __init__(self, *a, **k):
+        pass
+
+    async def track_package(self, tracking_number: str) -> TrackingResponse:
+        return TrackingResponse(success=True, data=None, error=None, metadata={})
+
+
+def test_track_package_by_id(db_session, monkeypatch):
+    colis_id = setup_colis(db_session, monkeypatch)
+    monkeypatch.setattr(tracking_router, "FedExService", DummyFedExService)
+
+    resp = asyncio.run(tracking_router.track_package(colis_id, db_session))
+    assert resp.success is True
+    assert resp.metadata["identifier"] == colis_id


### PR DESCRIPTION
## Summary
- add tests for tracking endpoint and notifications

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844eeef33c0832ebc60ba690f418700