### PR TITLE
Add tracking history feature

### DIFF
--- a/Frontend/src/app/app.routes.ts
+++ b/Frontend/src/app/app.routes.ts
@@ -13,6 +13,7 @@ import { TrackByMailComponent } from './features/track-by-mail/track-by-mail.com
 import { NotificationOptionsComponent } from './features/notification-options/notification-options.component';
 import { GenerateBarcodeComponent } from './features/generate-barcode/generate-barcode.component';
 import { AllTrackingServicesComponent } from './features/all-tracking-services/all-tracking-services.component';
+import { TrackingHistoryComponent } from './features/tracking-history/tracking-history.component';
 import { SetupTwofaComponent } from './features/auth/setup-twofa/setup-twofa.component';
 import { VerifyTwofaComponent } from './features/auth/verify-twofa/verify-twofa.component';
 import { ResendVerificationComponent } from './features/auth/resend-verification/resend-verification.component';
@@ -36,6 +37,7 @@ export const routes: Routes = [
 
   // Add other routes here, including for other standalone components
   { path: 'track/:identifier', component: TrackResultComponent, canActivate: [AuthGuard] },
+  { path: 'history', component: TrackingHistoryComponent, canActivate: [AuthGuard] },
   { path: 'notifications', component: NotificationsComponent, canActivate: [AuthGuard] },
   // Service routes
   { path: 'services/track-by-mail', component: TrackByMailComponent, canActivate: [AuthGuard] },

--- a/Frontend/src/app/features/tracking-history/tracking-history.component.html
+++ b/Frontend/src/app/features/tracking-history/tracking-history.component.html
@@ -1,0 +1,9 @@
+<h2>Historique des recherches</h2>
+<ul class="history-list">
+  <li *ngFor="let item of history">
+    <a (click)="view(item.identifier)">{{ item.identifier }}</a>
+    <span class="date">{{ item.date | date:'short' }}</span>
+    <button (click)="remove(item.identifier)">Supprimer</button>
+  </li>
+</ul>
+<button *ngIf="history.length" (click)="clear()">Tout supprimer</button>

--- a/Frontend/src/app/features/tracking-history/tracking-history.component.scss
+++ b/Frontend/src/app/features/tracking-history/tracking-history.component.scss
@@ -1,0 +1,21 @@
+.history-list {
+  list-style: none;
+  padding: 0;
+}
+
+.history-list li {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.history-list a {
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.date {
+  flex: 1;
+  color: gray;
+}

--- a/Frontend/src/app/features/tracking-history/tracking-history.component.ts
+++ b/Frontend/src/app/features/tracking-history/tracking-history.component.ts
@@ -1,0 +1,39 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Router, RouterModule } from '@angular/router';
+import { TrackingHistoryService, TrackingHistoryItem } from '../tracking/services/tracking-history.service';
+
+@Component({
+  selector: 'app-tracking-history',
+  standalone: true,
+  imports: [CommonModule, RouterModule],
+  templateUrl: './tracking-history.component.html',
+  styleUrls: ['./tracking-history.component.scss']
+})
+export class TrackingHistoryComponent implements OnInit {
+  history: TrackingHistoryItem[] = [];
+
+  constructor(private historyService: TrackingHistoryService, private router: Router) {}
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.history = this.historyService.getHistory();
+  }
+
+  view(identifier: string): void {
+    this.router.navigate(['/track', identifier]);
+  }
+
+  remove(identifier: string): void {
+    this.historyService.remove(identifier);
+    this.load();
+  }
+
+  clear(): void {
+    this.historyService.clear();
+    this.load();
+  }
+}

--- a/Frontend/src/app/features/tracking/services/tracking-history.service.ts
+++ b/Frontend/src/app/features/tracking/services/tracking-history.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@angular/core';
+
+export interface TrackingHistoryItem {
+  identifier: string;
+  date: string;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class TrackingHistoryService {
+  private storageKey = 'tracking_history';
+
+  getHistory(): TrackingHistoryItem[] {
+    const data = localStorage.getItem(this.storageKey);
+    return data ? JSON.parse(data) as TrackingHistoryItem[] : [];
+  }
+
+  add(identifier: string): void {
+    const history = this.getHistory().filter(i => i.identifier !== identifier);
+    history.unshift({ identifier, date: new Date().toISOString() });
+    localStorage.setItem(this.storageKey, JSON.stringify(history));
+  }
+
+  remove(identifier: string): void {
+    const history = this.getHistory().filter(i => i.identifier !== identifier);
+    localStorage.setItem(this.storageKey, JSON.stringify(history));
+  }
+
+  clear(): void {
+    localStorage.removeItem(this.storageKey);
+  }
+}

--- a/Frontend/src/app/features/tracking/track-result/track-result.component.ts
+++ b/Frontend/src/app/features/tracking/track-result/track-result.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute } from '@angular/router';
 import { TrackingService, TrackingInfo } from '../services/tracking.service';
+import { TrackingHistoryService } from '../services/tracking-history.service';
 import { environment } from '../../../../environments/environment';
 
 declare global {
@@ -28,7 +29,8 @@ export class TrackResultComponent implements OnInit, OnDestroy {
 
   constructor(
     private route: ActivatedRoute,
-    private trackingService: TrackingService
+    private trackingService: TrackingService,
+    private historyService: TrackingHistoryService
   ) {}
 
   ngOnInit() {
@@ -41,6 +43,7 @@ export class TrackResultComponent implements OnInit, OnDestroy {
   }
 
   private loadTrackingInfo(identifier: string) {
+    this.historyService.add(identifier);
     this.loading = true;
     this.error = null;
 

--- a/backend/app/models/tracked_shipment.py
+++ b/backend/app/models/tracked_shipment.py
@@ -1,0 +1,15 @@
+from sqlalchemy import Column, Integer, String, ForeignKey, DateTime
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from ..database import Base
+
+class TrackedShipmentDB(Base):
+    __tablename__ = "tracked_shipments"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=True)
+    tracking_number = Column(String, index=True, nullable=False)
+    searched_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    user = relationship("UserDB")

--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -86,6 +86,16 @@ def require_role(*roles: UserRole):
 
     return dependency
 
+async def get_optional_user(
+    request: Request,
+    db: Session = Depends(get_db),
+    token: str | None = Depends(oauth2_scheme),
+) -> Optional[UserDB]:
+    try:
+        return await get_current_user(request, db, token)
+    except HTTPException:
+        return None
+
 def get_user_by_email(db: Session, email: str) -> Optional[UserDB]:
     return db.query(UserDB).filter(UserDB.email == email).first()
 

--- a/backend/app/services/tracking_history_service.py
+++ b/backend/app/services/tracking_history_service.py
@@ -1,0 +1,18 @@
+import logging
+from sqlalchemy.orm import Session
+from ..models.tracked_shipment import TrackedShipmentDB
+
+logger = logging.getLogger(__name__)
+
+class TrackingHistoryService:
+    def __init__(self, db: Session):
+        self.db = db
+
+    async def log_search(self, user_id: int | None, tracking_number: str) -> None:
+        try:
+            record = TrackedShipmentDB(user_id=user_id, tracking_number=tracking_number)
+            self.db.add(record)
+            self.db.commit()
+        except Exception as e:
+            self.db.rollback()
+            logger.error(f"Failed to log search {tracking_number}: {e}")


### PR DESCRIPTION
## Summary
- save searched tracking numbers locally
- add a page to list and remove previous searches
- store searches for authenticated users in future backend table

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for sqlalchemy/pyotp)*

------
https://chatgpt.com/codex/tasks/task_e_68458075c58c832eaa8aae1b117109d7