### PR TITLE
Add shared notification helper

### DIFF
--- a/Frontend/src/app/features/notification-options/notification-options.component.ts
+++ b/Frontend/src/app/features/notification-options/notification-options.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { NotificationService, NotificationPreferences } from '../../core/services/notification.service';
+import { showNotification } from '../../shared/show-notification';
 
 @Component({
   selector: 'app-notification-options',
@@ -27,6 +28,13 @@ export class NotificationOptionsComponent implements OnInit {
 
   save() {
     const prefs: NotificationPreferences = this.form.value;
-    this.notifService.updatePreferences(prefs).subscribe();
+    this.notifService.updatePreferences(prefs).subscribe({
+      next: () => {
+        showNotification('Preferences saved', 'success');
+      },
+      error: () => {
+        showNotification('Failed to save preferences', 'error');
+      }
+    });
   }
 }

--- a/Frontend/src/app/features/tracking/track-result/track-result.component.ts
+++ b/Frontend/src/app/features/tracking/track-result/track-result.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { ActivatedRoute } from '@angular/router';
 import { TrackingService, TrackingInfo } from '../services/tracking.service';
 import { environment } from '../../../../environments/environment';
+import { showNotification } from '../../../shared/show-notification';
 
 declare global {
   interface Window {
@@ -65,6 +66,7 @@ export class TrackResultComponent implements OnInit, OnDestroy {
   copyTracking() {
     if (this.trackingInfo?.tracking_number) {
       navigator.clipboard.writeText(this.trackingInfo.tracking_number);
+      showNotification('Num\u00e9ro copi\u00e9 dans le presse-papier', 'success');
     }
   }
 
@@ -74,9 +76,13 @@ export class TrackResultComponent implements OnInit, OnDestroy {
         title: 'Suivi de colis',
         text: `Suivi ${this.trackingInfo.tracking_number}`,
         url: window.location.href,
+      }).catch(() => {
+        showNotification('Erreur lors du partage', 'error');
       });
+      showNotification('Lien de suivi partag\u00e9', 'success');
     } else {
       this.copyTracking();
+      showNotification('Partage non support\u00e9, num\u00e9ro copi\u00e9', 'info');
     }
   }
 

--- a/Frontend/src/app/shared/show-notification.ts
+++ b/Frontend/src/app/shared/show-notification.ts
@@ -1,0 +1,25 @@
+export type NotificationType = 'success' | 'error' | 'info';
+
+let container: HTMLElement | null = null;
+
+function getContainer(): HTMLElement {
+  if (!container) {
+    container = document.createElement('div');
+    container.className = 'global-notification-container';
+    document.body.appendChild(container);
+  }
+  return container;
+}
+
+export function showNotification(message: string, type: NotificationType = 'info'): void {
+  const parent = getContainer();
+  const notif = document.createElement('div');
+  notif.className = `global-notification ${type}`;
+  notif.textContent = message;
+  parent.appendChild(notif);
+
+  setTimeout(() => {
+    notif.classList.add('hide');
+    setTimeout(() => parent.removeChild(notif), 300);
+  }, 3000);
+}

--- a/Frontend/src/styles.scss
+++ b/Frontend/src/styles.scss
@@ -42,3 +42,40 @@ html, body {
 ::-webkit-scrollbar-thumb:hover {
   background: #555;
 }
+
+.global-notification-container {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  z-index: 2000;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.global-notification {
+  background: white;
+  padding: 1rem;
+  border-radius: 8px;
+  min-width: 200px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  border-left: 4px solid;
+  opacity: 1;
+  transition: opacity 0.3s ease;
+}
+
+.global-notification.success {
+  border-color: #28a745;
+}
+
+.global-notification.error {
+  border-color: #dc3545;
+}
+
+.global-notification.info {
+  border-color: #17a2b8;
+}
+
+.global-notification.hide {
+  opacity: 0;
+}


### PR DESCRIPTION
## Summary
- create a `showNotification` helper in `src/app/shared`
- style global notification container
- show notifications when sharing tracking info or saving preferences

## Testing
- `npm test` *(fails: ng not found)*
- `pytest -q` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6845820ba59c832e81182a0f9bc7dcf6