### PR TITLE
Add delivery option dialogs

### DIFF
--- a/Frontend/src/app/features/tracking/dialogs/change-address-dialog.component.ts
+++ b/Frontend/src/app/features/tracking/dialogs/change-address-dialog.component.ts
@@ -1,0 +1,60 @@
+import { Component } from '@angular/core';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+
+@Component({
+  selector: 'app-change-address-dialog',
+  standalone: true,
+  imports: [
+    MatDialogModule,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule
+  ],
+  template: `
+    <h1 mat-dialog-title>Change Address</h1>
+    <div mat-dialog-content>
+      <form [formGroup]="form">
+        <mat-form-field appearance="fill">
+          <mat-label>Street</mat-label>
+          <input matInput formControlName="street" />
+          <mat-error *ngIf="form.get('street')?.hasError('required')">Required</mat-error>
+        </mat-form-field>
+        <mat-form-field appearance="fill">
+          <mat-label>City</mat-label>
+          <input matInput formControlName="city" />
+          <mat-error *ngIf="form.get('city')?.hasError('required')">Required</mat-error>
+        </mat-form-field>
+        <mat-form-field appearance="fill">
+          <mat-label>Postal Code</mat-label>
+          <input matInput formControlName="postal" />
+          <mat-error *ngIf="form.get('postal')?.hasError('required')">Required</mat-error>
+        </mat-form-field>
+      </form>
+    </div>
+    <div mat-dialog-actions align="end">
+      <button mat-button (click)="dialogRef.close()">Cancel</button>
+      <button mat-button color="primary" [disabled]="form.invalid" (click)="confirm()">Confirm</button>
+    </div>
+  `
+})
+export class ChangeAddressDialogComponent {
+  form: FormGroup;
+  constructor(public dialogRef: MatDialogRef<ChangeAddressDialogComponent>, private fb: FormBuilder) {
+    this.form = this.fb.group({
+      street: ['', Validators.required],
+      city: ['', Validators.required],
+      postal: ['', Validators.required]
+    });
+  }
+
+  confirm() {
+    if (this.form.valid) {
+      this.dialogRef.close(this.form.value);
+    }
+  }
+}

--- a/Frontend/src/app/features/tracking/dialogs/delivery-instructions-dialog.component.ts
+++ b/Frontend/src/app/features/tracking/dialogs/delivery-instructions-dialog.component.ts
@@ -1,0 +1,44 @@
+import { Component } from '@angular/core';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { FormsModule } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-delivery-instructions-dialog',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule
+  ],
+  template: `
+    <h1 mat-dialog-title>Delivery Instructions</h1>
+    <div mat-dialog-content>
+      <mat-form-field appearance="fill" class="w-full">
+        <mat-label>Instructions</mat-label>
+        <textarea matInput rows="3" [(ngModel)]="instructions"></textarea>
+      </mat-form-field>
+    </div>
+    <div mat-dialog-actions align="end">
+      <button mat-button (click)="dialogRef.close()">Cancel</button>
+      <button mat-button color="primary" [disabled]="!instructions" (click)="confirm()">Confirm</button>
+    </div>
+  `
+})
+export class DeliveryInstructionsDialogComponent {
+  instructions = '';
+  constructor(public dialogRef: MatDialogRef<DeliveryInstructionsDialogComponent>) {}
+
+  confirm() {
+    const value = this.instructions.trim();
+    if (value) {
+      this.dialogRef.close(value);
+    }
+  }
+}

--- a/Frontend/src/app/features/tracking/dialogs/hold-location-dialog.component.ts
+++ b/Frontend/src/app/features/tracking/dialogs/hold-location-dialog.component.ts
@@ -1,0 +1,44 @@
+import { Component } from '@angular/core';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSelectModule } from '@angular/material/select';
+import { MatButtonModule } from '@angular/material/button';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-hold-location-dialog',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatSelectModule,
+    MatButtonModule
+  ],
+  template: `
+    <h1 mat-dialog-title>Hold at Location</h1>
+    <div mat-dialog-content>
+      <mat-form-field appearance="fill">
+        <mat-label>Select Location</mat-label>
+        <mat-select [(ngModel)]="location">
+          <mat-option *ngFor="let loc of locations" [value]="loc">{{ loc }}</mat-option>
+        </mat-select>
+      </mat-form-field>
+    </div>
+    <div mat-dialog-actions align="end">
+      <button mat-button (click)="dialogRef.close()">Cancel</button>
+      <button mat-button color="primary" [disabled]="!location" (click)="confirm()">Confirm</button>
+    </div>
+  `
+})
+export class HoldLocationDialogComponent {
+  locations = ['Main Office', 'Depot 1', 'Depot 2'];
+  location: string | null = null;
+  constructor(public dialogRef: MatDialogRef<HoldLocationDialogComponent>) {}
+
+  confirm() {
+    if (this.location) {
+      this.dialogRef.close(this.location);
+    }
+  }
+}

--- a/Frontend/src/app/features/tracking/dialogs/schedule-delivery-dialog.component.ts
+++ b/Frontend/src/app/features/tracking/dialogs/schedule-delivery-dialog.component.ts
@@ -1,0 +1,57 @@
+import { Component } from '@angular/core';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MatNativeDateModule } from '@angular/material/core';
+
+@Component({
+  selector: 'app-schedule-delivery-dialog',
+  standalone: true,
+  imports: [
+    MatDialogModule,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatDatepickerModule,
+    MatNativeDateModule
+  ],
+  template: `
+    <h1 mat-dialog-title>Schedule Delivery</h1>
+    <div mat-dialog-content>
+      <form [formGroup]="form">
+        <mat-form-field appearance="fill">
+          <mat-label>Date</mat-label>
+          <input matInput [matDatepicker]="picker" formControlName="date" />
+          <mat-datepicker #picker></mat-datepicker>
+        </mat-form-field>
+        <mat-form-field appearance="fill">
+          <mat-label>Time</mat-label>
+          <input matInput type="time" formControlName="time" />
+        </mat-form-field>
+      </form>
+    </div>
+    <div mat-dialog-actions align="end">
+      <button mat-button (click)="dialogRef.close()">Cancel</button>
+      <button mat-button color="primary" [disabled]="form.invalid" (click)="confirm()">Confirm</button>
+    </div>
+  `
+})
+export class ScheduleDeliveryDialogComponent {
+  form: FormGroup;
+  constructor(public dialogRef: MatDialogRef<ScheduleDeliveryDialogComponent>, private fb: FormBuilder) {
+    this.form = this.fb.group({
+      date: ['', Validators.required],
+      time: ['', Validators.required]
+    });
+  }
+
+  confirm() {
+    if (this.form.valid) {
+      this.dialogRef.close(this.form.value);
+    }
+  }
+}

--- a/Frontend/src/app/features/tracking/track-result/track-result.component.html
+++ b/Frontend/src/app/features/tracking/track-result/track-result.component.html
@@ -94,6 +94,13 @@
       </div>
     </div>
 
+    <div class="option-card-container mb-4">
+      <div class="option-card" (click)="openScheduleDelivery()">Schedule Delivery</div>
+      <div class="option-card" (click)="openChangeAddress()">Change Address</div>
+      <div class="option-card" (click)="openHoldAtLocation()">Hold at Location</div>
+      <div class="option-card" (click)="openDeliveryInstructions()">Delivery Instructions</div>
+    </div>
+
     <div *ngIf="trackingInfo.tracking_history?.length">
       <h3 class="font-bold mb-2">Historique</h3>
       <ul class="space-y-4">

--- a/Frontend/src/app/features/tracking/track-result/track-result.component.scss
+++ b/Frontend/src/app/features/tracking/track-result/track-result.component.scss
@@ -176,3 +176,19 @@
   border-radius: 4px;
   cursor: pointer;
 }
+
+.option-card-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.option-card {
+  flex: 1 1 calc(50% - 1rem);
+  background: #ffffff;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  padding: 1rem;
+  text-align: center;
+  cursor: pointer;
+}

--- a/Frontend/src/app/features/tracking/track-result/track-result.component.ts
+++ b/Frontend/src/app/features/tracking/track-result/track-result.component.ts
@@ -1,5 +1,11 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { ScheduleDeliveryDialogComponent } from '../dialogs/schedule-delivery-dialog.component';
+import { ChangeAddressDialogComponent } from '../dialogs/change-address-dialog.component';
+import { HoldLocationDialogComponent } from '../dialogs/hold-location-dialog.component';
+import { DeliveryInstructionsDialogComponent } from '../dialogs/delivery-instructions-dialog.component';
 import { ActivatedRoute } from '@angular/router';
 import { TrackingService, TrackingInfo } from '../services/tracking.service';
 import { environment } from '../../../../environments/environment';
@@ -13,7 +19,7 @@ declare global {
 @Component({
   selector: 'app-track-result',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, MatDialogModule, MatSnackBarModule],
   templateUrl: './track-result.component.html',
   styleUrls: ['./track-result.component.scss']
 })
@@ -28,7 +34,9 @@ export class TrackResultComponent implements OnInit, OnDestroy {
 
   constructor(
     private route: ActivatedRoute,
-    private trackingService: TrackingService
+    private trackingService: TrackingService,
+    private dialog: MatDialog,
+    private snackBar: MatSnackBar
   ) {}
 
   ngOnInit() {
@@ -89,6 +97,38 @@ export class TrackResultComponent implements OnInit, OnDestroy {
 
   contactSupport() {
     window.location.href = '/support';
+  }
+
+  openScheduleDelivery() {
+    this.dialog.open(ScheduleDeliveryDialogComponent).afterClosed().subscribe(res => {
+      if (res) {
+        this.snackBar.open('Delivery scheduled', undefined, { duration: 3000 });
+      }
+    });
+  }
+
+  openChangeAddress() {
+    this.dialog.open(ChangeAddressDialogComponent).afterClosed().subscribe(res => {
+      if (res) {
+        this.snackBar.open('Address updated', undefined, { duration: 3000 });
+      }
+    });
+  }
+
+  openHoldAtLocation() {
+    this.dialog.open(HoldLocationDialogComponent).afterClosed().subscribe(res => {
+      if (res) {
+        this.snackBar.open('Hold request sent', undefined, { duration: 3000 });
+      }
+    });
+  }
+
+  openDeliveryInstructions() {
+    this.dialog.open(DeliveryInstructionsDialogComponent).afterClosed().subscribe(res => {
+      if (res) {
+        this.snackBar.open('Instructions saved', undefined, { duration: 3000 });
+      }
+    });
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
## Summary
- implement four new dialogs for tracking options
- add option cards to tracking result view
- open dialogs and show a snackbar on confirmation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6845821d7a58832ebf90240c672fbb2d