### PR TITLE
Add barcode scanning to tracking services

### DIFF
--- a/Frontend/src/app/features/all-tracking-services/all-tracking-services.component.html
+++ b/Frontend/src/app/features/all-tracking-services/all-tracking-services.component.html
@@ -27,9 +27,23 @@
       <button type="submit">Track All</button>
     </form>
 
-    <div *ngIf="activeTab==='barcode'" class="barcode-form">
-      <p>Scan your barcode using the camera.</p>
-      <button type="button" (click)="startBarcodeScan()">Start Scan</button>
+    <form *ngIf="activeTab==='barcode'" [formGroup]="barcodeForm" (ngSubmit)="submitBarcode()" class="barcode-form">
+      <label>Tracking Number
+        <input formControlName="trackingNumber" />
+      </label>
+      <label>Package Name
+        <input formControlName="packageName" />
+      </label>
+      <input type="file" accept="image/*" (change)="onBarcodeFileSelected($event)" />
+      <button type="button" (click)="startBarcodeScan()">
+        {{ isScanning ? 'Stop Scan' : 'Scan with Webcam' }}
+      </button>
+      <video #videoPreview *ngIf="isScanning" class="webcam-preview" autoplay></video>
+      <button type="submit">Track</button>
+    </form>
+    <div *ngIf="barcodeResult" class="barcode-result">
+      <p *ngIf="barcodeResult.success">Tracked {{ barcodeResult.metadata?.identifier || barcodeResult.data?.tracking_number }}</p>
+      <p *ngIf="!barcodeResult.success">Failed: {{ barcodeResult.error }}</p>
     </div>
   </div>
 </div>

--- a/Frontend/src/app/features/all-tracking-services/all-tracking-services.component.scss
+++ b/Frontend/src/app/features/all-tracking-services/all-tracking-services.component.scss
@@ -54,6 +54,12 @@
   gap: 10px;
 }
 
+.webcam-preview {
+  width: 100%;
+  max-height: 300px;
+  margin-top: 10px;
+}
+
 .error {
   color: #d9534f;
   font-size: 12px;


### PR DESCRIPTION
## Summary
- integrate webcam scan and file upload decoding in AllTrackingServices
- automatically track decoded barcode numbers and show result

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6845884c8750832ea0ee09cd324e41cf