### PR TITLE
Add barcode upload component

### DIFF
--- a/Frontend/src/app/features/barcode-upload/barcode-upload.component.html
+++ b/Frontend/src/app/features/barcode-upload/barcode-upload.component.html
@@ -1,0 +1,4 @@
+<div class="upload-wrapper" (dragover)="onDragOver($event)" (drop)="onDrop($event)">
+  <p>Déposez une image ou choisissez un fichier :</p>
+  <input type="file" accept="image/*" (change)="onFileSelected($event)" />
+</div>

--- a/Frontend/src/app/features/barcode-upload/barcode-upload.component.scss
+++ b/Frontend/src/app/features/barcode-upload/barcode-upload.component.scss
@@ -1,0 +1,6 @@
+.upload-wrapper {
+  border: 2px dashed #ccc;
+  padding: 1rem;
+  text-align: center;
+  cursor: pointer;
+}

--- a/Frontend/src/app/features/barcode-upload/barcode-upload.component.ts
+++ b/Frontend/src/app/features/barcode-upload/barcode-upload.component.ts
@@ -1,0 +1,46 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { AbstractControl } from '@angular/forms';
+import { TrackingService } from '../tracking/services/tracking.service';
+
+@Component({
+  selector: 'app-barcode-upload',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './barcode-upload.component.html',
+  styleUrls: ['./barcode-upload.component.scss']
+})
+export class BarcodeUploadComponent {
+  @Input() control: AbstractControl | null = null;
+
+  constructor(private trackingService: TrackingService) {}
+
+  onFileSelected(event: any): void {
+    const file: File = event.target.files?.[0];
+    if (file) {
+      this.decode(file);
+    }
+  }
+
+  onDrop(event: DragEvent): void {
+    event.preventDefault();
+    const file = event.dataTransfer?.files?.[0];
+    if (file) {
+      this.decode(file);
+    }
+  }
+
+  onDragOver(event: DragEvent): void {
+    event.preventDefault();
+  }
+
+  private decode(file: File) {
+    this.trackingService.decodeBarcode(file)
+      .then(code => {
+        if (this.control) {
+          this.control.setValue(code);
+        }
+      })
+      .catch(err => console.error('Barcode decode failed', err));
+  }
+}

--- a/Frontend/src/app/features/tracking/services/tracking.service.ts
+++ b/Frontend/src/app/features/tracking/services/tracking.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { BrowserMultiFormatReader } from '@zxing/browser';
 import { environment } from '../../../../environments/environment';
 import { TrackingInfo } from '../models/tracking';
 
@@ -35,6 +36,23 @@ export class TrackingService {
 
   trackByEmail(tracking_number: string, email: string): Observable<TrackingResponse> {
     return this.http.post<TrackingResponse>(`${this.baseUrl}/email`, { tracking_number, email });
+  }
+
+  decodeBarcode(file: File): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = async () => {
+        try {
+          const decoder = new BrowserMultiFormatReader();
+          const result = await decoder.decodeFromImageUrl(reader.result as string);
+          resolve(result.getText());
+        } catch (err) {
+          reject(err);
+        }
+      };
+      reader.onerror = err => reject(err);
+      reader.readAsDataURL(file);
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
- add reusable `BarcodeUploadComponent` for decoding barcode files
- decode image files in `TrackingService`

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_684580715390832e819e7c8eaa0ea656