### PR TITLE
Add Google Maps view in tracking result

### DIFF
--- a/Frontend/src/app/features/tracking/track-result/track-result.component.html
+++ b/Frontend/src/app/features/tracking/track-result/track-result.component.html
@@ -72,8 +72,8 @@
     </div>
 
     <div class="grid md:grid-cols-2 gap-4 mb-4">
-      <div id="map" class="h-64 w-full bg-gray-200 rounded" *ngIf="false">
-        <!-- Map placeholder -->
+      <div id="map" class="h-64 w-full bg-gray-200 rounded" *ngIf="trackingInfo">
+        <!-- Google Map will be rendered here -->
       </div>
       <div>
         <h3 class="font-bold mb-2">Détails du colis</h3>


### PR DESCRIPTION
## Summary
- render a map in the tracking result view
- initialise Google Maps once tracking data is loaded
- place origin, destination and current markers using provided coordinates
- draw shipment route with a coloured polyline

## Testing
- `npm test --silent` *(fails: ng not found)*
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844ef0cd814832ea6f7b75ebd2981b4