### PR TITLE
Improve sharing fallback

### DIFF
--- a/Frontend/src/app/core/services/notification.service.ts
+++ b/Frontend/src/app/core/services/notification.service.ts
@@ -45,4 +45,26 @@ export class NotificationService {
   updatePreferences(prefs: NotificationPreferences): Observable<NotificationPreferences> {
     return this.http.post<NotificationPreferences>(`${this.baseUrl}/preferences`, prefs);
   }
+
+  showMessage(message: string): void {
+    if ('Notification' in window) {
+      if (Notification.permission === 'granted') {
+        const n = new Notification(message);
+        setTimeout(() => n.close(), 2000);
+      } else if (Notification.permission !== 'denied') {
+        Notification.requestPermission().then((perm) => {
+          if (perm === 'granted') {
+            const n = new Notification(message);
+            setTimeout(() => n.close(), 2000);
+          } else {
+            alert(message);
+          }
+        });
+      } else {
+        alert(message);
+      }
+    } else {
+      alert(message);
+    }
+  }
 }

--- a/Frontend/src/app/features/tracking/track-result/track-result.component.ts
+++ b/Frontend/src/app/features/tracking/track-result/track-result.component.ts
@@ -4,6 +4,7 @@ import { CommonModule } from '@angular/common';
 import { ActivatedRoute } from '@angular/router';
 import { TrackingService, TrackingInfo } from '../services/tracking.service';
 import { AnalyticsService } from '../../../core/services/analytics.service';
+import { NotificationService } from '../../../core/services/notification.service';
 import { environment } from '../../../../environments/environment';
 
 declare global {
@@ -42,7 +43,8 @@ export class TrackResultComponent implements OnInit, OnDestroy {
   constructor(
     private route: ActivatedRoute,
     private trackingService: TrackingService,
-    private analytics: AnalyticsService
+    private analytics: AnalyticsService,
+    private notificationService: NotificationService
   ) {}
 
   ngOnInit() {
@@ -91,7 +93,8 @@ export class TrackResultComponent implements OnInit, OnDestroy {
         url: window.location.href,
       });
     } else {
-      this.copyTracking();
+      navigator.clipboard.writeText(window.location.href);
+      this.notificationService.showMessage('Lien copié dans le presse-papiers');
     }
     this.analytics.logAction('share_tracking', this.trackingInfo?.tracking_number);
   }


### PR DESCRIPTION
## Summary
- copy the current page URL in `shareTracking` when Web Share API is unavailable
- show a small notification with `NotificationService` after copying
- provide helper `showMessage` in `NotificationService` for user-facing notices

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for dependencies)*
- `npm test --prefix Frontend --silent` *(fails: no Chrome binary)*
- `npx --yes tsc -p Frontend/tsconfig.app.json` *(fails: missing Google Maps types)*

------
https://chatgpt.com/codex/tasks/task_e_684588455e88832eb20be72915aba027