### PR TITLE
Add FedEx-like tracking timeline with animation

### DIFF
--- a/Frontend/src/app/features/tracking/track-result/track-result.component.html
+++ b/Frontend/src/app/features/tracking/track-result/track-result.component.html
@@ -96,16 +96,24 @@
 
     <div *ngIf="trackingInfo.tracking_history?.length">
       <h3 class="font-bold mb-2">Historique</h3>
-      <ul class="space-y-4">
-        <li *ngFor="let event of trackingInfo.tracking_history" class="border-l-2 pl-4">
-          <div class="font-medium">{{ event.status }}</div>
-          <div class="text-sm text-gray-600">{{ event.timestamp | date:'medium' }}</div>
-          <div class="text-sm" *ngIf="event.description">{{ event.description }}</div>
-          <div class="text-sm text-gray-500" *ngIf="event.location">
-            {{ event.location.city }} {{ event.location.state }} {{ event.location.country }}
+      <div class="timeline">
+        <div *ngFor="let event of trackingInfo.tracking_history; let i = index"
+             class="timeline-item"
+             [class.current]="i === trackingInfo.tracking_history.length - 1"
+             @timelineAnimation>
+          <div class="timeline-icon">
+            <span class="material-icons">local_shipping</span>
           </div>
-        </li>
-      </ul>
+          <div class="timeline-content">
+            <div class="status">{{ event.status }}</div>
+            <div class="time text-sm text-gray-600">{{ event.timestamp | date:'medium' }}</div>
+            <div class="text-sm" *ngIf="event.description">{{ event.description }}</div>
+            <div class="text-sm text-gray-500" *ngIf="event.location">
+              {{ event.location.city }} {{ event.location.state }} {{ event.location.country }}
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/Frontend/src/app/features/tracking/track-result/track-result.component.scss
+++ b/Frontend/src/app/features/tracking/track-result/track-result.component.scss
@@ -176,3 +176,40 @@
   border-radius: 4px;
   cursor: pointer;
 }
+
+/* Timeline styling */
+.timeline {
+  position: relative;
+  margin-top: 1rem;
+  padding-left: 2rem;
+  border-left: 2px solid #4d148c;
+}
+
+.timeline-item {
+  position: relative;
+  margin-bottom: 1.5rem;
+  padding-left: 1.5rem;
+}
+
+.timeline-icon {
+  position: absolute;
+  left: -1.1rem;
+  top: 0;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 50%;
+  background: #ff6600;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+}
+
+.timeline-item.current .timeline-icon {
+  background: #4d148c;
+}
+
+.timeline-item.current .status {
+  font-weight: 700;
+}

--- a/Frontend/src/app/features/tracking/track-result/track-result.component.ts
+++ b/Frontend/src/app/features/tracking/track-result/track-result.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
+import { trigger, transition, style, animate, query, stagger } from '@angular/animations';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute } from '@angular/router';
 import { TrackingService, TrackingInfo } from '../services/tracking.service';
@@ -15,7 +16,18 @@ declare global {
   standalone: true,
   imports: [CommonModule],
   templateUrl: './track-result.component.html',
-  styleUrls: ['./track-result.component.scss']
+  styleUrls: ['./track-result.component.scss'],
+  animations: [
+    trigger('timelineAnimation', [
+      transition(':enter', [
+        style({ opacity: 0, transform: 'translateX(-10px)' }),
+        animate('300ms ease-out', style({ opacity: 1, transform: 'translateX(0)' }))
+      ]),
+      transition(':leave', [
+        animate('200ms', style({ opacity: 0 }))
+      ])
+    ])
+  ]
 })
 export class TrackResultComponent implements OnInit, OnDestroy {
   trackingInfo: TrackingInfo | null = null;


### PR DESCRIPTION
## Summary
- animate `TrackResultComponent` timeline
- display `tracking_history` as a styled FedEx-like timeline
- style the timeline with purple/orange colors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845806fe15c832eacd8f33a9c8c853b