### PR TITLE
Add dynamic FedEx progress bar

### DIFF
--- a/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.html
+++ b/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.html
@@ -4,6 +4,13 @@
   <div *ngIf="!loading && trackingData" class="content">
     <h2>Tracking #{{ trackingData.tracking_number }}</h2>
     <p class="status">{{ trackingData.status.status }} - {{ trackingData.status.description }}</p>
+
+    <div class="progress">
+      <div *ngFor="let step of steps; let i = index" class="progress-step" [ngClass]="getStepClass(i)">
+        {{ step }}
+      </div>
+    </div>
+
     <div id="fedex-map" class="map"></div>
   </div>
 </div>

--- a/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.scss
+++ b/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.scss
@@ -19,3 +19,77 @@
   width: 100%;
   margin-top: 1rem;
 }
+
+.progress {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 1rem;
+}
+
+.progress-step {
+  flex: 1;
+  text-align: center;
+  position: relative;
+}
+
+.progress-step::before {
+  content: '';
+  display: block;
+  margin: 0 auto 0.5rem;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #ccc;
+}
+
+.progress-step + .progress-step::after {
+  content: '';
+  position: absolute;
+  top: 6px;
+  left: -50%;
+  width: 100%;
+  height: 2px;
+  background: #ccc;
+  z-index: -1;
+}
+
+.progress-step.completed::before,
+.progress-step.completed + .progress-step::after {
+  background: #4d148c;
+}
+
+.progress-step.current::before {
+  background: #4d148c;
+  animation: pulse 2s infinite;
+}
+
+.progress-step.pending::before {
+  background: #ccc;
+}
+
+.progress-step.delivered.current::before {
+  background: #16a34a;
+}
+
+.progress-step.in-transit.current::before {
+  background: #2563eb;
+}
+
+.progress-step.exception.current::before {
+  background: #dc2626;
+}
+
+@keyframes pulse {
+  0% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(1.2);
+    opacity: 0.7;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Summary
- implement progress bar in FedEx tracking result
- assign classes to completed, current, and pending steps based on status
- style progress bar and animation

## Testing
- `pytest -q`
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68458834ebc4832ea64901040d4473b2