### PR TITLE
Improve FedEx-style theming

### DIFF
--- a/Frontend/src/app/features/all-tracking-services/all-tracking-services.component.scss
+++ b/Frontend/src/app/features/all-tracking-services/all-tracking-services.component.scss
@@ -27,6 +27,25 @@
   margin-left: 5px;
 }
 
+@media (max-width: 600px) {
+  .tabs {
+    flex-direction: column;
+  }
+
+  .tab + .tab {
+    margin-left: 0;
+    margin-top: 5px;
+  }
+}
+
+@media (max-width: 480px) {
+  input,
+  textarea,
+  button {
+    width: 100%;
+  }
+}
+
 .single-form,
 .bulk-form,
 .barcode-form {

--- a/Frontend/src/app/features/home/home.component.scss
+++ b/Frontend/src/app/features/home/home.component.scss
@@ -358,9 +358,9 @@ $error-color: #dc3545;
   background: $light-gray;
 
   &__list {
-    display: flex;
-    flex-direction: column;
-    gap: 40px; // Espace entre les éléments de service
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 2rem;
   }
 
   &__display {
@@ -387,24 +387,17 @@ $error-color: #dc3545;
 
 .service-item {
   display: flex;
-  align-items: center;
-  gap: 40px;
+  flex-direction: column;
   background: white;
   border-radius: 10px;
   overflow: hidden;
   @include card-shadow();
-  max-width: 1200px; // Augmenter la largeur max
+  max-width: 1200px;
   width: 100%;
-  margin: 0 auto; // Centrer l'élément
-
-  &:nth-child(even) { // Inverser l'ordre pour les éléments pairs
-    flex-direction: row-reverse;
-  }
+  margin: 0 auto;
 
   &__image {
-    flex: 1;
-    min-width: 300px;
-    max-width: 50%; // Limiter la largeur de l'image
+    width: 100%;
     img {
       width: 100%;
       height: auto;
@@ -413,7 +406,6 @@ $error-color: #dc3545;
   }
 
   &__content {
-    flex: 1;
     padding: 2rem;
     display: flex;
     flex-direction: column;
@@ -459,7 +451,7 @@ $error-color: #dc3545;
 
   &__grid {
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
     gap: 2rem;
   }
 }
@@ -537,7 +529,7 @@ $error-color: #dc3545;
 
 .locations-container {
   display: grid;
-  grid-template-columns: 1fr 400px;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   gap: 2rem;
   background: white;
   border-radius: 10px;

--- a/Frontend/src/styles.scss
+++ b/Frontend/src/styles.scss
@@ -42,3 +42,40 @@ html, body {
 ::-webkit-scrollbar-thumb:hover {
   background: #555;
 }
+
+/* Global Theme */
+$primary-color: #4d148c;
+$secondary-color: #ff6600;
+
+.navbar {
+  background-color: $primary-color;
+  color: #fff;
+  font-family: Roboto, "Helvetica Neue", sans-serif;
+}
+
+.btn {
+  font-family: Roboto, "Helvetica Neue", sans-serif;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  border: none;
+  cursor: pointer;
+
+  &--primary {
+    background: $secondary-color;
+    color: #fff;
+  }
+
+  &--secondary {
+    background: transparent;
+    border: 2px solid $secondary-color;
+    color: $secondary-color;
+  }
+}
+
+.card {
+  background: #fff;
+  border-radius: 6px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  padding: 1rem;
+  font-family: Roboto, "Helvetica Neue", sans-serif;
+}


### PR DESCRIPTION
## Summary
- tweak global styles for FedEx palette and Roboto
- unify service/news/location grids
- make tracking service tabs mobile-friendly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684580754e50832e87948ff6a7afd938