### PR TITLE
Improve share, print and save functions

### DIFF
--- a/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.html
+++ b/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.html
@@ -10,9 +10,9 @@
         <div class="description">{{ trackingData.status.description }}</div>
       </div>
       <div class="actions">
-        <button type="button" (click)="shareTracking()">Share</button>
-        <button type="button" (click)="printTracking()">Print</button>
-        <button type="button" (click)="saveTracking()">Save</button>
+        <button type="button" aria-label="Share tracking" (click)="shareTracking()" (keydown.enter)="shareTracking()" (keydown.space)="shareTracking()">Share</button>
+        <button type="button" aria-label="Print tracking" (click)="printTracking()" (keydown.enter)="printTracking()" (keydown.space)="printTracking()">Print</button>
+        <button type="button" aria-label="Save tracking" (click)="saveTracking()" (keydown.enter)="saveTracking()" (keydown.space)="saveTracking()">Save</button>
       </div>
     </div>
 

--- a/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.ts
+++ b/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.ts
@@ -112,33 +112,6 @@ export class FedexTrackResultComponent implements OnInit, OnDestroy {
     this.waitForGoogleMaps().then(() => this.initializeMap());
   }
 
-  shareTracking(): void {
-    if (navigator.share && this.trackingData) {
-      navigator.share({
-        title: 'Tracking',
-        text: `Tracking ${this.trackingData.tracking_number}`,
-        url: window.location.href
-      });
-    } else if (this.trackingData?.tracking_number) {
-      navigator.clipboard.writeText(this.trackingData.tracking_number);
-    }
-  }
-
-  printTracking(): void {
-    window.print();
-  }
-
-  saveTracking(): void {
-    if (!this.trackingData?.tracking_number) {
-      return;
-    }
-    const key = 'savedTrackingNumbers';
-    const saved: string[] = JSON.parse(localStorage.getItem(key) || '[]');
-    if (!saved.includes(this.trackingData.tracking_number)) {
-      saved.push(this.trackingData.tracking_number);
-      localStorage.setItem(key, JSON.stringify(saved));
-    }
-  }
 
   getItemClasses(event: any, index: number): string {
     const classes = ['timeline-item'];
@@ -176,10 +149,25 @@ export class FedexTrackResultComponent implements OnInit, OnDestroy {
   }
 
   shareTracking(): void {
-    if (this.trackingData?.tracking_number) {
-      this.analytics.logAction('share_tracking', this.trackingData.tracking_number);
-      console.log('Sharing tracking number', this.trackingData.tracking_number);
+    const number = this.trackingData?.tracking_number;
+    if (!number) {
+      return;
     }
+
+    if (navigator.share) {
+      navigator
+        .share({
+          title: 'Tracking',
+          text: `Tracking ${number}`,
+          url: window.location.href,
+        })
+        .catch(() => navigator.clipboard.writeText(number));
+    } else {
+      navigator.clipboard.writeText(number);
+    }
+
+    this.analytics.logAction('share_tracking', number);
+    console.log('Sharing tracking number', number);
   }
 
   printTracking(): void {

--- a/Frontend/src/app/features/tracking/track-result/track-result.component.html
+++ b/Frontend/src/app/features/tracking/track-result/track-result.component.html
@@ -39,9 +39,9 @@
         </p>
       </div>
       <div class="summary-actions">
-        <button type="button" (click)="shareTracking()" (keydown.enter)="shareTracking()" (keydown.space)="shareTracking()">Share</button>
-        <button type="button" (click)="printTracking()" (keydown.enter)="printTracking()" (keydown.space)="printTracking()">Print</button>
-        <button type="button" (click)="saveTracking()" (keydown.enter)="saveTracking()" (keydown.space)="saveTracking()">Save</button>
+        <button type="button" aria-label="Share tracking" (click)="shareTracking()" (keydown.enter)="shareTracking()" (keydown.space)="shareTracking()">Share</button>
+        <button type="button" aria-label="Print tracking" (click)="printTracking()" (keydown.enter)="printTracking()" (keydown.space)="printTracking()">Print</button>
+        <button type="button" aria-label="Save tracking" (click)="saveTracking()" (keydown.enter)="saveTracking()" (keydown.space)="saveTracking()">Save</button>
         <button type="button" (click)="copyTracking()">Copier</button>
         <button type="button" (click)="downloadProof()">Télécharger la preuve</button>
         <button type="button" (click)="contactSupport()">Contacter le support</button>

--- a/Frontend/src/app/features/tracking/track-result/track-result.component.ts
+++ b/Frontend/src/app/features/tracking/track-result/track-result.component.ts
@@ -89,17 +89,24 @@ export class TrackResultComponent implements OnInit, OnDestroy {
   }
 
   shareTracking() {
-    if (navigator.share && this.trackingInfo) {
-      navigator.share({
-        title: 'Suivi de colis',
-        text: `Suivi ${this.trackingInfo.tracking_number}`,
-        url: window.location.href,
-      });
-      showNotification('Share dialog opened', 'info');
+    const number = this.trackingInfo?.tracking_number;
+    if (!number) {
+      return;
+    }
+
+    if (navigator.share) {
+      navigator
+        .share({
+          title: 'Suivi de colis',
+          text: `Suivi ${number}`,
+          url: window.location.href,
+        })
+        .catch(() => this.copyTracking());
     } else {
       this.copyTracking();
     }
-    this.analytics.logAction('share_tracking', this.trackingInfo?.tracking_number);
+
+    this.analytics.logAction('share_tracking', number);
   }
 
   downloadProof() {


### PR DESCRIPTION
## Summary
- fix double definitions and update shareTracking for FedEx page
- ensure Web Share API with clipboard fallback
- add aria labels and keyboard handlers in both tracking result views

## Testing
- `pip install -r backend/requirements.txt`
- `npm install` (in `Frontend`)
- `python -m backend.app.init_db`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68458caef820832e893cf0d219b70023