### PR TITLE
Add service components and routing

### DIFF
--- a/Frontend/src/app/app.routes.ts
+++ b/Frontend/src/app/app.routes.ts
@@ -9,6 +9,9 @@ import { ResetPasswordComponent } from './features/auth/reset-password/reset-pas
 import { TrackResultComponent } from './features/tracking/track-result/track-result.component';
 import { GoogleCallbackComponent } from './features/auth/google-callback/google-callback.component';
 import { NotificationsComponent } from './features/notifications/notifications.component';
+import { TrackByMailComponent } from './features/track-by-mail/track-by-mail.component';
+import { NotificationOptionsComponent } from './features/notification-options/notification-options.component';
+import { GenerateBarcodeComponent } from './features/generate-barcode/generate-barcode.component';
 import { SetupTwofaComponent } from './features/auth/setup-twofa/setup-twofa.component';
 import { VerifyTwofaComponent } from './features/auth/verify-twofa/verify-twofa.component';
 
@@ -30,6 +33,10 @@ export const routes: Routes = [
   // Add other routes here, including for other standalone components
   { path: 'track/:identifier', component: TrackResultComponent, canActivate: [AuthGuard] },
   { path: 'notifications', component: NotificationsComponent, canActivate: [AuthGuard] },
+  // Service routes
+  { path: 'services/track-by-mail', component: TrackByMailComponent, canActivate: [AuthGuard] },
+  { path: 'services/notifications', component: NotificationOptionsComponent, canActivate: [AuthGuard] },
+  { path: 'services/generate-barcode', component: GenerateBarcodeComponent, canActivate: [AuthGuard] },
   { path: 'auth/login', component: LoginComponent },
   { path: 'verify-email', component: VerifyEmailComponent },
   { path: 'auth/callback', component: GoogleCallbackComponent },

--- a/Frontend/src/app/features/generate-barcode/generate-barcode.component.html
+++ b/Frontend/src/app/features/generate-barcode/generate-barcode.component.html
@@ -1,0 +1,1 @@
+<p>generate-barcode works!</p>

--- a/Frontend/src/app/features/generate-barcode/generate-barcode.component.scss
+++ b/Frontend/src/app/features/generate-barcode/generate-barcode.component.scss
@@ -1,0 +1,1 @@
+/* Styles for GenerateBarcodeComponent */

--- a/Frontend/src/app/features/generate-barcode/generate-barcode.component.ts
+++ b/Frontend/src/app/features/generate-barcode/generate-barcode.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-generate-barcode',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './generate-barcode.component.html',
+  styleUrls: ['./generate-barcode.component.scss']
+})
+export class GenerateBarcodeComponent {}

--- a/Frontend/src/app/features/home/home.component.html
+++ b/Frontend/src/app/features/home/home.component.html
@@ -89,7 +89,7 @@
           <i [class]="service.icon" class="service-item__icon"></i>
           <h3>{{ service.title }}</h3>
           <p>{{ service.description }}</p>
-          <a [href]="service.link" class="service-item__link btn btn--outline-primary">
+          <a [routerLink]="service.link" class="service-item__link btn btn--outline-primary">
             CONTACT US FOR MORE INFO
             <i class="fas fa-arrow-right"></i>
           </a>

--- a/Frontend/src/app/features/notification-options/notification-options.component.html
+++ b/Frontend/src/app/features/notification-options/notification-options.component.html
@@ -1,0 +1,1 @@
+<p>notification-options works!</p>

--- a/Frontend/src/app/features/notification-options/notification-options.component.scss
+++ b/Frontend/src/app/features/notification-options/notification-options.component.scss
@@ -1,0 +1,1 @@
+/* Styles for NotificationOptionsComponent */

--- a/Frontend/src/app/features/notification-options/notification-options.component.ts
+++ b/Frontend/src/app/features/notification-options/notification-options.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-notification-options',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './notification-options.component.html',
+  styleUrls: ['./notification-options.component.scss']
+})
+export class NotificationOptionsComponent {}

--- a/Frontend/src/app/features/track-by-mail/track-by-mail.component.html
+++ b/Frontend/src/app/features/track-by-mail/track-by-mail.component.html
@@ -1,0 +1,1 @@
+<p>track-by-mail works!</p>

--- a/Frontend/src/app/features/track-by-mail/track-by-mail.component.scss
+++ b/Frontend/src/app/features/track-by-mail/track-by-mail.component.scss
@@ -1,0 +1,1 @@
+/* Styles for TrackByMailComponent */

--- a/Frontend/src/app/features/track-by-mail/track-by-mail.component.ts
+++ b/Frontend/src/app/features/track-by-mail/track-by-mail.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-track-by-mail',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './track-by-mail.component.html',
+  styleUrls: ['./track-by-mail.component.scss']
+})
+export class TrackByMailComponent {}


### PR DESCRIPTION
## Summary
- add basic service components for track by mail, notification options and barcode generation
- wire up routes for these pages
- use `[routerLink]` in the services list

## Testing
- `pytest -q`
- `npm test --silent` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_6844f83027d8832ea09972915fdaff47