### PR TITLE
Add advanced tracking methods

### DIFF
--- a/Frontend/src/app/features/all-tracking-services/all-tracking-services.component.html
+++ b/Frontend/src/app/features/all-tracking-services/all-tracking-services.component.html
@@ -11,6 +11,9 @@
       <label>Tracking Number
         <input formControlName="trackingNumber" />
       </label>
+      <label>Package Name
+        <input formControlName="packageName" />
+      </label>
       <div class="error" *ngIf="singleForm.get('trackingNumber')?.touched && singleForm.get('trackingNumber')?.invalid">
         Invalid tracking number
       </div>

--- a/Frontend/src/app/features/all-tracking-services/all-tracking-services.component.ts
+++ b/Frontend/src/app/features/all-tracking-services/all-tracking-services.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { TrackingService } from '../tracking/services/tracking.service';
 
 @Component({
   selector: 'app-all-tracking-services',
@@ -15,9 +16,10 @@ export class AllTrackingServicesComponent {
   singleForm: FormGroup;
   bulkForm: FormGroup;
 
-  constructor(private fb: FormBuilder) {
+  constructor(private fb: FormBuilder, private trackingService: TrackingService) {
     this.singleForm = this.fb.group({
-      trackingNumber: ['', [Validators.required, Validators.pattern('^[A-Z0-9]{10,}$')]]
+      trackingNumber: ['', [Validators.required, Validators.pattern('^[A-Z0-9]{10,}$')]],
+      packageName: ['']
     });
     this.bulkForm = this.fb.group({
       trackingNumbers: ['', Validators.required]
@@ -33,8 +35,8 @@ export class AllTrackingServicesComponent {
       this.singleForm.markAllAsTouched();
       return;
     }
-    // Placeholder for single tracking logic
-    console.log('Track single', this.singleForm.value.trackingNumber);
+    const { trackingNumber, packageName } = this.singleForm.value;
+    this.trackingService.trackNumber(trackingNumber, packageName).subscribe();
   }
 
   submitBulk(): void {

--- a/Frontend/src/app/features/home/home.component.html
+++ b/Frontend/src/app/features/home/home.component.html
@@ -32,6 +32,7 @@
         <form [formGroup]="trackingForm" (ngSubmit)="onSubmit()">
           <div class="tracking-form__input-group">
             <input type="text" formControlName="trackingNumber" class="tracking-form__input" placeholder="Enter your tracking number">
+            <input type="text" formControlName="packageName" class="tracking-form__input" placeholder="Package name (optional)">
             <button type="submit" class="tracking-form__btn">
               <i class="fas fa-search"></i>
               Track

--- a/Frontend/src/app/features/home/home.component.ts
+++ b/Frontend/src/app/features/home/home.component.ts
@@ -132,7 +132,8 @@ export class HomeComponent implements OnInit, OnDestroy {
     private notificationService: NotificationService
   ) {
     this.trackingForm = this.fb.group({
-      trackingNumber: ['', [Validators.required, Validators.pattern('^[A-Z0-9]{10,}$')]]
+      trackingNumber: ['', [Validators.required, Validators.pattern('^[A-Z0-9]{10,}$')]],
+      packageName: ['']
     });
     
     this.barcodeForm = this.fb.group({
@@ -347,6 +348,7 @@ export class HomeComponent implements OnInit, OnDestroy {
     }
 
     const identifier = this.trackingForm.get('trackingNumber')?.value.trim();
+    const name = this.trackingForm.get('packageName')?.value;
     if (!identifier) {
       return;
     }
@@ -357,7 +359,7 @@ export class HomeComponent implements OnInit, OnDestroy {
       `Recherche du colis #${identifier}...`
     );
 
-    this.trackingService.trackPackage(identifier).subscribe({
+    this.trackingService.trackNumber(identifier, name).subscribe({
       next: (response) => {
         if (response.success && response.data) {
           this.router.navigate(['/track', identifier]);

--- a/Frontend/src/app/features/track-by-mail/track-by-mail.component.html
+++ b/Frontend/src/app/features/track-by-mail/track-by-mail.component.html
@@ -2,6 +2,9 @@
   <label>Tracking Number
     <input formControlName="trackingNumber" />
   </label>
+  <label>Package Name
+    <input formControlName="packageName" />
+  </label>
   <label>Email
     <input formControlName="email" type="email" />
   </label>

--- a/Frontend/src/app/features/track-by-mail/track-by-mail.component.ts
+++ b/Frontend/src/app/features/track-by-mail/track-by-mail.component.ts
@@ -17,7 +17,8 @@ export class TrackByMailComponent {
   constructor(private fb: FormBuilder, private trackingService: TrackingService) {
     this.form = this.fb.group({
       trackingNumber: ['', Validators.required],
-      email: ['', [Validators.required, Validators.email]]
+      email: ['', [Validators.required, Validators.email]],
+      packageName: ['']
     });
   }
 
@@ -25,9 +26,11 @@ export class TrackByMailComponent {
     if (this.form.invalid) {
       return;
     }
-    const { trackingNumber, email } = this.form.value;
-    this.trackingService.trackByEmail(trackingNumber, email).subscribe(res => {
-      this.result = res;
+    const { trackingNumber, email, packageName } = this.form.value;
+    this.trackingService.trackNumber(trackingNumber, packageName).subscribe(() => {
+      this.trackingService.trackByEmail(trackingNumber, email).subscribe(res => {
+        this.result = res;
+      });
     });
   }
 }

--- a/Frontend/src/app/features/tracking/services/tracking.service.ts
+++ b/Frontend/src/app/features/tracking/services/tracking.service.ts
@@ -23,6 +23,31 @@ export class TrackingService {
     return this.http.get<TrackingResponse>(`${this.baseUrl}/${identifier}`);
   }
 
+  trackNumber(trackingNumber: string, packageName?: string): Observable<TrackingResponse> {
+    return this.http.post<TrackingResponse>(`${this.baseUrl}/create`, {
+      id: trackingNumber,
+      description: packageName
+    });
+  }
+
+  trackReference(reference: string): Observable<TrackingResponse> {
+    return this.trackPackage(reference);
+  }
+
+  trackTcn(tcn: string): Observable<TrackingResponse> {
+    return this.trackPackage(tcn);
+  }
+
+  decodeBarcode(file: File): Observable<{ value: string }> {
+    const formData = new FormData();
+    formData.append('file', file);
+    return this.http.post<{ value: string }>(`${this.baseUrl}/decode-barcode`, formData);
+  }
+
+  downloadExport(): Observable<Blob> {
+    return this.http.get(`${this.baseUrl}/export`, { responseType: 'blob' });
+  }
+
   downloadProof(trackingNumber: string): Observable<Blob> {
     const url = `${this.baseUrl}/${trackingNumber}/proof`;
     return this.http.get(url, { responseType: 'blob' });


### PR DESCRIPTION
## Summary
- extend tracking service with helpers
- support package name in tracking forms
- call new tracking methods

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845806e6018832e99d769485bf2c92e