### PR TITLE
Add FedEx tracking result component

### DIFF
--- a/Frontend/src/app/app.routes.ts
+++ b/Frontend/src/app/app.routes.ts
@@ -7,6 +7,7 @@ import { VerifyEmailComponent } from './features/auth/verify-email/verify-email.
 import { ForgotPasswordComponent } from './features/auth/forgot-password/forgot-password.component';
 import { ResetPasswordComponent } from './features/auth/reset-password/reset-password.component';
 import { TrackResultComponent } from './features/tracking/track-result/track-result.component';
+import { FedexTrackResultComponent } from './features/tracking/fedex-track-result/fedex-track-result.component';
 import { GoogleCallbackComponent } from './features/auth/google-callback/google-callback.component';
 import { NotificationsComponent } from './features/notifications/notifications.component';
 import { TrackByMailComponent } from './features/track-by-mail/track-by-mail.component';
@@ -36,6 +37,7 @@ export const routes: Routes = [
 
   // Add other routes here, including for other standalone components
   { path: 'track/:identifier', component: TrackResultComponent, canActivate: [AuthGuard] },
+  { path: 'fedex-track/:identifier', component: FedexTrackResultComponent, canActivate: [AuthGuard] },
   { path: 'notifications', component: NotificationsComponent, canActivate: [AuthGuard] },
   // Service routes
   { path: 'services/track-by-mail', component: TrackByMailComponent, canActivate: [AuthGuard] },

--- a/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.html
+++ b/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.html
@@ -1,0 +1,9 @@
+<div class="fedex-container">
+  <div *ngIf="loading" class="loading">Loading...</div>
+  <div *ngIf="!loading && error" class="error">{{ error }}</div>
+  <div *ngIf="!loading && trackingData" class="content">
+    <h2>Tracking #{{ trackingData.tracking_number }}</h2>
+    <p class="status">{{ trackingData.status.status }} - {{ trackingData.status.description }}</p>
+    <div id="fedex-map" class="map"></div>
+  </div>
+</div>

--- a/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.scss
+++ b/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.scss
@@ -1,0 +1,21 @@
+.fedex-container {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.loading {
+  text-align: center;
+  padding: 1rem;
+}
+
+.error {
+  color: red;
+  text-align: center;
+  padding: 1rem;
+}
+
+.map {
+  height: 300px;
+  width: 100%;
+  margin-top: 1rem;
+}

--- a/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.ts
+++ b/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.ts
@@ -1,0 +1,109 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute } from '@angular/router';
+import { TrackingService, TrackingInfo } from '../services/tracking.service';
+
+interface FedexTrackingInfo extends TrackingInfo {
+  currentLocation?: {
+    latitude: number;
+    longitude: number;
+  };
+}
+
+@Component({
+  selector: 'app-fedex-track-result',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './fedex-track-result.component.html',
+  styleUrls: ['./fedex-track-result.component.scss']
+})
+export class FedexTrackResultComponent implements OnInit, OnDestroy {
+  trackingData: FedexTrackingInfo | null = null;
+  loading = true;
+  error: string | null = null;
+
+  private refreshInterval: any;
+  private map: google.maps.Map | null = null;
+  private marker: google.maps.Marker | null = null;
+  private identifier = '';
+
+  constructor(private route: ActivatedRoute, private trackingService: TrackingService) {}
+
+  ngOnInit(): void {
+    this.route.params.subscribe(params => {
+      this.identifier = params['identifier'];
+      if (this.identifier) {
+        this.loadData();
+        this.refreshInterval = setInterval(() => this.updateLocation(), 30000);
+      }
+    });
+  }
+
+  ngOnDestroy(): void {
+    if (this.refreshInterval) {
+      clearInterval(this.refreshInterval);
+    }
+    if (this.marker) {
+      this.marker.setMap(null);
+    }
+    this.map = null;
+  }
+
+  private loadData(): void {
+    this.loading = true;
+    this.trackingService.trackPackage(this.identifier).subscribe({
+      next: res => {
+        if (res.success && res.data) {
+          this.trackingData = res.data as FedexTrackingInfo;
+          this.initializeMap();
+        } else {
+          this.useMockData();
+        }
+        this.loading = false;
+      },
+      error: () => {
+        this.useMockData();
+        this.loading = false;
+      }
+    });
+  }
+
+  private updateLocation(): void {
+    this.trackingService.trackPackage(this.identifier).subscribe({
+      next: res => {
+        const loc = (res.data as FedexTrackingInfo | undefined)?.currentLocation;
+        if (loc && this.marker && this.map) {
+          const position = { lat: loc.latitude, lng: loc.longitude };
+          this.marker.setPosition(position);
+          this.map.panTo(position);
+        }
+      },
+      error: () => {}
+    });
+  }
+
+  private initializeMap(): void {
+    if (!this.trackingData?.currentLocation || typeof window.google === 'undefined') {
+      return;
+    }
+    const coords = {
+      lat: this.trackingData.currentLocation.latitude,
+      lng: this.trackingData.currentLocation.longitude
+    };
+    const mapEl = document.getElementById('fedex-map') as HTMLElement;
+    this.map = new window.google.maps.Map(mapEl, { center: coords, zoom: 8 });
+    this.marker = new window.google.maps.Marker({ position: coords, map: this.map });
+  }
+
+  private useMockData(): void {
+    this.error = 'API unavailable - using mock data';
+    this.trackingData = {
+      tracking_number: this.identifier,
+      carrier: 'FedEx',
+      status: { status: 'In transit', description: 'Mocked data', is_delivered: false },
+      tracking_history: [],
+      currentLocation: { latitude: 33.5731, longitude: -7.5898 }
+    } as FedexTrackingInfo;
+    this.initializeMap();
+  }
+}


### PR DESCRIPTION
## Summary
- create standalone `FedexTrackResultComponent`
- add route `/fedex-track/:identifier`
- load data via `TrackingService` with mocked fallback
- display current location on Google Maps and refresh every 30s

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684582207754832e93a9ebe28cc0f58f