### PR TITLE
Rename barcode methods

### DIFF
--- a/Frontend/src/app/features/barcode-upload/barcode-upload.component.ts
+++ b/Frontend/src/app/features/barcode-upload/barcode-upload.component.ts
@@ -35,7 +35,7 @@ export class BarcodeUploadComponent {
   }
 
   private decode(file: File) {
-    this.trackingService.decodeBarcode(file)
+    this.trackingService.decodeBarcodeClient(file)
       .then(code => {
         if (this.control) {
           this.control.setValue(code);

--- a/Frontend/src/app/features/tracking/services/tracking.service.ts
+++ b/Frontend/src/app/features/tracking/services/tracking.service.ts
@@ -32,7 +32,7 @@ export class TrackingService {
     return this.trackPackage(tcn);
   }
 
-  decodeBarcode(file: File): Observable<{ value: string }> {
+  decodeBarcodeServer(file: File): Observable<{ value: string }> {
     const formData = new FormData();
     formData.append('file', file);
     return this.http.post<{ value: string }>(`${this.baseUrl}/decode-barcode`, formData);
@@ -56,7 +56,7 @@ export class TrackingService {
     return this.http.post<TrackingResponse>(`${this.baseUrl}/email`, { tracking_number, email });
   }
 
-  decodeBarcode(file: File): Promise<string> {
+  decodeBarcodeClient(file: File): Promise<string> {
     return new Promise((resolve, reject) => {
       const reader = new FileReader();
       reader.onload = async () => {


### PR DESCRIPTION
## Summary
- fix duplicate method name in `TrackingService`
- update `BarcodeUploadComponent` to use `decodeBarcodeClient`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845883c0ff8832eaed7ed83e02e8e09