### PR TITLE
Implement FedEx tracking layout

### DIFF
--- a/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.html
+++ b/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.html
@@ -1,9 +1,39 @@
 <div class="fedex-container">
   <div *ngIf="loading" class="loading">Loading...</div>
   <div *ngIf="!loading && error" class="error">{{ error }}</div>
+
   <div *ngIf="!loading && trackingData" class="content">
-    <h2>Tracking #{{ trackingData.tracking_number }}</h2>
-    <p class="status">{{ trackingData.status.status }} - {{ trackingData.status.description }}</p>
-    <div id="fedex-map" class="map"></div>
+    <div class="header">
+      <div class="info">
+        <h2>#{{ trackingData.tracking_number }}</h2>
+        <div class="status">{{ trackingData.status.status }}</div>
+        <div class="description">{{ trackingData.status.description }}</div>
+      </div>
+      <div class="actions">
+        <button type="button" (click)="shareTracking()">Share</button>
+        <button type="button" (click)="printTracking()">Print</button>
+        <button type="button" (click)="saveTracking()">Save</button>
+      </div>
+    </div>
+
+    <div class="grid">
+      <div id="fedex-map" class="map"></div>
+      <div class="timeline" *ngIf="trackingData.tracking_history?.length">
+        <div
+          *ngFor="let event of trackingData.tracking_history; let i = index"
+          [ngClass]="getItemClasses(event, i)"
+        >
+          <div class="timeline-icon"></div>
+          <div class="timeline-content">
+            <div class="status">{{ event.status }}</div>
+            <div class="time">{{ event.timestamp | date: 'medium' }}</div>
+            <div class="location" *ngIf="event.location">
+              {{ event.location.city }} {{ event.location.state }} {{ event.location.country }}
+            </div>
+            <div class="desc" *ngIf="event.description">{{ event.description }}</div>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </div>

--- a/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.scss
+++ b/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.scss
@@ -1,21 +1,118 @@
 .fedex-container {
-  max-width: 800px;
+  max-width: 1000px;
   margin: 0 auto;
+  font-family: Arial, sans-serif;
 }
 
-.loading {
+.loading,
+.error {
   text-align: center;
   padding: 1rem;
 }
 
 .error {
   color: red;
-  text-align: center;
+}
+
+.content .header {
+  background: #4d148c;
+  color: #fff;
   padding: 1rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.header h2 {
+  margin: 0;
+}
+
+.actions button {
+  background: #ff6600;
+  color: #fff;
+  border: none;
+  padding: 0.5rem 0.75rem;
+  margin-left: 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.grid {
+  display: flex;
+  flex-wrap: wrap;
+  margin-top: 1rem;
+  gap: 1rem;
 }
 
 .map {
-  height: 300px;
-  width: 100%;
-  margin-top: 1rem;
+  flex: 1 1 60%;
+  height: 400px;
+}
+
+.timeline {
+  flex: 1 1 35%;
+  position: relative;
+  padding-left: 2rem;
+  border-left: 2px solid #4d148c;
+}
+
+.timeline-item {
+  position: relative;
+  padding-left: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.timeline-icon {
+  position: absolute;
+  left: -1.1rem;
+  top: 0;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 50%;
+  background: #ff6600;
+}
+
+.timeline-item.current .timeline-icon {
+  background: #4d148c;
+  animation: pulse 2s infinite;
+}
+
+.timeline-item.past .timeline-icon {
+  opacity: 0.5;
+}
+
+.timeline-item.delivered .timeline-icon {
+  background: #16a34a;
+}
+
+.timeline-item.exception .timeline-icon {
+  background: #dc2626;
+}
+
+.timeline-item.in-transit .timeline-icon {
+  background: #2563eb;
+}
+
+.timeline-content .status {
+  font-weight: 600;
+}
+
+.timeline-content .time {
+  font-size: 0.875rem;
+  color: #666;
+}
+
+@keyframes pulse {
+  0% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(1.2);
+    opacity: 0.7;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
 }


### PR DESCRIPTION
## Summary
- overhaul `FedexTrackResultComponent` with FedEx-style page
- add share/print/save actions and progress timeline
- style component to match FedEx mockup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6845882e37b4832e9722465674aa8db5