### PR TITLE
Add all tracking services view

### DIFF
--- a/Frontend/src/app/app.routes.ts
+++ b/Frontend/src/app/app.routes.ts
@@ -12,6 +12,7 @@ import { NotificationsComponent } from './features/notifications/notifications.c
 import { TrackByMailComponent } from './features/track-by-mail/track-by-mail.component';
 import { NotificationOptionsComponent } from './features/notification-options/notification-options.component';
 import { GenerateBarcodeComponent } from './features/generate-barcode/generate-barcode.component';
+import { AllTrackingServicesComponent } from './features/all-tracking-services/all-tracking-services.component';
 import { SetupTwofaComponent } from './features/auth/setup-twofa/setup-twofa.component';
 import { VerifyTwofaComponent } from './features/auth/verify-twofa/verify-twofa.component';
 import { ResendVerificationComponent } from './features/auth/resend-verification/resend-verification.component';
@@ -40,6 +41,7 @@ export const routes: Routes = [
   { path: 'services/track-by-mail', component: TrackByMailComponent, canActivate: [AuthGuard] },
   { path: 'services/notifications', component: NotificationOptionsComponent, canActivate: [AuthGuard] },
   { path: 'services/generate-barcode', component: GenerateBarcodeComponent, canActivate: [AuthGuard] },
+  { path: 'services/all-tracking', component: AllTrackingServicesComponent, canActivate: [AuthGuard] },
   { path: 'auth/login', component: LoginComponent },
   { path: 'verify-email', component: VerifyEmailComponent },
   { path: 'auth/callback', component: GoogleCallbackComponent },

--- a/Frontend/src/app/features/all-tracking-services/all-tracking-services.component.html
+++ b/Frontend/src/app/features/all-tracking-services/all-tracking-services.component.html
@@ -1,0 +1,32 @@
+<div class="ats">
+  <h1>All Tracking Services</h1>
+  <div class="tabs">
+    <button class="tab" [class.active]="activeTab==='single'" (click)="switchTab('single')">Single</button>
+    <button class="tab" [class.active]="activeTab==='bulk'" (click)="switchTab('bulk')">Bulk</button>
+    <button class="tab" [class.active]="activeTab==='barcode'" (click)="switchTab('barcode')">Barcode</button>
+  </div>
+
+  <div class="tab-content">
+    <form *ngIf="activeTab==='single'" [formGroup]="singleForm" (ngSubmit)="submitSingle()" class="single-form">
+      <label>Tracking Number
+        <input formControlName="trackingNumber" />
+      </label>
+      <div class="error" *ngIf="singleForm.get('trackingNumber')?.touched && singleForm.get('trackingNumber')?.invalid">
+        Invalid tracking number
+      </div>
+      <button type="submit">Track</button>
+    </form>
+
+    <form *ngIf="activeTab==='bulk'" [formGroup]="bulkForm" (ngSubmit)="submitBulk()" class="bulk-form">
+      <label>Tracking Numbers
+        <textarea formControlName="trackingNumbers" rows="5" placeholder="One ID per line"></textarea>
+      </label>
+      <button type="submit">Track All</button>
+    </form>
+
+    <div *ngIf="activeTab==='barcode'" class="barcode-form">
+      <p>Scan your barcode using the camera.</p>
+      <button type="button" (click)="startBarcodeScan()">Start Scan</button>
+    </div>
+  </div>
+</div>

--- a/Frontend/src/app/features/all-tracking-services/all-tracking-services.component.scss
+++ b/Frontend/src/app/features/all-tracking-services/all-tracking-services.component.scss
@@ -1,0 +1,41 @@
+.ats {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+.tabs {
+  display: flex;
+  margin-bottom: 20px;
+}
+
+.tab {
+  flex: 1;
+  padding: 10px;
+  border: 1px solid #ccc;
+  background: #f5f5f5;
+  cursor: pointer;
+  text-align: center;
+}
+
+.tab.active {
+  background: #4d148c;
+  color: #fff;
+}
+
+.tab + .tab {
+  margin-left: 5px;
+}
+
+.single-form,
+.bulk-form,
+.barcode-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.error {
+  color: #d9534f;
+  font-size: 12px;
+}

--- a/Frontend/src/app/features/all-tracking-services/all-tracking-services.component.ts
+++ b/Frontend/src/app/features/all-tracking-services/all-tracking-services.component.ts
@@ -1,0 +1,57 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
+
+@Component({
+  selector: 'app-all-tracking-services',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './all-tracking-services.component.html',
+  styleUrls: ['./all-tracking-services.component.scss']
+})
+export class AllTrackingServicesComponent {
+  activeTab: 'single' | 'bulk' | 'barcode' = 'single';
+
+  singleForm: FormGroup;
+  bulkForm: FormGroup;
+
+  constructor(private fb: FormBuilder) {
+    this.singleForm = this.fb.group({
+      trackingNumber: ['', [Validators.required, Validators.pattern('^[A-Z0-9]{10,}$')]]
+    });
+    this.bulkForm = this.fb.group({
+      trackingNumbers: ['', Validators.required]
+    });
+  }
+
+  switchTab(tab: 'single' | 'bulk' | 'barcode'): void {
+    this.activeTab = tab;
+  }
+
+  submitSingle(): void {
+    if (this.singleForm.invalid) {
+      this.singleForm.markAllAsTouched();
+      return;
+    }
+    // Placeholder for single tracking logic
+    console.log('Track single', this.singleForm.value.trackingNumber);
+  }
+
+  submitBulk(): void {
+    if (this.bulkForm.invalid) {
+      this.bulkForm.markAllAsTouched();
+      return;
+    }
+    const numbers = this.bulkForm.value.trackingNumbers
+      .split(/\r?\n/)
+      .map((n: string) => n.trim())
+      .filter((n: string) => n);
+    console.log('Track bulk', numbers);
+    // Placeholder for bulk tracking logic
+  }
+
+  startBarcodeScan(): void {
+    // Placeholder for barcode scanning implementation
+    console.log('Barcode scan feature coming soon');
+  }
+}

--- a/Frontend/src/app/shared/components/navbar/navbar.component.html
+++ b/Frontend/src/app/shared/components/navbar/navbar.component.html
@@ -14,7 +14,7 @@
           <hr />
           <a routerLink="/advanced-shipment-tracking">Advanced Shipment Tracking</a>
           <a routerLink="/mobile-tracking">Track by Mobile</a>
-          <a routerLink="/all-tracking"><strong>All Tracking Services</strong></a>
+          <a routerLink="/services/all-tracking"><strong>All Tracking Services</strong></a>
         </div>
       </li>
 


### PR DESCRIPTION
## Summary
- add an `AllTrackingServicesComponent` with tabbed UI
- route `/services/all-tracking` points to the new component
- link to the new route from the navbar dropdown

## Testing
- `npm test` *(fails: ng not found)*
- `pytest -q` *(fails: ModuleNotFoundError: sqlalchemy, pyotp)*

------
https://chatgpt.com/codex/tasks/task_e_68451ddee630832ebf1368a4918bf771