### PR TITLE
Integrate barcode upload component

### DIFF
--- a/Frontend/src/app/features/all-tracking-services/all-tracking-services.component.html
+++ b/Frontend/src/app/features/all-tracking-services/all-tracking-services.component.html
@@ -30,6 +30,7 @@
     <div *ngIf="activeTab==='barcode'" class="barcode-form">
       <p>Scan your barcode using the camera.</p>
       <button type="button" (click)="startBarcodeScan()">Start Scan</button>
+      <app-barcode-upload [control]="singleForm.get('trackingNumber')"></app-barcode-upload>
     </div>
   </div>
 </div>

--- a/Frontend/src/app/features/all-tracking-services/all-tracking-services.component.ts
+++ b/Frontend/src/app/features/all-tracking-services/all-tracking-services.component.ts
@@ -3,11 +3,12 @@ import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { TrackingService } from '../tracking/services/tracking.service';
 import { AnalyticsService } from '../../core/services/analytics.service';
+import { BarcodeUploadComponent } from '../barcode-upload/barcode-upload.component';
 
 @Component({
   selector: 'app-all-tracking-services',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule],
+  imports: [CommonModule, ReactiveFormsModule, BarcodeUploadComponent],
   templateUrl: './all-tracking-services.component.html',
   styleUrls: ['./all-tracking-services.component.scss']
 })

--- a/Frontend/src/app/features/barcode-upload/barcode-upload.component.ts
+++ b/Frontend/src/app/features/barcode-upload/barcode-upload.component.ts
@@ -39,6 +39,8 @@ export class BarcodeUploadComponent {
       .then(code => {
         if (this.control) {
           this.control.setValue(code);
+          this.control.markAsTouched();
+          this.control.updateValueAndValidity();
         }
       })
       .catch(err => console.error('Barcode decode failed', err));

--- a/Frontend/src/app/features/home/home.component.html
+++ b/Frontend/src/app/features/home/home.component.html
@@ -87,6 +87,7 @@
           {{ isScanning ? 'Stop Scan' : 'Pro Scan (Webcam)' }}
         </button>
         <video #videoPreview *ngIf="isScanning" class="webcam-preview" autoplay></video>
+        <app-barcode-upload [control]="trackingForm.get('trackingNumber')"></app-barcode-upload>
       </div>
 
       <!-- Obtain Your Proof Option -->

--- a/Frontend/src/app/features/home/home.component.ts
+++ b/Frontend/src/app/features/home/home.component.ts
@@ -11,6 +11,7 @@ import { AnalyticsService } from '../../core/services/analytics.service';
 import { Subject, Observable } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { BrowserCodeReader, IScannerControls, BrowserMultiFormatReader } from '@zxing/browser';
+import { BarcodeUploadComponent } from '../barcode-upload/barcode-upload.component';
 
 // Import Google Maps types
 declare global {
@@ -68,7 +69,7 @@ interface ServiceItem {
 @Component({
   selector: 'app-home',
   standalone: true,
-  imports: [CommonModule, FormsModule, ReactiveFormsModule, RouterModule],
+  imports: [CommonModule, FormsModule, ReactiveFormsModule, RouterModule, BarcodeUploadComponent],
   templateUrl: './home.component.html',
   styleUrls: ['./home.component.scss'],
   animations: [


### PR DESCRIPTION
## Summary
- expose barcode upload widget in home page and services page
- wire barcode upload component to automatically set the tracking number field and validate

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68458844d200832eabf4a865e2aee2f4