### PR TITLE
Add analytics service

### DIFF
--- a/Frontend/src/app/core/services/analytics.service.ts
+++ b/Frontend/src/app/core/services/analytics.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AnalyticsService {
+  logAction(action: string, details?: any): void {
+    // For now we just log to the console. In the future this could send
+    // the event to an external analytics endpoint.
+    console.log('[Analytics]', action, details ?? '');
+  }
+}

--- a/Frontend/src/app/features/all-tracking-services/all-tracking-services.component.ts
+++ b/Frontend/src/app/features/all-tracking-services/all-tracking-services.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { TrackingService } from '../tracking/services/tracking.service';
+import { AnalyticsService } from '../../core/services/analytics.service';
 
 @Component({
   selector: 'app-all-tracking-services',
@@ -16,7 +17,11 @@ export class AllTrackingServicesComponent {
   singleForm: FormGroup;
   bulkForm: FormGroup;
 
-  constructor(private fb: FormBuilder, private trackingService: TrackingService) {
+  constructor(
+    private fb: FormBuilder,
+    private trackingService: TrackingService,
+    private analytics: AnalyticsService
+  ) {
     this.singleForm = this.fb.group({
       trackingNumber: ['', [Validators.required, Validators.pattern('^[A-Z0-9]{10,}$')]],
       packageName: ['']
@@ -28,6 +33,7 @@ export class AllTrackingServicesComponent {
 
   switchTab(tab: 'single' | 'bulk' | 'barcode'): void {
     this.activeTab = tab;
+    this.analytics.logAction('switch_tab', tab);
   }
 
   submitSingle(): void {
@@ -36,6 +42,7 @@ export class AllTrackingServicesComponent {
       return;
     }
     const { trackingNumber, packageName } = this.singleForm.value;
+    this.analytics.logAction('submit_single', trackingNumber);
     this.trackingService.trackNumber(trackingNumber, packageName).subscribe();
   }
 
@@ -49,11 +56,13 @@ export class AllTrackingServicesComponent {
       .map((n: string) => n.trim())
       .filter((n: string) => n);
     console.log('Track bulk', numbers);
+    this.analytics.logAction('submit_bulk', numbers.length);
     // Placeholder for bulk tracking logic
   }
 
   startBarcodeScan(): void {
     // Placeholder for barcode scanning implementation
+    this.analytics.logAction('start_barcode_scan');
     console.log('Barcode scan feature coming soon');
   }
 }

--- a/Frontend/src/app/features/notification-options/notification-options.component.ts
+++ b/Frontend/src/app/features/notification-options/notification-options.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { NotificationService, NotificationPreferences } from '../../core/services/notification.service';
+import { AnalyticsService } from '../../core/services/analytics.service';
 
 @Component({
   selector: 'app-notification-options',
@@ -13,7 +14,11 @@ import { NotificationService, NotificationPreferences } from '../../core/service
 export class NotificationOptionsComponent implements OnInit {
   form: FormGroup;
 
-  constructor(private fb: FormBuilder, private notifService: NotificationService) {
+  constructor(
+    private fb: FormBuilder,
+    private notifService: NotificationService,
+    private analytics: AnalyticsService
+  ) {
     this.form = this.fb.group({
       email_updates: [true]
     });
@@ -27,6 +32,7 @@ export class NotificationOptionsComponent implements OnInit {
 
   save() {
     const prefs: NotificationPreferences = this.form.value;
+    this.analytics.logAction('save_notification_options');
     this.notifService.updatePreferences(prefs).subscribe();
   }
 }

--- a/Frontend/src/app/features/tracking/track-result/track-result.component.ts
+++ b/Frontend/src/app/features/tracking/track-result/track-result.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute } from '@angular/router';
 import { TrackingService, TrackingInfo } from '../services/tracking.service';
+import { AnalyticsService } from '../../../core/services/analytics.service';
 import { environment } from '../../../../environments/environment';
 
 declare global {
@@ -28,7 +29,8 @@ export class TrackResultComponent implements OnInit, OnDestroy {
 
   constructor(
     private route: ActivatedRoute,
-    private trackingService: TrackingService
+    private trackingService: TrackingService,
+    private analytics: AnalyticsService
   ) {}
 
   ngOnInit() {
@@ -65,6 +67,7 @@ export class TrackResultComponent implements OnInit, OnDestroy {
   copyTracking() {
     if (this.trackingInfo?.tracking_number) {
       navigator.clipboard.writeText(this.trackingInfo.tracking_number);
+      this.analytics.logAction('copy_tracking', this.trackingInfo.tracking_number);
     }
   }
 
@@ -78,16 +81,19 @@ export class TrackResultComponent implements OnInit, OnDestroy {
     } else {
       this.copyTracking();
     }
+    this.analytics.logAction('share_tracking', this.trackingInfo?.tracking_number);
   }
 
   downloadProof() {
     if (this.trackingInfo) {
       const url = `${environment.apiUrl}/tracking/${this.trackingInfo.tracking_number}/proof`;
       window.open(url, '_blank');
+      this.analytics.logAction('download_proof', this.trackingInfo.tracking_number);
     }
   }
 
   contactSupport() {
+    this.analytics.logAction('contact_support');
     window.location.href = '/support';
   }
 


### PR DESCRIPTION
## Summary
- add simple AnalyticsService
- log actions from home, tracking results, notifications options & all-tracking-services

## Testing
- `pip install -r backend/requirements.txt`
- `npm install --silent`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845820740c8832ea190ad4c2e49aea9