### PR TITLE
Implement role checks for admin routes

### DIFF
--- a/backend/app/api/v1/endpoints/notifications.py
+++ b/backend/app/api/v1/endpoints/notifications.py
@@ -10,13 +10,16 @@ from ....models.notification import (
 )
 from ....services.notification_service import NotificationService
 from ....database import get_db
+from ....services.auth import require_role
+from ....models.user import UserDB, UserRole
 
 router = APIRouter()
 
 @router.post("/", response_model=NotificationResponse)
 async def create_notification(
     notification: NotificationCreate,
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    current_user: UserDB = Depends(require_role(UserRole.admin))
 ):
     """
     Create a new notification
@@ -64,7 +67,8 @@ async def get_notifications(
 async def update_notification(
     notification_id: str,
     update_data: NotificationUpdate,
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    current_user: UserDB = Depends(require_role(UserRole.admin))
 ):
     """
     Update a notification
@@ -81,7 +85,8 @@ async def update_notification(
 @router.delete("/{notification_id}", response_model=NotificationResponse)
 async def delete_notification(
     notification_id: str,
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    current_user: UserDB = Depends(require_role(UserRole.admin))
 ):
     """
     Delete a notification
@@ -93,7 +98,10 @@ async def delete_notification(
     return response
 
 @router.post("/mark-all-read", response_model=NotificationResponse)
-async def mark_all_as_read(db: Session = Depends(get_db)):
+async def mark_all_as_read(
+    db: Session = Depends(get_db),
+    current_user: UserDB = Depends(require_role(UserRole.admin))
+):
     """
     Mark all notifications as read
     """

--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -75,6 +75,17 @@ async def get_current_active_user(current_user: User = Depends(get_current_user)
         raise HTTPException(status_code=400, detail="Inactive user")
     return current_user
 
+
+def require_role(*roles: UserRole):
+    """FastAPI dependency factory to ensure the current user has one of the given roles."""
+
+    async def dependency(current_user: UserDB = Depends(get_current_active_user)) -> UserDB:
+        if current_user.role not in roles:
+            raise HTTPException(status_code=403, detail="Forbidden")
+        return current_user
+
+    return dependency
+
 def get_user_by_email(db: Session, email: str) -> Optional[UserDB]:
     return db.query(UserDB).filter(UserDB.email == email).first()
 

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -2,6 +2,7 @@ import os
 import sys
 import asyncio
 import pytest
+from fastapi import HTTPException
 
 # Set required env vars before importing the app modules
 os.environ.setdefault('DATABASE_URL', 'sqlite:///:memory:')
@@ -16,6 +17,8 @@ from backend.app.database import Base, engine, SessionLocal
 from backend.app.models.database import Base as ModelsBase, NotificationDB
 from backend.app.api.v1.endpoints import notifications as notifications_router
 from backend.app.models.notification import NotificationCreate, NotificationUpdate, NotificationType
+from backend.app.models.user import UserCreate, UserRole
+from backend.app.services import auth
 
 
 @pytest.fixture
@@ -31,31 +34,50 @@ def db_session():
         db.close()
 
 
+def create_user_with_role(db, role: UserRole):
+    user = auth.create_user(db, UserCreate(email=f"{role}@example.com", full_name="U", password="pw"))
+    user.role = role
+    db.commit()
+    db.refresh(user)
+    return user
+
+
 def test_create_and_mark_notification(db_session):
+    admin = create_user_with_role(db_session, UserRole.admin)
     create = NotificationCreate(
         type=NotificationType.CUSTOM,
         title="hello",
         message="msg"
     )
-    resp = asyncio.run(notifications_router.create_notification(create, db_session))
+    resp = asyncio.run(notifications_router.create_notification(create, db_session, admin))
     assert resp.success is True
     notif_id = resp.data.id
 
     update = NotificationUpdate(is_read=True)
-    updated = asyncio.run(notifications_router.update_notification(notif_id, update, db_session))
+    updated = asyncio.run(notifications_router.update_notification(notif_id, update, db_session, admin))
     assert updated.success is True
     assert updated.data.is_read is True
     assert updated.data.read_at is not None
 
 
 def test_mark_all_as_read(db_session):
+    admin = create_user_with_role(db_session, UserRole.admin)
     create = NotificationCreate(type=NotificationType.CUSTOM, title="one", message="1")
-    resp1 = asyncio.run(notifications_router.create_notification(create, db_session))
-    resp2 = asyncio.run(notifications_router.create_notification(create, db_session))
+    resp1 = asyncio.run(notifications_router.create_notification(create, db_session, admin))
+    resp2 = asyncio.run(notifications_router.create_notification(create, db_session, admin))
     assert resp1.success and resp2.success
 
-    res = asyncio.run(notifications_router.mark_all_as_read(db_session))
+    res = asyncio.run(notifications_router.mark_all_as_read(db_session, admin))
     assert res.success is True
 
     all_notifs = asyncio.run(notifications_router.get_notifications(db=db_session))
     assert all(n.is_read for n in all_notifs)
+
+
+def test_create_notification_forbidden(db_session):
+    user = create_user_with_role(db_session, UserRole.client)
+    create = NotificationCreate(type=NotificationType.CUSTOM, title="bad", message="x")
+    check = auth.require_role(UserRole.admin)
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(check(current_user=user))
+    assert exc.value.status_code == 403


### PR DESCRIPTION
## Summary
- enforce role-based access control with `require_role`
- secure notification endpoints for admin users only
- update tests and add a check for 403 on unauthorized access

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844fc41e2b4832e97015992722842d6