### PR TITLE
Add tracking form validation errors

### DIFF
--- a/Frontend/src/app/features/home/home.component.html
+++ b/Frontend/src/app/features/home/home.component.html
@@ -37,6 +37,12 @@
               Track
             </button>
           </div>
+          <div class="error-message" *ngIf="trackingForm.get('trackingNumber')?.errors?.required && trackingForm.get('trackingNumber')?.touched">
+            Tracking number is required.
+          </div>
+          <div class="error-message" *ngIf="trackingForm.get('trackingNumber')?.errors?.pattern && trackingForm.get('trackingNumber')?.touched">
+            Tracking number must be alphanumeric.
+          </div>
           <!-- Barcode scan option removed from default form -->
         </form>
       </div>
@@ -62,6 +68,12 @@
               <i class="fas fa-download"></i>
               Download Proof
             </button>
+          </div>
+          <div class="error-message" *ngIf="trackingForm.get('trackingNumber')?.errors?.required && trackingForm.get('trackingNumber')?.touched">
+            Tracking number is required.
+          </div>
+          <div class="error-message" *ngIf="trackingForm.get('trackingNumber')?.errors?.pattern && trackingForm.get('trackingNumber')?.touched">
+            Tracking number must be alphanumeric.
           </div>
         </form>
       </div>

--- a/Frontend/src/app/features/home/home.component.scss
+++ b/Frontend/src/app/features/home/home.component.scss
@@ -217,10 +217,16 @@ $error-color: #dc3545;
     gap: 0.5rem;
     color: $text-color;
     cursor: pointer;
-    
+
     &:hover {
       color: $primary-color;
     }
+  }
+
+  .error-message {
+    color: $error-color;
+    font-size: 0.9rem;
+    margin-top: 0.5rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- display required/pattern messages on home tracking input
- style error messages for home component

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844f82df500832e9768d8c8c0b9e61b