### PR TITLE
Add share, print, and save options

### DIFF
--- a/Frontend/src/app/features/tracking/track-result/track-result.component.html
+++ b/Frontend/src/app/features/tracking/track-result/track-result.component.html
@@ -39,10 +39,12 @@
         </p>
       </div>
       <div class="summary-actions">
-        <button (click)="copyTracking()">Copier</button>
-        <button (click)="shareTracking()">Partager</button>
-        <button (click)="downloadProof()">Télécharger la preuve</button>
-        <button (click)="contactSupport()">Contacter le support</button>
+        <button type="button" (click)="shareTracking()" (keydown.enter)="shareTracking()" (keydown.space)="shareTracking()">Share</button>
+        <button type="button" (click)="printTracking()" (keydown.enter)="printTracking()" (keydown.space)="printTracking()">Print</button>
+        <button type="button" (click)="saveTracking()" (keydown.enter)="saveTracking()" (keydown.space)="saveTracking()">Save</button>
+        <button type="button" (click)="copyTracking()">Copier</button>
+        <button type="button" (click)="downloadProof()">Télécharger la preuve</button>
+        <button type="button" (click)="contactSupport()">Contacter le support</button>
       </div>
     </div>
 

--- a/Frontend/src/app/features/tracking/track-result/track-result.component.ts
+++ b/Frontend/src/app/features/tracking/track-result/track-result.component.ts
@@ -87,6 +87,21 @@ export class TrackResultComponent implements OnInit, OnDestroy {
     }
   }
 
+  printTracking() {
+    window.print();
+  }
+
+  saveTracking() {
+    if (this.trackingInfo?.tracking_number) {
+      const key = 'savedTrackingNumbers';
+      const saved = JSON.parse(localStorage.getItem(key) || '[]');
+      if (!saved.includes(this.trackingInfo.tracking_number)) {
+        saved.push(this.trackingInfo.tracking_number);
+        localStorage.setItem(key, JSON.stringify(saved));
+      }
+    }
+  }
+
   contactSupport() {
     window.location.href = '/support';
   }


### PR DESCRIPTION
## Summary
- extend track-result component with share, print, and save buttons
- implement print and save logic in the component
- ensure share/print/save are keyboard accessible

## Testing
- `pytest -q`
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845821f1290832e83ef14edcf8649a9