### PR TITLE
Add sharing and save controls to FedEx tracking

### DIFF
--- a/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.html
+++ b/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.html
@@ -4,6 +4,23 @@
   <div *ngIf="!loading && trackingData" class="content">
     <h2>Tracking #{{ trackingData.tracking_number }}</h2>
     <p class="status">{{ trackingData.status.status }} - {{ trackingData.status.description }}</p>
+    <div class="actions">
+      <button type="button"
+              aria-label="Share tracking number"
+              (click)="shareTracking()"
+              (keydown.enter)="shareTracking()"
+              (keydown.space)="shareTracking()">Share</button>
+      <button type="button"
+              aria-label="Print tracking information"
+              (click)="printTracking()"
+              (keydown.enter)="printTracking()"
+              (keydown.space)="printTracking()">Print</button>
+      <button type="button"
+              aria-label="Save tracking number"
+              (click)="saveTracking()"
+              (keydown.enter)="saveTracking()"
+              (keydown.space)="saveTracking()">Save</button>
+    </div>
     <div id="fedex-map" class="map"></div>
   </div>
 </div>

--- a/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.scss
+++ b/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.scss
@@ -19,3 +19,19 @@
   width: 100%;
   margin-top: 1rem;
 }
+
+.actions {
+  padding: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.actions button {
+  background: #ff6600;
+  color: #ffffff;
+  border: none;
+  padding: 0.5rem 0.75rem;
+  border-radius: 4px;
+  cursor: pointer;
+}

--- a/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.ts
+++ b/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.ts
@@ -106,4 +106,37 @@ export class FedexTrackResultComponent implements OnInit, OnDestroy {
     } as FedexTrackingInfo;
     this.initializeMap();
   }
+
+  shareTracking(): void {
+    if (!this.trackingData?.tracking_number) {
+      return;
+    }
+
+    if (navigator.share) {
+      navigator.share({
+        title: 'Tracking information',
+        text: `Tracking ${this.trackingData.tracking_number}`,
+        url: window.location.href
+      });
+    } else if (navigator.clipboard) {
+      navigator.clipboard.writeText(this.trackingData.tracking_number);
+    }
+  }
+
+  printTracking(): void {
+    window.print();
+  }
+
+  saveTracking(): void {
+    if (!this.trackingData?.tracking_number) {
+      return;
+    }
+
+    const key = 'savedTrackingNumbers';
+    const saved = JSON.parse(localStorage.getItem(key) || '[]');
+    if (!saved.includes(this.trackingData.tracking_number)) {
+      saved.push(this.trackingData.tracking_number);
+      localStorage.setItem(key, JSON.stringify(saved));
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- enable sharing, printing and saving tracking numbers in `FedexTrackResultComponent`
- add action buttons with keyboard handlers
- style the new buttons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68458830a6d0832e8a11128ac89bebae