### PR TITLE
Add advanced tracking dashboard

### DIFF
--- a/Frontend/src/app/app.routes.spec.ts
+++ b/Frontend/src/app/app.routes.spec.ts
@@ -1,0 +1,10 @@
+import { routes } from './app.routes';
+import { AuthGuard } from './core/guards/auth.guard';
+
+describe('App Routes', () => {
+  it('should include advanced shipment tracking route protected by AuthGuard', () => {
+    const route = routes.find(r => r.path === 'advanced-shipment-tracking');
+    expect(route).toBeTruthy();
+    expect(route?.canActivate).toContain(AuthGuard);
+  });
+});

--- a/Frontend/src/app/app.routes.ts
+++ b/Frontend/src/app/app.routes.ts
@@ -12,6 +12,7 @@ import { NotificationsComponent } from './features/notifications/notifications.c
 import { TrackByMailComponent } from './features/track-by-mail/track-by-mail.component';
 import { NotificationOptionsComponent } from './features/notification-options/notification-options.component';
 import { GenerateBarcodeComponent } from './features/generate-barcode/generate-barcode.component';
+import { AdvancedTrackingComponent } from './features/advanced-tracking/advanced-tracking.component';
 import { SetupTwofaComponent } from './features/auth/setup-twofa/setup-twofa.component';
 import { VerifyTwofaComponent } from './features/auth/verify-twofa/verify-twofa.component';
 import { ResendVerificationComponent } from './features/auth/resend-verification/resend-verification.component';
@@ -35,6 +36,7 @@ export const routes: Routes = [
 
   // Add other routes here, including for other standalone components
   { path: 'track/:identifier', component: TrackResultComponent, canActivate: [AuthGuard] },
+  { path: 'advanced-shipment-tracking', component: AdvancedTrackingComponent, canActivate: [AuthGuard] },
   { path: 'notifications', component: NotificationsComponent, canActivate: [AuthGuard] },
   // Service routes
   { path: 'services/track-by-mail', component: TrackByMailComponent, canActivate: [AuthGuard] },

--- a/Frontend/src/app/features/advanced-tracking/advanced-tracking.component.html
+++ b/Frontend/src/app/features/advanced-tracking/advanced-tracking.component.html
@@ -1,0 +1,35 @@
+<div class="advanced-tracking">
+  <h1>Advanced Shipment Tracking</h1>
+
+  <section class="stats" *ngIf="stats">
+    <div class="stat-card">
+      <h3>Total</h3>
+      <p>{{ stats.total_trackings }}</p>
+    </div>
+    <div class="stat-card">
+      <h3>Delivered</h3>
+      <p>{{ stats.delivered_trackings }}</p>
+    </div>
+    <div class="stat-card">
+      <h3>In Transit</h3>
+      <p>{{ stats.in_transit_trackings }}</p>
+    </div>
+    <div class="stat-card">
+      <h3>Exceptions</h3>
+      <p>{{ stats.exception_trackings }}</p>
+    </div>
+  </section>
+
+  <section class="search">
+    <input [(ngModel)]="query" placeholder="Tracking number" />
+    <button (click)="search()" [disabled]="loadingResults">Search</button>
+  </section>
+
+  <section class="results" *ngIf="results.length">
+    <div *ngFor="let item of results" class="result-item">
+      <span class="tracking-number">{{ item.tracking_number }}</span>
+      <span class="status">{{ item.status }}</span>
+      <span class="carrier">{{ item.carrier }}</span>
+    </div>
+  </section>
+</div>

--- a/Frontend/src/app/features/advanced-tracking/advanced-tracking.component.scss
+++ b/Frontend/src/app/features/advanced-tracking/advanced-tracking.component.scss
@@ -1,0 +1,39 @@
+.advanced-tracking {
+  padding: 2rem;
+
+  h1 {
+    margin-bottom: 1.5rem;
+  }
+
+  .stats {
+    display: flex;
+    gap: 1rem;
+    margin-bottom: 2rem;
+
+    .stat-card {
+      background: #f5f5f5;
+      padding: 1rem;
+      border-radius: 4px;
+      flex: 1;
+      text-align: center;
+    }
+  }
+
+  .search {
+    margin-bottom: 1rem;
+
+    input {
+      padding: 0.5rem;
+      margin-right: 0.5rem;
+    }
+  }
+
+  .results {
+    .result-item {
+      padding: 0.5rem 0;
+      border-bottom: 1px solid #eee;
+      display: flex;
+      gap: 1rem;
+    }
+  }
+}

--- a/Frontend/src/app/features/advanced-tracking/advanced-tracking.component.ts
+++ b/Frontend/src/app/features/advanced-tracking/advanced-tracking.component.ts
@@ -1,0 +1,55 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { HttpClient } from '@angular/common/http';
+import { environment } from '../../../environments/environment';
+
+@Component({
+  selector: 'app-advanced-tracking',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './advanced-tracking.component.html',
+  styleUrls: ['./advanced-tracking.component.scss']
+})
+export class AdvancedTrackingComponent implements OnInit {
+  stats: any;
+  query = '';
+  results: any[] = [];
+  loadingStats = false;
+  loadingResults = false;
+
+  constructor(private http: HttpClient) {}
+
+  ngOnInit() {
+    this.fetchStats();
+  }
+
+  fetchStats() {
+    this.loadingStats = true;
+    this.http.get<any>(`${environment.apiUrl}/tracking/stats`).subscribe({
+      next: (resp) => {
+        this.stats = resp.data;
+        this.loadingStats = false;
+      },
+      error: () => {
+        this.loadingStats = false;
+      }
+    });
+  }
+
+  search() {
+    if (!this.query) {
+      return;
+    }
+    this.loadingResults = true;
+    this.http.post<any>(`${environment.apiUrl}/tracking/search`, { tracking_number: this.query }).subscribe({
+      next: (resp) => {
+        this.results = resp.data || [];
+        this.loadingResults = false;
+      },
+      error: () => {
+        this.loadingResults = false;
+      }
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- create AdvancedTrackingComponent files
- add route for `advanced-shipment-tracking`
- integrate stats & search requests in component
- test route is protected by `AuthGuard`

## Testing
- `npx -p @angular/cli --prefix Frontend ng test --watch=false` *(fails: could not determine executable to run)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68451e452600832e94acb47535d3f97d