### PR TITLE
Update gitignore for frontend folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,9 @@ venv/
 # Ignore backend dependencies
 backend/node_modules/
 backend/venv/
+
+# Ignore frontend dependencies and build outputs
+Frontend/node_modules/
+Frontend/dist/
+# Include if Docker builds create one
+frontend/node_modules/


### PR DESCRIPTION
## Summary
- ignore `Frontend/node_modules/` and `Frontend/dist/`
- ignore `frontend/node_modules/` if Docker builds make one

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for `sqlalchemy` and `pyotp`)*

------
https://chatgpt.com/codex/tasks/task_e_6844fcd8a138832e9bee58c86328529a