### PR TITLE
Add email verification resend endpoint

### DIFF
--- a/Frontend/src/app/app.routes.ts
+++ b/Frontend/src/app/app.routes.ts
@@ -14,6 +14,7 @@ import { NotificationOptionsComponent } from './features/notification-options/no
 import { GenerateBarcodeComponent } from './features/generate-barcode/generate-barcode.component';
 import { SetupTwofaComponent } from './features/auth/setup-twofa/setup-twofa.component';
 import { VerifyTwofaComponent } from './features/auth/verify-twofa/verify-twofa.component';
+import { ResendVerificationComponent } from './features/auth/resend-verification/resend-verification.component';
 
 // Assuming you might have other standalone components or lazy-loaded routes
 // import { HomeComponent } from './features/home/home.component';
@@ -42,6 +43,7 @@ export const routes: Routes = [
   { path: 'auth/callback', component: GoogleCallbackComponent },
   { path: 'auth/forgot-password', component: ForgotPasswordComponent },
   { path: 'auth/reset-password', component: ResetPasswordComponent },
+  { path: 'auth/resend-verification', component: ResendVerificationComponent },
   { path: 'auth/setup-2fa', component: SetupTwofaComponent, canActivate: [AuthGuard] },
   { path: 'auth/verify-2fa', component: VerifyTwofaComponent, canActivate: [AuthGuard] },
 ];

--- a/Frontend/src/app/core/services/auth.service.ts
+++ b/Frontend/src/app/core/services/auth.service.ts
@@ -77,6 +77,10 @@ export class AuthService {
     return this.http.post(`${this.apiUrl}/request-reset`, { email });
   }
 
+  resendVerification(email: string): Observable<any> {
+    return this.http.post(`${this.apiUrl}/resend-verification`, { email });
+  }
+
   resetPassword(token: string, newPassword: string): Observable<any> {
     return this.http.post(`${this.apiUrl}/reset-password`, {
       token,

--- a/Frontend/src/app/features/auth/resend-verification/resend-verification.component.html
+++ b/Frontend/src/app/features/auth/resend-verification/resend-verification.component.html
@@ -1,0 +1,14 @@
+<div class="resend-verification-container">
+  <h2>Renvoyer l'email de vérification</h2>
+  <form [formGroup]="form" (ngSubmit)="onSubmit()">
+    <div class="form-group">
+      <label for="email">Email</label>
+      <input id="email" type="email" formControlName="email" />
+      <div class="error-message" *ngIf="form.get('email')?.invalid && form.get('email')?.touched">
+        Adresse email invalide
+      </div>
+    </div>
+    <button type="submit">Envoyer</button>
+  </form>
+  <div class="message" *ngIf="message">{{ message }}</div>
+</div>

--- a/Frontend/src/app/features/auth/resend-verification/resend-verification.component.scss
+++ b/Frontend/src/app/features/auth/resend-verification/resend-verification.component.scss
@@ -1,0 +1,4 @@
+.resend-verification-container {
+  max-width: 400px;
+  margin: auto;
+}

--- a/Frontend/src/app/features/auth/resend-verification/resend-verification.component.ts
+++ b/Frontend/src/app/features/auth/resend-verification/resend-verification.component.ts
@@ -1,0 +1,33 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { AuthService } from '../../../core/services/auth.service';
+
+@Component({
+  selector: 'app-resend-verification',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, FormsModule],
+  templateUrl: './resend-verification.component.html',
+  styleUrls: ['./resend-verification.component.scss']
+})
+export class ResendVerificationComponent {
+  form: FormGroup;
+  message: string | null = null;
+
+  constructor(private fb: FormBuilder, private authService: AuthService) {
+    this.form = this.fb.group({
+      email: ['', [Validators.required, Validators.email]]
+    });
+  }
+
+  onSubmit() {
+    if (this.form.valid) {
+      this.authService.resendVerification(this.form.value.email).subscribe({
+        next: res => this.message = res.message,
+        error: () => this.message = "Erreur lors de l'envoi"
+      });
+    } else {
+      this.form.markAllAsTouched();
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -83,3 +83,18 @@ On the first run Docker Compose builds the backend and frontend images. Once the
 - lors de la connexion, renseignez le champ `totp_code` si l'option est activée.
 
 Le paquet `pyotp` utilisé pour générer les codes TOTP figure déjà dans `backend/requirements.txt`.
+
+## Ré-envoi de l'email de vérification
+
+Si vous n'avez pas reçu l'email de confirmation lors de l'inscription, vous
+pouvez demander un nouvel envoi via l'endpoint `POST /auth/resend-verification`.
+Envoyez simplement l'adresse email utilisée à l'inscription :
+
+```bash
+curl -X POST http://localhost:8000/api/v1/auth/resend-verification \
+     -H 'Content-Type: application/json' \
+     -d '{"email": "user@example.com"}'
+```
+
+L'interface Angular propose un formulaire accessible à l'adresse
+`/auth/resend-verification` pour effectuer cette action.


### PR DESCRIPTION
## Summary
- implement `POST /auth/resend-verification` API
- expose resend verification form in Angular
- document resend feature in README
- test resend verification

## Testing
- `pip install -r backend/requirements.txt`
- `npm install`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844fc3d32c4832e8dbb83e235047df2