### PR TITLE
Implement email verification expiry

### DIFF
--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -26,6 +26,7 @@ class UserDB(Base):
     is_google_user = Column(Boolean, default=False)  # Indique si l'utilisateur s'est connecté via Google
     google_id = Column(String, nullable=True)  # ID Google de l'utilisateur
     verification_token = Column(String, nullable=True)
+    verification_token_expires_at = Column(DateTime(timezone=True), nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     role = Column(SQLEnum(UserRole), default=UserRole.client, nullable=False)
     last_login_at = Column(DateTime(timezone=True), nullable=True)


### PR DESCRIPTION
## Summary
- add `verification_token_expires_at` column to `UserDB`
- set email verification expiry when registering users
- reject expired verification tokens when verifying email
- test the expired token scenario

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844fc3c99c8832e8451b950e9ae8145