### PR TITLE
Add install instructions and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,28 @@
 # AppTracking
 
+## Installation
+
+1. Installez les dépendances Python :
+   ```bash
+   pip install -r backend/requirements.txt
+   ```
+2. Depuis le répertoire `Frontend/`, installez les dépendances Node.js :
+   ```bash
+   npm install
+   ```
+3. Lancez le backend :
+   ```bash
+   uvicorn backend.app.main:app
+   ```
+4. Dans `Frontend/`, démarrez l’interface :
+   ```bash
+   npm start
+   ```
+
 ## Environment Variables
 
 The backend requires several FedEx credentials to be provided via environment variables.
-Copy `backend/.env.example` to `.env.local` in the same directory or export the variables in your shell:
+Créez un fichier `backend/.env.local` en vous basant sur `backend/.env.example` ou exportez les variables dans votre shell :
 
 ```
 FEDEX_AUTH_URL=<FedEx OAuth URL>
@@ -12,9 +31,9 @@ FEDEX_CLIENT_SECRET=<your FedEx client secret>
 FEDEX_ACCOUNT_NUMBER=<your FedEx account number>
 ```
 
-The `.env.local` file should include values for `FEDEX_CLIENT_ID`,
-`FEDEX_CLIENT_SECRET`, `FEDEX_ACCOUNT_NUMBER`, `SECRET_KEY` and any other
-required secrets.
+Le fichier `.env.local` doit au minimum définir `FEDEX_CLIENT_ID`,
+`FEDEX_CLIENT_SECRET`, `FEDEX_ACCOUNT_NUMBER` et `SECRET_KEY` ainsi que toutes
+les autres variables nécessaires.
 
 Optionally set `FEDEX_BASE_URL` to override the default `https://apis-sandbox.fedex.com`.
 
@@ -22,7 +41,16 @@ Both `backend/.env` and `backend/.env.local` are ignored by Git. Store your secr
 
 `SECRET_KEY` must be provided in production. Define it in `backend/.env.local` or set the environment variable before starting the backend.
 
+
 `REDIS_URL` controls the Redis connection used for rate limiting. If omitted, the API defaults to `redis://localhost:6379/0`.
 
 The frontend needs a Google Maps API key. Set `GOOGLE_MAPS_API_KEY` in a `.env` file at the project root or export it in your shell before running the Angular app.
+
+## Tests
+
+Pour exécuter la suite de tests automatisés :
+
+```bash
+pytest
+```
 


### PR DESCRIPTION
## Summary
- add setup commands for backend and frontend
- explain minimal variables required in backend/.env.local
- document running the tests

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844ef0e9000832e8b5b065daa9689ad