### PR TITLE
Implement proof of delivery retrieval

### DIFF
--- a/Frontend/src/app/features/tracking/track-result/track-result.component.ts
+++ b/Frontend/src/app/features/tracking/track-result/track-result.component.ts
@@ -97,11 +97,26 @@ export class TrackResultComponent implements OnInit, OnDestroy {
   }
 
   downloadProof() {
-    if (this.trackingInfo) {
-      const url = `${environment.apiUrl}/tracking/${this.trackingInfo.tracking_number}/proof`;
-      window.open(url, '_blank');
-      this.analytics.logAction('download_proof', this.trackingInfo.tracking_number);
+    if (!this.trackingInfo) {
+      return;
     }
+
+    this.analytics.logAction('download_proof', this.trackingInfo.tracking_number);
+
+    this.trackingService.downloadProof(this.trackingInfo.tracking_number).subscribe({
+      next: (blob) => {
+        const url = window.URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `proof_${this.trackingInfo!.tracking_number}.pdf`;
+        a.click();
+        window.URL.revokeObjectURL(url);
+      },
+      error: (err) => {
+        this.error = err.error?.error || 'Aucune preuve de livraison disponible';
+        console.error('Erreur de preuve:', err);
+      }
+    });
   }
 
   printTracking() {

--- a/backend/app/services/fedex_service.py
+++ b/backend/app/services/fedex_service.py
@@ -61,6 +61,17 @@ class FedExService:
             await self._authenticate()
         return self._token
 
+    async def get_proof_of_delivery(self, tracking_number: str) -> bytes:
+        """Return the proof of delivery PDF for a tracking number."""
+        try:
+            file_path = Path(__file__).resolve().parents[1] / "static" / "proofs" / f"{tracking_number}.pdf"
+            if file_path.exists():
+                return file_path.read_bytes()
+            raise FileNotFoundError(f"Proof of delivery for {tracking_number} not found")
+        except Exception as e:
+            logger.error(f"Error fetching proof of delivery: {str(e)}")
+            raise
+
     def _map_fedex_status(self, fedex_status: str) -> PackageStatus:
         """Map FedEx status to our PackageStatus enum"""
         status_map = {


### PR DESCRIPTION
## Summary
- connect proof endpoint to FedExService
- implement FedExService.get_proof_of_delivery
- update TrackResultComponent to stream proof PDF with error handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68458847ca20832e8375206d7f8be747