### PR TITLE
Improve keyboard accessibility

### DIFF
--- a/Frontend/src/app/features/home/home.component.html
+++ b/Frontend/src/app/features/home/home.component.html
@@ -10,15 +10,36 @@
     </button>
 
     <div class="hero__features">
-      <div class="hero__feature-card" [class.active]="selectedHeroFeature === 'barcode_scan'" (click)="selectHeroFeature('barcode_scan')">
+      <div class="hero__feature-card"
+           role="button"
+           aria-label="Scan barcode feature"
+           tabindex="0"
+           [class.active]="selectedHeroFeature === 'barcode_scan'"
+           (click)="selectHeroFeature('barcode_scan')"
+           (keydown.enter)="selectHeroFeature('barcode_scan')"
+           (keydown.space)="selectHeroFeature('barcode_scan')">
         <i class="fas fa-barcode hero__feature-icon"></i>
         <p class="hero__feature-text">Scan<br>Barcode</p>
       </div>
-      <div class="hero__feature-card" [class.active]="selectedHeroFeature === null" (click)="selectHeroFeature(null)">
+      <div class="hero__feature-card"
+           role="button"
+           aria-label="Track by ID feature"
+           tabindex="0"
+           [class.active]="selectedHeroFeature === null"
+           (click)="selectHeroFeature(null)"
+           (keydown.enter)="selectHeroFeature(null)"
+           (keydown.space)="selectHeroFeature(null)">
         <i class="fas fa-search hero__feature-icon"></i>
         <p class="hero__feature-text">TRACK</p>
       </div>
-      <div class="hero__feature-card" [class.active]="selectedHeroFeature === 'obtain_proof'" (click)="selectHeroFeature('obtain_proof')">
+      <div class="hero__feature-card"
+           role="button"
+           aria-label="Obtain proof feature"
+           tabindex="0"
+           [class.active]="selectedHeroFeature === 'obtain_proof'"
+           (click)="selectHeroFeature('obtain_proof')"
+           (keydown.enter)="selectHeroFeature('obtain_proof')"
+           (keydown.space)="selectHeroFeature('obtain_proof')">
         <i class="fas fa-file-alt hero__feature-icon"></i>
         <p class="hero__feature-text">Obtain your<br>proof</p>
       </div>
@@ -51,7 +72,13 @@
       <!-- Barcode Scan Option -->
       <div *ngIf="selectedHeroFeature === 'barcode_scan'" class="barcode-scan-option">
         <p>Upload a barcode image or use Pro Scan to track your package.</p>
-        <div class="upload-box" (click)="fileInput.click()">
+        <div class="upload-box"
+             role="button"
+             aria-label="Upload barcode image"
+             tabindex="0"
+             (click)="fileInput.click()"
+             (keydown.enter)="fileInput.click()"
+             (keydown.space)="fileInput.click()">
           <i class="fas fa-cloud-upload-alt upload-icon"></i>
           <p>Drag and drop or click to upload</p>
           <input type="file" accept="image/*" (change)="onBarcodeFileSelected($event)" #fileInput hidden>
@@ -171,9 +198,14 @@
     <div class="locations-container">
       <div id="map" class="map-container"></div>
       <div class="locations-list">
-        <div class="location-card" *ngFor="let location of locations" 
+        <div class="location-card" *ngFor="let location of locations"
+             role="button"
+             [attr.aria-label]="'Select ' + location.name + ' location'"
+             tabindex="0"
              [class.active]="location === selectedLocation"
-             (click)="selectLocation(location)">
+             (click)="selectLocation(location)"
+             (keydown.enter)="selectLocation(location)"
+             (keydown.space)="selectLocation(location)">
           <h3>{{location.name}}</h3>
           <div class="location-details">
             <p><i class="fas fa-map-marker-alt"></i> {{location.address}}</p>
@@ -241,7 +273,10 @@
        [class.notification--error]="notification.type === 'error'">
     <div class="notification__header">
       <span class="notification__title">{{notification.title}}</span>
-      <button class="notification__close" (click)="removeNotification(notification)">
+      <button class="notification__close"
+              aria-label="Close notification"
+              tabindex="0"
+              (click)="removeNotification(notification)">
         <i class="fas fa-times"></i>
       </button>
     </div>

--- a/Frontend/src/app/features/home/home.component.scss
+++ b/Frontend/src/app/features/home/home.component.scss
@@ -134,6 +134,11 @@ $error-color: #dc3545;
     transition: all 0.3s ease;
     border: 2px solid transparent;
 
+    &:focus {
+      outline: 2px solid $primary-color;
+      outline-offset: 2px;
+    }
+
     &:hover {
       border-color: $primary-color;
       transform: translateY(-5px);
@@ -255,6 +260,11 @@ $error-color: #dc3545;
   flex-direction: column;
   align-items: center;
   gap: 15px;
+
+  &:focus {
+    outline: 2px dashed $primary-color;
+    outline-offset: 2px;
+  }
 
   &:hover {
     border-color: $primary-color;
@@ -577,6 +587,11 @@ $error-color: #dc3545;
   cursor: pointer;
   transition: all 0.3s ease;
 
+  &:focus {
+    outline: 2px solid $primary-color;
+    outline-offset: 2px;
+  }
+
   &:hover {
     border-color: $primary-color;
     transform: translateY(-2px);
@@ -634,6 +649,11 @@ $error-color: #dc3545;
   align-items: center;
   cursor: pointer;
   transition: all 0.3s ease;
+
+  &:focus {
+    outline: 2px solid $primary-color;
+    outline-offset: 2px;
+  }
 
   &:hover {
     border-color: $primary-color;
@@ -793,6 +813,11 @@ $error-color: #dc3545;
     color: color.mix($text-color, white, 80%);
     cursor: pointer;
     padding: 0.25rem;
+
+    &:focus {
+      outline: 2px solid $primary-color;
+      outline-offset: 2px;
+    }
     
     &:hover {
       color: $text-color;


### PR DESCRIPTION
## Summary
- add ARIA roles and keyboard handlers to hero feature cards, upload box, location cards and notification button
- show focus outline for custom interactive elements

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845820dd578832ebe97cd44bf85fd89