### PR TITLE
Add tracking history feature

### DIFF
--- a/Frontend/src/app/app.routes.ts
+++ b/Frontend/src/app/app.routes.ts
@@ -18,6 +18,7 @@ import { SetupTwofaComponent } from './features/auth/setup-twofa/setup-twofa.com
 import { VerifyTwofaComponent } from './features/auth/verify-twofa/verify-twofa.component';
 import { ResendVerificationComponent } from './features/auth/resend-verification/resend-verification.component';
 import { NewsDetailComponent } from './features/news/news-detail.component';
+import { HistoryComponent } from './features/history/history.component';
 import { NotFoundComponent } from './shared/not-found.component';
 
 // Assuming you might have other standalone components or lazy-loaded routes
@@ -39,6 +40,7 @@ export const routes: Routes = [
   { path: 'track/:identifier', component: TrackResultComponent, canActivate: [AuthGuard] },
   { path: 'fedex-track/:identifier', component: FedexTrackResultComponent, canActivate: [AuthGuard] },
   { path: 'notifications', component: NotificationsComponent, canActivate: [AuthGuard] },
+  { path: 'history', component: HistoryComponent, canActivate: [AuthGuard] },
   // Service routes
   { path: 'services/track-by-mail', component: TrackByMailComponent, canActivate: [AuthGuard] },
   { path: 'services/notifications', component: NotificationOptionsComponent, canActivate: [AuthGuard] },

--- a/Frontend/src/app/core/services/tracking-history.service.ts
+++ b/Frontend/src/app/core/services/tracking-history.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class TrackingHistoryService {
+  private storageKey = 'trackingHistory';
+  private maxItems = 10;
+
+  getHistory(): string[] {
+    const raw = localStorage.getItem(this.storageKey);
+    return raw ? JSON.parse(raw) as string[] : [];
+  }
+
+  addIdentifier(id: string): void {
+    const history = this.getHistory().filter(item => item !== id);
+    history.unshift(id);
+    if (history.length > this.maxItems) {
+      history.pop();
+    }
+    localStorage.setItem(this.storageKey, JSON.stringify(history));
+  }
+
+  removeIdentifier(id: string): void {
+    const history = this.getHistory().filter(item => item !== id);
+    localStorage.setItem(this.storageKey, JSON.stringify(history));
+  }
+
+  clear(): void {
+    localStorage.removeItem(this.storageKey);
+  }
+}

--- a/Frontend/src/app/features/history/history.component.html
+++ b/Frontend/src/app/features/history/history.component.html
@@ -1,0 +1,15 @@
+<div class="history">
+  <h2>Tracking History</h2>
+  <ng-container *ngIf="history.length; else none">
+    <ul>
+      <li *ngFor="let id of history">
+        <a [routerLink]="['/track', id]">{{ id }}</a>
+        <button (click)="delete(id)">Delete</button>
+      </li>
+    </ul>
+    <button (click)="clear()">Clear History</button>
+  </ng-container>
+  <ng-template #none>
+    <p>No history yet.</p>
+  </ng-template>
+</div>

--- a/Frontend/src/app/features/history/history.component.scss
+++ b/Frontend/src/app/features/history/history.component.scss
@@ -1,0 +1,22 @@
+.history {
+  padding: 1rem;
+}
+
+.history ul {
+  list-style: none;
+  padding: 0;
+}
+
+.history li {
+  display: flex;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.history li a {
+  flex: 1;
+}
+
+.history button {
+  margin-left: 0.5rem;
+}

--- a/Frontend/src/app/features/history/history.component.ts
+++ b/Frontend/src/app/features/history/history.component.ts
@@ -1,0 +1,35 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { TrackingHistoryService } from '../../core/services/tracking-history.service';
+
+@Component({
+  selector: 'app-history',
+  standalone: true,
+  imports: [CommonModule, RouterModule],
+  templateUrl: './history.component.html',
+  styleUrls: ['./history.component.scss']
+})
+export class HistoryComponent implements OnInit {
+  history: string[] = [];
+
+  constructor(private historyService: TrackingHistoryService) {}
+
+  ngOnInit(): void {
+    this.loadHistory();
+  }
+
+  private loadHistory(): void {
+    this.history = this.historyService.getHistory();
+  }
+
+  delete(id: string): void {
+    this.historyService.removeIdentifier(id);
+    this.loadHistory();
+  }
+
+  clear(): void {
+    this.historyService.clear();
+    this.loadHistory();
+  }
+}

--- a/Frontend/src/app/features/home/home.component.ts
+++ b/Frontend/src/app/features/home/home.component.ts
@@ -6,6 +6,7 @@ import { trigger, transition, style, animate } from '@angular/animations';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { AuthService } from '../../core/services/auth.service';
 import { TrackingService } from '../tracking/services/tracking.service';
+import { TrackingHistoryService } from '../../core/services/tracking-history.service';
 import { NotificationService } from '../../core/services/notification.service';
 import { AnalyticsService } from '../../core/services/analytics.service';
 import { Subject, Observable } from 'rxjs';
@@ -131,7 +132,8 @@ export class HomeComponent implements OnInit, OnDestroy {
     private authService: AuthService,
     private trackingService: TrackingService,
     private notificationService: NotificationService,
-    private analytics: AnalyticsService
+    private analytics: AnalyticsService,
+    private history: TrackingHistoryService
   ) {
     this.trackingForm = this.fb.group({
       trackingNumber: ['', [Validators.required, Validators.pattern('^[A-Z0-9]{10,}$')]],
@@ -366,6 +368,7 @@ export class HomeComponent implements OnInit, OnDestroy {
     this.trackingService.trackNumber(identifier, name).subscribe({
       next: (response) => {
         if (response.success && response.data) {
+          this.history.addIdentifier(identifier);
           this.router.navigate(['/track', identifier]);
           } else {
           this.addNotification('error', 'Erreur', response.error || 'Erreur inconnue');

--- a/Frontend/src/app/features/track-by-mail/track-by-mail.component.ts
+++ b/Frontend/src/app/features/track-by-mail/track-by-mail.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { TrackingService, TrackingResponse } from '../tracking/services/tracking.service';
+import { TrackingHistoryService } from '../../core/services/tracking-history.service';
 
 @Component({
   selector: 'app-track-by-mail',
@@ -14,7 +15,11 @@ export class TrackByMailComponent {
   form: FormGroup;
   result: TrackingResponse | null = null;
 
-  constructor(private fb: FormBuilder, private trackingService: TrackingService) {
+  constructor(
+    private fb: FormBuilder,
+    private trackingService: TrackingService,
+    private history: TrackingHistoryService
+  ) {
     this.form = this.fb.group({
       trackingNumber: ['', Validators.required],
       email: ['', [Validators.required, Validators.email]],
@@ -28,6 +33,7 @@ export class TrackByMailComponent {
     }
     const { trackingNumber, email, packageName } = this.form.value;
     this.trackingService.trackNumber(trackingNumber, packageName).subscribe(() => {
+      this.history.addIdentifier(trackingNumber);
       this.trackingService.trackByEmail(trackingNumber, email).subscribe(res => {
         this.result = res;
       });

--- a/Frontend/src/app/features/tracking/track-result/track-result.component.ts
+++ b/Frontend/src/app/features/tracking/track-result/track-result.component.ts
@@ -3,6 +3,7 @@ import { trigger, transition, style, animate, query, stagger } from '@angular/an
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute } from '@angular/router';
 import { TrackingService, TrackingInfo } from '../services/tracking.service';
+import { TrackingHistoryService } from '../../../core/services/tracking-history.service';
 import { AnalyticsService } from '../../../core/services/analytics.service';
 import { environment } from '../../../../environments/environment';
 
@@ -42,7 +43,8 @@ export class TrackResultComponent implements OnInit, OnDestroy {
   constructor(
     private route: ActivatedRoute,
     private trackingService: TrackingService,
-    private analytics: AnalyticsService
+    private analytics: AnalyticsService,
+    private history: TrackingHistoryService
   ) {}
 
   ngOnInit() {
@@ -62,6 +64,7 @@ export class TrackResultComponent implements OnInit, OnDestroy {
       next: (response) => {
         if (response.success && response.data) {
           this.trackingInfo = response.data;
+          this.history.addIdentifier(identifier);
           this.waitForGoogleMaps().then(() => this.initializeMap());
         } else {
           this.error = response.error || 'Impossible de récupérer les informations de suivi';


### PR DESCRIPTION
## Summary
- implement `TrackingHistoryService` using `localStorage`
- add `HistoryComponent` to display recent searches
- record tracking identifiers from home, result and track-by-mail
- expose `/history` route

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68458846bc50832e8d52009ddc6c5c8a