### PR TITLE
Fix barcode URL lifetime

### DIFF
--- a/Frontend/src/app/features/home/home.component.ts
+++ b/Frontend/src/app/features/home/home.component.ts
@@ -513,7 +513,12 @@ export class HomeComponent implements OnInit, OnDestroy {
           link.href = url;
           link.download = `${trackingId}.png`;
           link.click();
-          window.URL.revokeObjectURL(url);
+
+          // Delay revoking the object URL to ensure the image loads
+          // and the download has completed before releasing the blob
+          setTimeout(() => {
+            window.URL.revokeObjectURL(url);
+          }, 1000);
 
           this.addNotification(
             'success',


### PR DESCRIPTION
## Summary
- delay revocation of barcode URL until after preview and download

## Testing
- `pip install -r backend/requirements.txt`
- `npm install` *(fails: ENOENT: no such file or directory 'package.json')*
- `python backend/app/init_db.py` *(fails: attempted relative import with no known parent package)*
- `python -m backend.app.init_db` *(fails: `SECRET_KEY` must be set)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684509381a58832e92afd19c613a2675