### PR TITLE
Update login flow to handle cookies and errors

### DIFF
--- a/Frontend/src/app/features/auth/login/login.component.ts
+++ b/Frontend/src/app/features/auth/login/login.component.ts
@@ -3,8 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, Validators, ReactiveFormsModule, FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
 import { AuthService } from '../../../core/services/auth.service';
-import { catchError, switchMap } from 'rxjs/operators';
-import { of } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
 
 @Component({
   selector: 'app-login',
@@ -26,18 +25,16 @@ export class LoginComponent {
 
   onSubmit() {
     if (this.loginForm.valid) {
-      this.authService.login(this.loginForm.value).pipe(
-        switchMap(() => this.authService.me()),
-        catchError(err => {
-          console.error('Login failed', err);
-          this.error = 'Login failed';
-          return of(null);
-        })
-      ).subscribe(user => {
-        if (user) {
-          this.router.navigate(['/home']);
-        }
-      });
+      this.error = null;
+      this.authService.login(this.loginForm.value)
+        .pipe(switchMap(() => this.authService.me()))
+        .subscribe({
+          next: () => this.router.navigate(['/home']),
+          error: err => {
+            console.error('Login failed', err);
+            this.error = err?.error?.detail || 'Login failed';
+          }
+        });
     } else {
       this.loginForm.markAllAsTouched();
     }


### PR DESCRIPTION
## Summary
- ensure cookies from login are stored by calling `me()` after login
- display the server-provided error message when login fails

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844ef0b6e5c832e97fb876fa7a01028