### PR TITLE
Fix TrackingResponse definition

### DIFF
--- a/Frontend/src/app/features/tracking/models/tracking.ts
+++ b/Frontend/src/app/features/tracking/models/tracking.ts
@@ -49,6 +49,8 @@ export interface TrackingInfo {
 }
 
 export interface TrackingResponse {
-  tracking_info: TrackingInfo | null;
+  success: boolean;
+  data?: TrackingInfo;
   error?: string;
-} 
+  metadata?: { [key: string]: any };
+}

--- a/Frontend/src/app/features/tracking/services/tracking.service.ts
+++ b/Frontend/src/app/features/tracking/services/tracking.service.ts
@@ -2,14 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../../../environments/environment';
-import { TrackingInfo } from '../models/tracking';
-
-export interface TrackingResponse {
-  success: boolean;
-  data?: TrackingInfo;
-  error?: string;
-  metadata?: { [key: string]: any };
-}
+import { TrackingInfo, TrackingResponse } from '../models/tracking';
 
 @Injectable({
   providedIn: 'root'
@@ -63,4 +56,4 @@ export class TrackingService {
   }
 }
 
-export type { TrackingInfo } from '../models/tracking';
+export type { TrackingInfo, TrackingResponse } from '../models/tracking';


### PR DESCRIPTION
## Summary
- centralize `TrackingResponse` type in `tracking/models`
- re-export `TrackingResponse` from `tracking.service`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6845820312c0832eaed897eaf087df3a