### PR TITLE
Add strong password validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ On the first run Docker Compose builds the backend and frontend images. Once the
 - Frontend: http://localhost:4200
 - Redis: localhost:6379
 
+## Password requirements
+
+User registration requires a strong password. The password must be at least 8
+characters long and include at least one digit and one uppercase letter. A
+validation error is returned if this rule is not met.
+
 ## Double authentification
 
 - exécutez `/auth/setup-2fa` pour obtenir l'URL du QR à scanner ;

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, field_validator
 from typing import Optional
 from datetime import datetime
 from sqlalchemy import Boolean, Column, Integer, String, DateTime, Enum as SQLEnum
@@ -39,6 +39,17 @@ class UserBase(BaseModel):
 
 class UserCreate(UserBase):
     password: str
+
+    @field_validator("password")
+    @classmethod
+    def strong_password(cls, v: str):
+        has_digit = any(c.isdigit() for c in v)
+        has_upper = any(c.isupper() for c in v)
+        if len(v) < 8 or not has_digit or not has_upper:
+            raise ValueError(
+                "Password must be at least 8 characters long and include at least one digit and one uppercase letter"
+            )
+        return v
 
 class UserLogin(BaseModel):
     email: EmailStr

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -16,6 +16,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from backend.app.database import Base, engine, SessionLocal
 from backend.app.models.user import UserCreate
+from pydantic import ValidationError
 from backend.app.services import auth
 
 @pytest.fixture
@@ -29,7 +30,7 @@ def db_session():
         db.close()
 
 def setup_user(db):
-    return auth.create_user(db, UserCreate(email='u@example.com', full_name='U', password='pw'))
+    return auth.create_user(db, UserCreate(email='u@example.com', full_name='U', password='Password1'))
 
 async def call_get_current_user(request, db, token=None):
     return await auth.get_current_user(request=request, db=db, token=token)
@@ -60,6 +61,11 @@ def parse_cookies(header_list):
     return {k: v.value for k, v in jar.items()}
 
 
+def test_password_validation():
+    with pytest.raises(ValidationError):
+        UserCreate(email="bad@example.com", full_name="Bad", password="short")
+
+
 @pytest.fixture
 def patched_router(monkeypatch):
     from backend.app.routers import auth as auth_router
@@ -85,7 +91,7 @@ def patched_router(monkeypatch):
 
 
 def test_register_and_verify_email(db_session, patched_router):
-    user_data = UserCreate(email="new@example.com", full_name="New", password="pw")
+    user_data = UserCreate(email="new@example.com", full_name="New", password="Password1")
     user = asyncio.run(patched_router.register(user_data, db_session))
     assert user.email == "new@example.com"
     assert user.is_verified is False
@@ -101,11 +107,11 @@ def test_register_and_verify_email(db_session, patched_router):
 
 
 def test_login_returns_tokens(db_session, patched_router):
-    user_data = UserCreate(email="login@example.com", full_name="Login", password="pw")
+    user_data = UserCreate(email="login@example.com", full_name="Login", password="Password1")
     user = asyncio.run(patched_router.register(user_data, db_session))
     asyncio.run(patched_router.verify_email(patched_router.EmailVerification(token=user.verification_token), db_session))
 
-    form = patched_router.OAuth2PasswordRequestForm(username=user.email, password="pw", scope="")
+    form = patched_router.OAuth2PasswordRequestForm(username=user.email, password="Password1", scope="")
     response = patched_router.Response()
     token_model = asyncio.run(patched_router.login(response, form, db_session))
 
@@ -116,11 +122,11 @@ def test_login_returns_tokens(db_session, patched_router):
 
 
 def test_refresh_token_flow(db_session, patched_router):
-    user_data = UserCreate(email="ref@example.com", full_name="Ref", password="pw")
+    user_data = UserCreate(email="ref@example.com", full_name="Ref", password="Password1")
     user = asyncio.run(patched_router.register(user_data, db_session))
     asyncio.run(patched_router.verify_email(patched_router.EmailVerification(token=user.verification_token), db_session))
 
-    form = patched_router.OAuth2PasswordRequestForm(username=user.email, password="pw", scope="")
+    form = patched_router.OAuth2PasswordRequestForm(username=user.email, password="Password1", scope="")
     login_response = patched_router.Response()
     asyncio.run(patched_router.login(login_response, form, db_session))
     old_cookies = parse_cookies(login_response.headers.getlist("set-cookie"))
@@ -141,11 +147,11 @@ def test_refresh_token_flow(db_session, patched_router):
 
 
 def test_logout_revokes_refresh(db_session, patched_router):
-    user_data = UserCreate(email="out@example.com", full_name="Out", password="pw")
+    user_data = UserCreate(email="out@example.com", full_name="Out", password="Password1")
     user = asyncio.run(patched_router.register(user_data, db_session))
     asyncio.run(patched_router.verify_email(patched_router.EmailVerification(token=user.verification_token), db_session))
 
-    form = patched_router.OAuth2PasswordRequestForm(username=user.email, password="pw", scope="")
+    form = patched_router.OAuth2PasswordRequestForm(username=user.email, password="Password1", scope="")
     login_response = patched_router.Response()
     asyncio.run(patched_router.login(login_response, form, db_session))
     cookies = parse_cookies(login_response.headers.getlist("set-cookie"))
@@ -163,11 +169,11 @@ def test_logout_revokes_refresh(db_session, patched_router):
     assert cleared.get("access_token") == ""
 
 def test_register_verify_login_logout_flow(db_session, patched_router):
-    user_data = UserCreate(email="flow@example.com", full_name="Flow", password="pw")
+    user_data = UserCreate(email="flow@example.com", full_name="Flow", password="Password1")
     user = asyncio.run(patched_router.register(user_data, db_session))
     asyncio.run(patched_router.verify_email(patched_router.EmailVerification(token=user.verification_token), db_session))
 
-    form = patched_router.OAuth2PasswordRequestForm(username=user.email, password="pw", scope="")
+    form = patched_router.OAuth2PasswordRequestForm(username=user.email, password="Password1", scope="")
     login_resp = patched_router.Response()
     asyncio.run(patched_router.login(login_resp, form, db_session))
     cookies = parse_cookies(login_resp.headers.getlist("set-cookie"))
@@ -212,7 +218,7 @@ def test_google_callback_sets_cookies(db_session, monkeypatch):
 
 
 def test_password_reset_flow(db_session, patched_router):
-    user_data = UserCreate(email="reset@example.com", full_name="Res", password="pw")
+    user_data = UserCreate(email="reset@example.com", full_name="Res", password="Password1")
     user = asyncio.run(patched_router.register(user_data, db_session))
     asyncio.run(patched_router.verify_email(patched_router.EmailVerification(token=user.verification_token), db_session))
 
@@ -223,20 +229,20 @@ def test_password_reset_flow(db_session, patched_router):
     token_db = db_session.query(PasswordResetTokenDB).filter_by(user_id=user.id).first()
     assert token_db is not None
 
-    asyncio.run(patched_router.reset_password(patched_router.PasswordReset(token=token_db.token, new_password="newpw"), db_session))
+    asyncio.run(patched_router.reset_password(patched_router.PasswordReset(token=token_db.token, new_password="Newpass1"), db_session))
     db_session.refresh(user)
-    assert auth.verify_password("newpw", user.hashed_password)
+    assert auth.verify_password("Newpass1", user.hashed_password)
     assert token_db.revoked is True
 
 
 def test_last_login_timestamp_updated(db_session, patched_router):
-    user_data = UserCreate(email="ll@example.com", full_name="LastLogin", password="pw")
+    user_data = UserCreate(email="ll@example.com", full_name="LastLogin", password="Password1")
     user = asyncio.run(patched_router.register(user_data, db_session))
     asyncio.run(patched_router.verify_email(patched_router.EmailVerification(token=user.verification_token), db_session))
 
     assert user.last_login_at is None
 
-    form = patched_router.OAuth2PasswordRequestForm(username=user.email, password="pw", scope="")
+    form = patched_router.OAuth2PasswordRequestForm(username=user.email, password="Password1", scope="")
     resp = patched_router.Response()
     asyncio.run(patched_router.login(resp, form, db_session))
     db_session.refresh(user)

--- a/tests/test_twofa.py
+++ b/tests/test_twofa.py
@@ -51,7 +51,7 @@ def patched_router(monkeypatch):
 
 
 def setup_verified_user(router, db, email="twofa@example.com"):
-    user = asyncio.run(router.register(UserCreate(email=email, full_name="T", password="pw"), db))
+    user = asyncio.run(router.register(UserCreate(email=email, full_name="T", password="Password1"), db))
     asyncio.run(router.verify_email(router.EmailVerification(token=user.verification_token), db))
     return user
 
@@ -83,12 +83,12 @@ def test_login_requires_totp_when_enabled(db_session, patched_router):
     asyncio.run(patched_router.verify_2fa(patched_router.TwoFACode(code=code), current_user=user, db=db_session))
     db_session.refresh(user)
 
-    form = patched_router.OAuth2PasswordRequestForm(username=user.email, password="pw", scope="")
+    form = patched_router.OAuth2PasswordRequestForm(username=user.email, password="Password1", scope="")
     response = patched_router.Response()
     with pytest.raises(patched_router.HTTPException):
         asyncio.run(patched_router.login(response, form, db_session))
 
-    form2 = patched_router.OAuth2PasswordRequestForm(username=user.email, password="pw", scope="", totp_code=pyotp.TOTP(secret).now())
+    form2 = patched_router.OAuth2PasswordRequestForm(username=user.email, password="Password1", scope="", totp_code=pyotp.TOTP(secret).now())
     response2 = patched_router.Response()
     token_model = asyncio.run(patched_router.login(response2, form2, db_session))
     assert token_model.access_token


### PR DESCRIPTION
## Summary
- validate password strength via Pydantic
- document the password policy in README
- adjust tests for new password rules
- add unit test for weak passwords

## Testing
- `pip install -q -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844fc404bdc832eb068bb688ccfa4b4