### PR TITLE
Add NotFound component and wildcard route

### DIFF
--- a/Frontend/src/app/app.routes.ts
+++ b/Frontend/src/app/app.routes.ts
@@ -14,6 +14,7 @@ import { NotificationOptionsComponent } from './features/notification-options/no
 import { GenerateBarcodeComponent } from './features/generate-barcode/generate-barcode.component';
 import { SetupTwofaComponent } from './features/auth/setup-twofa/setup-twofa.component';
 import { VerifyTwofaComponent } from './features/auth/verify-twofa/verify-twofa.component';
+import { NotFoundComponent } from './shared/components/not-found/not-found.component';
 
 // Assuming you might have other standalone components or lazy-loaded routes
 // import { HomeComponent } from './features/home/home.component';
@@ -44,4 +45,5 @@ export const routes: Routes = [
   { path: 'auth/reset-password', component: ResetPasswordComponent },
   { path: 'auth/setup-2fa', component: SetupTwofaComponent, canActivate: [AuthGuard] },
   { path: 'auth/verify-2fa', component: VerifyTwofaComponent, canActivate: [AuthGuard] },
+  { path: '**', component: NotFoundComponent },
 ];

--- a/Frontend/src/app/shared/components/not-found/not-found.component.html
+++ b/Frontend/src/app/shared/components/not-found/not-found.component.html
@@ -1,0 +1,5 @@
+<div class="not-found">
+  <h1>Page Not Found</h1>
+  <p>The page you're looking for doesn't exist.</p>
+  <a routerLink="/home">Return to Home</a>
+</div>

--- a/Frontend/src/app/shared/components/not-found/not-found.component.scss
+++ b/Frontend/src/app/shared/components/not-found/not-found.component.scss
@@ -1,0 +1,9 @@
+.not-found {
+  text-align: center;
+  margin-top: 3rem;
+}
+
+.not-found a {
+  color: #1976d2;
+  text-decoration: underline;
+}

--- a/Frontend/src/app/shared/components/not-found/not-found.component.ts
+++ b/Frontend/src/app/shared/components/not-found/not-found.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+
+@Component({
+  selector: 'app-not-found',
+  standalone: true,
+  imports: [CommonModule, RouterModule],
+  templateUrl: './not-found.component.html',
+  styleUrls: ['./not-found.component.scss']
+})
+export class NotFoundComponent {}


### PR DESCRIPTION
## Summary
- add a simple standalone NotFoundComponent
- show a friendly message with a link back to `/home`
- register the component in the main routes with the `**` wildcard

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for sqlalchemy and pyotp)*

------
https://chatgpt.com/codex/tasks/task_e_6844fcda55f8832ea9f197e6bb166ae6