### PR TITLE
Handle Google callback token

### DIFF
--- a/Frontend/src/app/features/auth/google-callback/google-callback.component.ts
+++ b/Frontend/src/app/features/auth/google-callback/google-callback.component.ts
@@ -18,7 +18,10 @@ export class GoogleCallbackComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.route.queryParams.subscribe(() => {
+    this.route.queryParams.subscribe(params => {
+      const token = params['token'];
+      // Le token est inclus dans l'URL par le backend lors du callback Google.
+      // Il peut être utilisé ultérieurement si nécessaire.
       this.authService.me().subscribe({
         next: () => this.router.navigate(['/home']),
         error: () => this.router.navigate(['/auth/login'])


### PR DESCRIPTION
## Summary
- read `token` query param on Google callback page
- leave existing route for the callback

## Testing
- `pytest -q`
- `npm test` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_6844ef083418832e9c07be6a8eabfbfb