### PR TITLE
Add notification utility

### DIFF
--- a/Frontend/src/app/features/notification-options/notification-options.component.ts
+++ b/Frontend/src/app/features/notification-options/notification-options.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { NotificationService, NotificationPreferences } from '../../core/services/notification.service';
+import { showNotification } from '../../shared/services/notification.util';
 import { AnalyticsService } from '../../core/services/analytics.service';
 
 @Component({
@@ -33,6 +34,8 @@ export class NotificationOptionsComponent implements OnInit {
   save() {
     const prefs: NotificationPreferences = this.form.value;
     this.analytics.logAction('save_notification_options');
-    this.notifService.updatePreferences(prefs).subscribe();
+    this.notifService.updatePreferences(prefs).subscribe(() => {
+      showNotification('Preferences saved', 'success');
+    });
   }
 }

--- a/Frontend/src/app/features/notifications/notifications.component.ts
+++ b/Frontend/src/app/features/notifications/notifications.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { NotificationService, Notification } from '../../core/services/notification.service';
+import { showNotification } from '../../shared/services/notification.util';
 
 @Component({
   selector: 'app-notifications',
@@ -35,6 +36,7 @@ export class NotificationsComponent implements OnInit {
   markAllAsRead() {
     this.notificationService.markAllAsRead().subscribe(() => {
       this.fetchNotifications();
+      showNotification('All notifications marked as read', 'success');
     });
   }
 }

--- a/Frontend/src/app/features/tracking/track-result/track-result.component.ts
+++ b/Frontend/src/app/features/tracking/track-result/track-result.component.ts
@@ -4,6 +4,7 @@ import { CommonModule } from '@angular/common';
 import { ActivatedRoute } from '@angular/router';
 import { TrackingService, TrackingInfo } from '../services/tracking.service';
 import { AnalyticsService } from '../../../core/services/analytics.service';
+import { showNotification } from '../../../shared/services/notification.util';
 import { environment } from '../../../../environments/environment';
 
 declare global {
@@ -80,6 +81,7 @@ export class TrackResultComponent implements OnInit, OnDestroy {
     if (this.trackingInfo?.tracking_number) {
       navigator.clipboard.writeText(this.trackingInfo.tracking_number);
       this.analytics.logAction('copy_tracking', this.trackingInfo.tracking_number);
+      showNotification('Tracking number copied', 'success');
     }
   }
 
@@ -90,6 +92,7 @@ export class TrackResultComponent implements OnInit, OnDestroy {
         text: `Suivi ${this.trackingInfo.tracking_number}`,
         url: window.location.href,
       });
+      showNotification('Share dialog opened', 'info');
     } else {
       this.copyTracking();
     }
@@ -106,6 +109,7 @@ export class TrackResultComponent implements OnInit, OnDestroy {
 
   printTracking() {
     window.print();
+    showNotification('Printing...', 'info');
   }
 
   saveTracking() {
@@ -115,6 +119,7 @@ export class TrackResultComponent implements OnInit, OnDestroy {
       if (!saved.includes(this.trackingInfo.tracking_number)) {
         saved.push(this.trackingInfo.tracking_number);
         localStorage.setItem(key, JSON.stringify(saved));
+        showNotification('Tracking saved', 'success');
       }
     }
   }

--- a/Frontend/src/app/shared/services/notification.util.ts
+++ b/Frontend/src/app/shared/services/notification.util.ts
@@ -1,0 +1,20 @@
+export function showNotification(message: string, type: 'success' | 'error' | 'info' = 'info'): void {
+  const containerId = 'global-notification-container';
+  let container = document.getElementById(containerId);
+  if (!container) {
+    container = document.createElement('div');
+    container.id = containerId;
+    container.className = 'notification-container';
+    document.body.appendChild(container);
+  }
+
+  const notif = document.createElement('div');
+  notif.className = `notification ${type}`;
+  notif.textContent = message;
+  container.appendChild(notif);
+
+  setTimeout(() => {
+    notif.classList.add('fade-out');
+    notif.addEventListener('transitionend', () => notif.remove());
+  }, 3000);
+}

--- a/Frontend/src/styles.scss
+++ b/Frontend/src/styles.scss
@@ -79,3 +79,31 @@ $secondary-color: #ff6600;
   padding: 1rem;
   font-family: Roboto, "Helvetica Neue", sans-serif;
 }
+
+/* Global Notification Styles */
+.notification-container {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  z-index: 1000;
+}
+
+.notification {
+  padding: 0.75rem 1rem;
+  border-radius: 4px;
+  color: #fff;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  background-color: #2196f3;
+  transition: opacity 0.3s ease;
+}
+
+.notification.success { background-color: #4caf50; }
+.notification.error { background-color: #f44336; }
+.notification.info { background-color: #2196f3; }
+
+.notification.fade-out {
+  opacity: 0;
+}


### PR DESCRIPTION
## Summary
- add notification helper and global styles
- show messages on share, print and save actions
- confirm updates with a toast notification

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68458837a0d0832e9b5bf90884735391