### PR TITLE
Fix duplicate Fedex tracking methods

### DIFF
--- a/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.ts
+++ b/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { ActivatedRoute } from '@angular/router';
 import { TrackingService, TrackingInfo } from '../services/tracking.service';
 import { AnalyticsService } from '../../../core/services/analytics.service';
+import { showNotification } from '../../../shared/services/notification.util';
 
 interface FedexTrackingInfo extends TrackingInfo {
   currentLocation?: {
@@ -112,33 +113,6 @@ export class FedexTrackResultComponent implements OnInit, OnDestroy {
     this.waitForGoogleMaps().then(() => this.initializeMap());
   }
 
-  shareTracking(): void {
-    if (navigator.share && this.trackingData) {
-      navigator.share({
-        title: 'Tracking',
-        text: `Tracking ${this.trackingData.tracking_number}`,
-        url: window.location.href
-      });
-    } else if (this.trackingData?.tracking_number) {
-      navigator.clipboard.writeText(this.trackingData.tracking_number);
-    }
-  }
-
-  printTracking(): void {
-    window.print();
-  }
-
-  saveTracking(): void {
-    if (!this.trackingData?.tracking_number) {
-      return;
-    }
-    const key = 'savedTrackingNumbers';
-    const saved: string[] = JSON.parse(localStorage.getItem(key) || '[]');
-    if (!saved.includes(this.trackingData.tracking_number)) {
-      saved.push(this.trackingData.tracking_number);
-      localStorage.setItem(key, JSON.stringify(saved));
-    }
-  }
 
   getItemClasses(event: any, index: number): string {
     const classes = ['timeline-item'];
@@ -176,16 +150,24 @@ export class FedexTrackResultComponent implements OnInit, OnDestroy {
   }
 
   shareTracking(): void {
-    if (this.trackingData?.tracking_number) {
-      this.analytics.logAction('share_tracking', this.trackingData.tracking_number);
-      console.log('Sharing tracking number', this.trackingData.tracking_number);
+    if (navigator.share && this.trackingData) {
+      navigator.share({
+        title: 'Tracking',
+        text: `Tracking ${this.trackingData.tracking_number}`,
+        url: window.location.href
+      });
+      showNotification('Share dialog opened', 'info');
+    } else if (this.trackingData?.tracking_number) {
+      navigator.clipboard.writeText(this.trackingData.tracking_number);
+      showNotification('Tracking number copied', 'success');
     }
+    this.analytics.logAction('share_tracking', this.trackingData?.tracking_number);
   }
 
   printTracking(): void {
     window.print();
     this.analytics.logAction('print_tracking');
-    console.log('Printing tracking information');
+    showNotification('Printing...', 'info');
   }
 
   saveTracking(): void {
@@ -195,9 +177,9 @@ export class FedexTrackResultComponent implements OnInit, OnDestroy {
       if (!saved.includes(this.trackingData.tracking_number)) {
         saved.push(this.trackingData.tracking_number);
         localStorage.setItem(key, JSON.stringify(saved));
+        showNotification('Tracking saved', 'success');
       }
       this.analytics.logAction('save_tracking', this.trackingData.tracking_number);
-      console.log('Saving tracking number', this.trackingData.tracking_number);
     }
   }
 


### PR DESCRIPTION
## Summary
- deduplicate `shareTracking`, `printTracking` and `saveTracking`
- integrate `AnalyticsService` and `showNotification`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68458cac4698832e829fe9ac771a5c51