### PR TITLE
Add barcode generator UI

### DIFF
--- a/Frontend/src/app/features/home/home.component.html
+++ b/Frontend/src/app/features/home/home.component.html
@@ -71,6 +71,20 @@
 </section>
 
 <!-- =======================
+🆕 GENERATE BARCODE SECTION
+======================= -->
+<div class="generate-barcode-option">
+  <p>Enter a tracking ID to generate its barcode.</p>
+  <form [formGroup]="barcodeForm" (ngSubmit)="generateBarcode()" class="input-group">
+    <input type="text" formControlName="trackingId" placeholder="Enter tracking ID">
+    <button type="submit" class="btn btn--primary">Generate</button>
+  </form>
+  <div class="barcode-display" *ngIf="barcodeImageUrl">
+    <img [src]="barcodeImageUrl" alt="Generated Barcode">
+  </div>
+</div>
+
+<!-- =======================
 🚀 SERVICES SECTION
 ======================= -->
 <section class="services">


### PR DESCRIPTION
## Summary
- show a new generate barcode section on home page
- allow generating barcodes through `barcodeForm`
- show the resulting barcode image when available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844f81c10f0832e90d4dc4987085392