### PR TITLE
Add FedEx delivery option dialogs

### DIFF
--- a/Frontend/src/app/features/tracking/change-address-dialog/change-address-dialog.component.html
+++ b/Frontend/src/app/features/tracking/change-address-dialog/change-address-dialog.component.html
@@ -1,0 +1,8 @@
+<h2 mat-dialog-title>Change Delivery Address</h2>
+<mat-dialog-content>
+  Confirm changing the delivery address?
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-button (click)="cancel()">Cancel</button>
+  <button mat-flat-button color="primary" (click)="confirm()">Confirm</button>
+</mat-dialog-actions>

--- a/Frontend/src/app/features/tracking/change-address-dialog/change-address-dialog.component.scss
+++ b/Frontend/src/app/features/tracking/change-address-dialog/change-address-dialog.component.scss
@@ -1,0 +1,1 @@
+/* Add any custom styles for the dialog here */

--- a/Frontend/src/app/features/tracking/change-address-dialog/change-address-dialog.component.ts
+++ b/Frontend/src/app/features/tracking/change-address-dialog/change-address-dialog.component.ts
@@ -1,0 +1,23 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatDialogRef, MatDialogModule } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+
+@Component({
+  selector: 'app-change-address-dialog',
+  standalone: true,
+  imports: [CommonModule, MatDialogModule, MatButtonModule],
+  templateUrl: './change-address-dialog.component.html',
+  styleUrls: ['./change-address-dialog.component.scss']
+})
+export class ChangeAddressDialogComponent {
+  constructor(private dialogRef: MatDialogRef<ChangeAddressDialogComponent>) {}
+
+  confirm(): void {
+    this.dialogRef.close(true);
+  }
+
+  cancel(): void {
+    this.dialogRef.close(false);
+  }
+}

--- a/Frontend/src/app/features/tracking/delivery-instructions-dialog/delivery-instructions-dialog.component.html
+++ b/Frontend/src/app/features/tracking/delivery-instructions-dialog/delivery-instructions-dialog.component.html
@@ -1,0 +1,8 @@
+<h2 mat-dialog-title>Delivery Instructions</h2>
+<mat-dialog-content>
+  Add special delivery instructions?
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-button (click)="cancel()">Cancel</button>
+  <button mat-flat-button color="primary" (click)="confirm()">Confirm</button>
+</mat-dialog-actions>

--- a/Frontend/src/app/features/tracking/delivery-instructions-dialog/delivery-instructions-dialog.component.scss
+++ b/Frontend/src/app/features/tracking/delivery-instructions-dialog/delivery-instructions-dialog.component.scss
@@ -1,0 +1,1 @@
+/* Add any custom styles for the dialog here */

--- a/Frontend/src/app/features/tracking/delivery-instructions-dialog/delivery-instructions-dialog.component.ts
+++ b/Frontend/src/app/features/tracking/delivery-instructions-dialog/delivery-instructions-dialog.component.ts
@@ -1,0 +1,23 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+
+@Component({
+  selector: 'app-delivery-instructions-dialog',
+  standalone: true,
+  imports: [CommonModule, MatDialogModule, MatButtonModule],
+  templateUrl: './delivery-instructions-dialog.component.html',
+  styleUrls: ['./delivery-instructions-dialog.component.scss']
+})
+export class DeliveryInstructionsDialogComponent {
+  constructor(private dialogRef: MatDialogRef<DeliveryInstructionsDialogComponent>) {}
+
+  confirm(): void {
+    this.dialogRef.close(true);
+  }
+
+  cancel(): void {
+    this.dialogRef.close(false);
+  }
+}

--- a/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.html
+++ b/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.html
@@ -4,6 +4,14 @@
   <div *ngIf="!loading && trackingData" class="content">
     <h2>Tracking #{{ trackingData.tracking_number }}</h2>
     <p class="status">{{ trackingData.status.status }} - {{ trackingData.status.description }}</p>
+
+    <div class="options">
+      <div class="option-card" (click)="openScheduleDelivery()">Schedule Delivery</div>
+      <div class="option-card" (click)="openChangeAddress()">Change Address</div>
+      <div class="option-card" (click)="openHoldLocation()">Hold at Location</div>
+      <div class="option-card" (click)="openDeliveryInstructions()">Delivery Instructions</div>
+    </div>
+
     <div id="fedex-map" class="map"></div>
   </div>
 </div>

--- a/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.scss
+++ b/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.scss
@@ -19,3 +19,26 @@
   width: 100%;
   margin-top: 1rem;
 }
+
+.options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.option-card {
+  flex: 1 1 calc(50% - 1rem);
+  background: #ffffff;
+  border: 1px solid #ddd;
+  padding: 1rem;
+  text-align: center;
+  cursor: pointer;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transition: background 0.2s ease;
+}
+
+.option-card:hover {
+  background: #f5f5f5;
+}

--- a/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.ts
+++ b/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.ts
@@ -1,7 +1,14 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute } from '@angular/router';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { TrackingService, TrackingInfo } from '../services/tracking.service';
+import { ScheduleDeliveryDialogComponent } from '../schedule-delivery-dialog/schedule-delivery-dialog.component';
+import { ChangeAddressDialogComponent } from '../change-address-dialog/change-address-dialog.component';
+import { HoldLocationDialogComponent } from '../hold-location-dialog/hold-location-dialog.component';
+import { DeliveryInstructionsDialogComponent } from '../delivery-instructions-dialog/delivery-instructions-dialog.component';
 
 interface FedexTrackingInfo extends TrackingInfo {
   currentLocation?: {
@@ -13,7 +20,12 @@ interface FedexTrackingInfo extends TrackingInfo {
 @Component({
   selector: 'app-fedex-track-result',
   standalone: true,
-  imports: [CommonModule],
+  imports: [
+    CommonModule,
+    MatDialogModule,
+    MatButtonModule,
+    MatSnackBarModule
+  ],
   templateUrl: './fedex-track-result.component.html',
   styleUrls: ['./fedex-track-result.component.scss']
 })
@@ -27,7 +39,12 @@ export class FedexTrackResultComponent implements OnInit, OnDestroy {
   private marker: google.maps.Marker | null = null;
   private identifier = '';
 
-  constructor(private route: ActivatedRoute, private trackingService: TrackingService) {}
+  constructor(
+    private route: ActivatedRoute,
+    private trackingService: TrackingService,
+    private dialog: MatDialog,
+    private snackBar: MatSnackBar
+  ) {}
 
   ngOnInit(): void {
     this.route.params.subscribe(params => {
@@ -80,6 +97,50 @@ export class FedexTrackResultComponent implements OnInit, OnDestroy {
       },
       error: () => {}
     });
+  }
+
+  openScheduleDelivery(): void {
+    this.dialog
+      .open(ScheduleDeliveryDialogComponent)
+      .afterClosed()
+      .subscribe(result => {
+        if (result) {
+          this.snackBar.open('Delivery scheduled', 'Close', { duration: 3000 });
+        }
+      });
+  }
+
+  openChangeAddress(): void {
+    this.dialog
+      .open(ChangeAddressDialogComponent)
+      .afterClosed()
+      .subscribe(result => {
+        if (result) {
+          this.snackBar.open('Address change requested', 'Close', { duration: 3000 });
+        }
+      });
+  }
+
+  openHoldLocation(): void {
+    this.dialog
+      .open(HoldLocationDialogComponent)
+      .afterClosed()
+      .subscribe(result => {
+        if (result) {
+          this.snackBar.open('Hold request sent', 'Close', { duration: 3000 });
+        }
+      });
+  }
+
+  openDeliveryInstructions(): void {
+    this.dialog
+      .open(DeliveryInstructionsDialogComponent)
+      .afterClosed()
+      .subscribe(result => {
+        if (result) {
+          this.snackBar.open('Instructions added', 'Close', { duration: 3000 });
+        }
+      });
   }
 
   private initializeMap(): void {

--- a/Frontend/src/app/features/tracking/hold-location-dialog/hold-location-dialog.component.html
+++ b/Frontend/src/app/features/tracking/hold-location-dialog/hold-location-dialog.component.html
@@ -1,0 +1,8 @@
+<h2 mat-dialog-title>Hold at Location</h2>
+<mat-dialog-content>
+  Request hold at a nearby location?
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-button (click)="cancel()">Cancel</button>
+  <button mat-flat-button color="primary" (click)="confirm()">Confirm</button>
+</mat-dialog-actions>

--- a/Frontend/src/app/features/tracking/hold-location-dialog/hold-location-dialog.component.scss
+++ b/Frontend/src/app/features/tracking/hold-location-dialog/hold-location-dialog.component.scss
@@ -1,0 +1,1 @@
+/* Add any custom styles for the dialog here */

--- a/Frontend/src/app/features/tracking/hold-location-dialog/hold-location-dialog.component.ts
+++ b/Frontend/src/app/features/tracking/hold-location-dialog/hold-location-dialog.component.ts
@@ -1,0 +1,23 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+
+@Component({
+  selector: 'app-hold-location-dialog',
+  standalone: true,
+  imports: [CommonModule, MatDialogModule, MatButtonModule],
+  templateUrl: './hold-location-dialog.component.html',
+  styleUrls: ['./hold-location-dialog.component.scss']
+})
+export class HoldLocationDialogComponent {
+  constructor(private dialogRef: MatDialogRef<HoldLocationDialogComponent>) {}
+
+  confirm(): void {
+    this.dialogRef.close(true);
+  }
+
+  cancel(): void {
+    this.dialogRef.close(false);
+  }
+}

--- a/Frontend/src/app/features/tracking/schedule-delivery-dialog/schedule-delivery-dialog.component.html
+++ b/Frontend/src/app/features/tracking/schedule-delivery-dialog/schedule-delivery-dialog.component.html
@@ -1,0 +1,8 @@
+<h2 mat-dialog-title>Schedule Delivery</h2>
+<mat-dialog-content>
+  Are you sure you want to schedule the delivery?
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-button (click)="cancel()">Cancel</button>
+  <button mat-flat-button color="primary" (click)="confirm()">Confirm</button>
+</mat-dialog-actions>

--- a/Frontend/src/app/features/tracking/schedule-delivery-dialog/schedule-delivery-dialog.component.scss
+++ b/Frontend/src/app/features/tracking/schedule-delivery-dialog/schedule-delivery-dialog.component.scss
@@ -1,0 +1,1 @@
+/* Add any custom styles for the dialog here */

--- a/Frontend/src/app/features/tracking/schedule-delivery-dialog/schedule-delivery-dialog.component.ts
+++ b/Frontend/src/app/features/tracking/schedule-delivery-dialog/schedule-delivery-dialog.component.ts
@@ -1,0 +1,23 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatDialogRef, MatDialogModule } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+
+@Component({
+  selector: 'app-schedule-delivery-dialog',
+  standalone: true,
+  imports: [CommonModule, MatDialogModule, MatButtonModule],
+  templateUrl: './schedule-delivery-dialog.component.html',
+  styleUrls: ['./schedule-delivery-dialog.component.scss']
+})
+export class ScheduleDeliveryDialogComponent {
+  constructor(private dialogRef: MatDialogRef<ScheduleDeliveryDialogComponent>) {}
+
+  confirm(): void {
+    this.dialogRef.close(true);
+  }
+
+  cancel(): void {
+    this.dialogRef.close(false);
+  }
+}


### PR DESCRIPTION
## Summary
- add Angular Material dialog components for delivery options
- show option cards in FedEx tracking results
- trigger dialogs on click and show snack bar notifications

## Testing
- `npm --prefix Frontend install`
- `npm --prefix Frontend test` *(fails: No binary for Chrome)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684588320c40832ebe7ca9e2d35ec32e