### PR TITLE
Add NotFoundComponent and wildcard route

### DIFF
--- a/Frontend/src/app/app.routes.ts
+++ b/Frontend/src/app/app.routes.ts
@@ -15,6 +15,7 @@ import { GenerateBarcodeComponent } from './features/generate-barcode/generate-b
 import { SetupTwofaComponent } from './features/auth/setup-twofa/setup-twofa.component';
 import { VerifyTwofaComponent } from './features/auth/verify-twofa/verify-twofa.component';
 import { ResendVerificationComponent } from './features/auth/resend-verification/resend-verification.component';
+import { NotFoundComponent } from './shared/not-found.component';
 
 // Assuming you might have other standalone components or lazy-loaded routes
 // import { HomeComponent } from './features/home/home.component';
@@ -46,4 +47,5 @@ export const routes: Routes = [
   { path: 'auth/resend-verification', component: ResendVerificationComponent },
   { path: 'auth/setup-2fa', component: SetupTwofaComponent, canActivate: [AuthGuard] },
   { path: 'auth/verify-2fa', component: VerifyTwofaComponent, canActivate: [AuthGuard] },
+  { path: '**', component: NotFoundComponent }
 ];

--- a/Frontend/src/app/shared/not-found.component.html
+++ b/Frontend/src/app/shared/not-found.component.html
@@ -1,0 +1,5 @@
+<div class="not-found">
+  <h2>Page not found</h2>
+  <p>The page you are looking for does not exist.</p>
+  <a routerLink="/home">Return to Home</a>
+</div>

--- a/Frontend/src/app/shared/not-found.component.scss
+++ b/Frontend/src/app/shared/not-found.component.scss
@@ -1,0 +1,4 @@
+.not-found {
+  text-align: center;
+  margin-top: 2rem;
+}

--- a/Frontend/src/app/shared/not-found.component.ts
+++ b/Frontend/src/app/shared/not-found.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+
+@Component({
+  selector: 'app-not-found',
+  standalone: true,
+  imports: [CommonModule, RouterModule],
+  templateUrl: './not-found.component.html',
+  styleUrls: ['./not-found.component.scss']
+})
+export class NotFoundComponent {}


### PR DESCRIPTION
## Summary
- add a standalone NotFoundComponent under `shared`
- route unknown URLs to the NotFoundComponent

## Testing
- `npx ng test --watch=false` *(fails: Error: Found 1 load error)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684500aa1868832eb09bd7102032ecb5