### PR TITLE
Add colis deletion endpoint

### DIFF
--- a/backend/app/api/v1/endpoints/colis.py
+++ b/backend/app/api/v1/endpoints/colis.py
@@ -77,6 +77,23 @@ async def update_colis(
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
+@router.delete("/{colis_id}")
+async def delete_colis(
+    colis_id: str,
+    db: Session = Depends(get_db)
+):
+    """Delete a colis"""
+    colis_service = ColisService(db)
+    try:
+        deleted = await colis_service.delete_colis(colis_id)
+        if not deleted:
+            raise HTTPException(status_code=404, detail="Colis not found")
+        return {"success": True}
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
 @router.post("/search", response_model=ColisSearchResponse)
 async def search_colis(
     filters: ColisFilter,

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -108,7 +108,7 @@ def test_register_and_verify_email(db_session, patched_router):
 
 
 def test_verify_email_expired_token(db_session, patched_router):
-    user_data = UserCreate(email="expire@example.com", full_name="Expire", password="pw")
+    user_data = UserCreate(email="expire@example.com", full_name="Expire", password="Password1")
     user = asyncio.run(patched_router.register(user_data, db_session))
     # Expire the token
     user.verification_token_expires_at = datetime.utcnow() - timedelta(hours=1)
@@ -268,7 +268,7 @@ def test_last_login_timestamp_updated(db_session, patched_router):
 
 def test_resend_verification_generates_new_token(db_session, patched_router):
     user = asyncio.run(patched_router.register(
-        UserCreate(email="resend@example.com", full_name="Res", password="pw"),
+        UserCreate(email="resend@example.com", full_name="Res", password="Password1"),
         db_session
     ))
     old_token = user.verification_token
@@ -282,7 +282,7 @@ def test_resend_verification_generates_new_token(db_session, patched_router):
 
 def test_resend_verification_ignored_for_verified_user(db_session, patched_router):
     user = asyncio.run(patched_router.register(
-        UserCreate(email="checked@example.com", full_name="Chk", password="pw"),
+        UserCreate(email="checked@example.com", full_name="Chk", password="Password1"),
         db_session
     ))
     asyncio.run(patched_router.verify_email(

--- a/tests/test_colis.py
+++ b/tests/test_colis.py
@@ -1,0 +1,63 @@
+import os
+import sys
+import asyncio
+import pytest
+
+# Set required env vars before importing the app modules
+os.environ.setdefault('DATABASE_URL', 'sqlite:///:memory:')
+os.environ.setdefault('FEDEX_CLIENT_ID', 'dummy')
+os.environ.setdefault('FEDEX_CLIENT_SECRET', 'dummy')
+os.environ.setdefault('FEDEX_ACCOUNT_NUMBER', 'dummy')
+os.environ.setdefault('SECRET_KEY', 'testsecret')
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from backend.app.database import Base, engine, SessionLocal
+from backend.app.models.database import Base as ModelsBase
+from backend.app.models.colis import ColisCreate
+from backend.app.services.colis_service import ColisService
+from backend.app.api.v1.endpoints import colis as colis_router
+
+@pytest.fixture
+def db_session():
+    Base.metadata.drop_all(bind=engine)
+    ModelsBase.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    ModelsBase.metadata.create_all(bind=engine)
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def setup_colis(db, monkeypatch, colis_id="TESTDEL"):
+    def dummy_image(self, value):
+        path = os.path.join(self.barcode_folder, f"{value}.png")
+        with open(path, "w") as f:
+            f.write("img")
+        return path
+    monkeypatch.setattr(ColisService, "generate_codebar_image", dummy_image)
+    service = ColisService(db)
+    asyncio.run(service.create_colis(ColisCreate(id=colis_id, description="d")))
+    return service.get_colis_by_id, colis_id
+
+
+def test_delete_colis_success(db_session, monkeypatch):
+    get_colis, colis_id = setup_colis(db_session, monkeypatch)
+    service = ColisService(db_session)
+    colis = asyncio.run(get_colis(colis_id))
+    image_path = os.path.join(service.barcode_folder, f"{colis.code_barre}.png")
+    assert os.path.exists(image_path)
+
+    resp = asyncio.run(colis_router.delete_colis(colis_id, db_session))
+    assert resp["success"] is True
+    assert asyncio.run(service.get_colis_by_id(colis_id)) is None
+    assert not os.path.exists(image_path)
+
+
+def test_delete_colis_not_found(db_session):
+    with pytest.raises(colis_router.HTTPException) as exc:
+        asyncio.run(colis_router.delete_colis("UNKNOWN", db_session))
+    assert exc.value.status_code == 404
+

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -35,7 +35,7 @@ def db_session():
 
 
 def create_user_with_role(db, role: UserRole):
-    user = auth.create_user(db, UserCreate(email=f"{role}@example.com", full_name="U", password="pw"))
+    user = auth.create_user(db, UserCreate(email=f"{role}@example.com", full_name="U", password="Password1"))
     user.role = role
     db.commit()
     db.refresh(user)


### PR DESCRIPTION
## Summary
- support deleting Colis records in `ColisService`
- expose `DELETE /{colis_id}` endpoint
- test deleting colis and nonexistent IDs
- update existing tests to use a valid password

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684500ae3218832e9f10c2538601e632