### PR TITLE
Handle FedEx tracking errors

### DIFF
--- a/Frontend/src/app/core/utils/notifier.service.ts
+++ b/Frontend/src/app/core/utils/notifier.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class NotifierService {
+  error(message: string): void {
+    // Simple implementation showing browser alert; could be replaced with a better UI
+    alert(message);
+  }
+}


### PR DESCRIPTION
## Summary
- add `NotifierService` utility
- surface errors from FedexTrackResultComponent using new notification utility
- simulate request failure when `environment.production` is false

## Testing
- `npm run build` *(fails: ng not found)*
- `pytest -q` *(fails: ModuleNotFoundError: sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_6845883e98c4832ebca4a5529da3e9b3