### PR TITLE
Centralize logging setup

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+import logging
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 from dotenv import load_dotenv
@@ -11,6 +12,9 @@ from .api.v1.api import api_router
 
 # Chargement des variables d'environnement
 load_dotenv()
+
+# Configure global logging
+logging.basicConfig(level=logging.INFO)
 
 app = FastAPI(
     title=settings.PROJECT_NAME,

--- a/backend/app/services/colis_service.py
+++ b/backend/app/services/colis_service.py
@@ -11,8 +11,6 @@ from ..models.colis import ColisCreate, ColisUpdate, ColisFilter
 from ..models.database import ColisDB
 from sqlalchemy.sql import func
 
-# Configure logging
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 class ColisService:

--- a/backend/app/services/fedex_service.py
+++ b/backend/app/services/fedex_service.py
@@ -12,8 +12,6 @@ from ..models.tracking import (
     KeyDates, CommercialInfo, ServiceType
 )
 
-# Configure logging
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 class FedExService:

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -15,8 +15,6 @@ from ..models.notification import (
 from ..models.database import NotificationDB
 from ..models.notification_preference import NotificationPreferenceDB
 
-# Configure logging
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 class NotificationService:

--- a/backend/app/services/tracking_service.py
+++ b/backend/app/services/tracking_service.py
@@ -9,8 +9,6 @@ from sqlalchemy.orm import Session
 from sqlalchemy import asc, desc, and_
 from ..models.database import TrackingDB, TrackingEventDB
 
-# Configure logging
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 class TrackingService:


### PR DESCRIPTION
## Summary
- configure global logging in `main.py`
- remove redundant `logging.basicConfig` calls from services

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845054b0d10832e86c91b04a7e9b2c4