### PR TITLE
Add SMTP placeholders in env template

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -25,3 +25,7 @@ DEBUG=True
 
 # CORS configuration
 FRONTEND_URL=http://localhost:4200
+
+# Email configuration
+SMTP_USERNAME=your-smtp-username
+SMTP_PASSWORD=your-smtp-password


### PR DESCRIPTION
## Summary
- clarify required SMTP credentials in `backend/.env.example`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6844eef4c460832ebc1d3f54786f43fa