### PR TITLE
Remove duplicate frontend folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,3 @@ backend/venv/
 # Ignore frontend dependencies and build outputs
 Frontend/node_modules/
 Frontend/dist/
-# Include if Docker builds create one
-frontend/node_modules/

--- a/Frontend/Dockerfile
+++ b/Frontend/Dockerfile
@@ -1,9 +1,9 @@
 # Build Angular app
 FROM node:20 AS build
 WORKDIR /app
-COPY Frontend/package*.json ./
+COPY package*.json ./
 RUN npm ci
-COPY Frontend/ ./
+COPY . ./
 RUN npm run build -- --configuration production
 
 # Serve with nginx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,8 @@ services:
       - redis
   frontend:
     build:
-      context: .
-      dockerfile: frontend/Dockerfile
+      context: ./Frontend
+      dockerfile: Dockerfile
     ports:
       - "4200:80"
     depends_on:

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,5 +1,0 @@
-# Frontend Docker Image
-
-This directory contains the Dockerfile used to build and serve the Angular application for production.
-
-The image builds the Angular code from the `Frontend` directory, then serves the compiled files with Nginx. It is referenced by `docker-compose.yml` to run the production frontend.


### PR DESCRIPTION
## Summary
- move frontend Dockerfile into Frontend
- drop the redundant `frontend` directory
- adjust `.gitignore`
- update docker-compose to use `Frontend/Dockerfile`

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68451de13268832e89d6c99e240908c3