### PR TITLE
Add delivery option dialogs

### DIFF
--- a/Frontend/src/app/features/tracking/change-address-dialog/change-address-dialog.component.html
+++ b/Frontend/src/app/features/tracking/change-address-dialog/change-address-dialog.component.html
@@ -1,0 +1,6 @@
+<h2>Change Delivery Address</h2>
+<p>Contact us to update your delivery address.</p>
+<div class="actions">
+  <button mat-button (click)="cancel()">Cancel</button>
+  <button mat-raised-button color="primary" (click)="confirm()">Confirm</button>
+</div>

--- a/Frontend/src/app/features/tracking/change-address-dialog/change-address-dialog.component.scss
+++ b/Frontend/src/app/features/tracking/change-address-dialog/change-address-dialog.component.scss
@@ -1,0 +1,6 @@
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}

--- a/Frontend/src/app/features/tracking/change-address-dialog/change-address-dialog.component.ts
+++ b/Frontend/src/app/features/tracking/change-address-dialog/change-address-dialog.component.ts
@@ -1,0 +1,23 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatDialogRef, MatDialogModule } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+
+@Component({
+  selector: 'app-change-address-dialog',
+  standalone: true,
+  imports: [CommonModule, MatDialogModule, MatButtonModule],
+  templateUrl: './change-address-dialog.component.html',
+  styleUrls: ['./change-address-dialog.component.scss']
+})
+export class ChangeAddressDialogComponent {
+  constructor(public dialogRef: MatDialogRef<ChangeAddressDialogComponent>) {}
+
+  confirm(): void {
+    this.dialogRef.close(true);
+  }
+
+  cancel(): void {
+    this.dialogRef.close();
+  }
+}

--- a/Frontend/src/app/features/tracking/delivery-instructions-dialog/delivery-instructions-dialog.component.html
+++ b/Frontend/src/app/features/tracking/delivery-instructions-dialog/delivery-instructions-dialog.component.html
@@ -1,0 +1,6 @@
+<h2>Add Delivery Instructions</h2>
+<p>Leave special instructions for the courier.</p>
+<div class="actions">
+  <button mat-button (click)="cancel()">Cancel</button>
+  <button mat-raised-button color="primary" (click)="confirm()">Confirm</button>
+</div>

--- a/Frontend/src/app/features/tracking/delivery-instructions-dialog/delivery-instructions-dialog.component.scss
+++ b/Frontend/src/app/features/tracking/delivery-instructions-dialog/delivery-instructions-dialog.component.scss
@@ -1,0 +1,6 @@
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}

--- a/Frontend/src/app/features/tracking/delivery-instructions-dialog/delivery-instructions-dialog.component.ts
+++ b/Frontend/src/app/features/tracking/delivery-instructions-dialog/delivery-instructions-dialog.component.ts
@@ -1,0 +1,23 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatDialogRef, MatDialogModule } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+
+@Component({
+  selector: 'app-delivery-instructions-dialog',
+  standalone: true,
+  imports: [CommonModule, MatDialogModule, MatButtonModule],
+  templateUrl: './delivery-instructions-dialog.component.html',
+  styleUrls: ['./delivery-instructions-dialog.component.scss']
+})
+export class DeliveryInstructionsDialogComponent {
+  constructor(public dialogRef: MatDialogRef<DeliveryInstructionsDialogComponent>) {}
+
+  confirm(): void {
+    this.dialogRef.close(true);
+  }
+
+  cancel(): void {
+    this.dialogRef.close();
+  }
+}

--- a/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.html
+++ b/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.html
@@ -16,6 +16,21 @@
       </div>
     </div>
 
+    <div class="options">
+      <mat-card class="option-card" (click)="openScheduleDelivery()">
+        Schedule Delivery
+      </mat-card>
+      <mat-card class="option-card" (click)="openChangeAddress()">
+        Change Address
+      </mat-card>
+      <mat-card class="option-card" (click)="openHoldLocation()">
+        Hold at Location
+      </mat-card>
+      <mat-card class="option-card" (click)="openDeliveryInstructions()">
+        Delivery Instructions
+      </mat-card>
+    </div>
+
     <div class="grid">
       <div id="fedex-map" class="map"></div>
       <div class="timeline" *ngIf="trackingData.tracking_history?.length">

--- a/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.scss
+++ b/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.scss
@@ -102,6 +102,27 @@
   color: #666;
 }
 
+.options {
+  margin-top: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.option-card {
+  flex: 1 1 calc(50% - 0.5rem);
+  text-align: center;
+  cursor: pointer;
+  padding: 1rem;
+  background: #fff;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.option-card:hover {
+  background: #f3f3f3;
+}
+
 @keyframes pulse {
   0% {
     transform: scale(1);

--- a/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.ts
+++ b/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.ts
@@ -3,6 +3,14 @@ import { CommonModule } from '@angular/common';
 import { ActivatedRoute } from '@angular/router';
 import { TrackingService, TrackingInfo } from '../services/tracking.service';
 import { AnalyticsService } from '../../../core/services/analytics.service';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { ScheduleDeliveryDialogComponent } from '../schedule-delivery-dialog/schedule-delivery-dialog.component';
+import { ChangeAddressDialogComponent } from '../change-address-dialog/change-address-dialog.component';
+import { HoldLocationDialogComponent } from '../hold-location-dialog/hold-location-dialog.component';
+import { DeliveryInstructionsDialogComponent } from '../delivery-instructions-dialog/delivery-instructions-dialog.component';
+import { showNotification } from '../../../shared/services/notification.util';
 
 interface FedexTrackingInfo extends TrackingInfo {
   currentLocation?: {
@@ -14,7 +22,16 @@ interface FedexTrackingInfo extends TrackingInfo {
 @Component({
   selector: 'app-fedex-track-result',
   standalone: true,
-  imports: [CommonModule],
+  imports: [
+    CommonModule,
+    MatButtonModule,
+    MatDialogModule,
+    MatCardModule,
+    ScheduleDeliveryDialogComponent,
+    ChangeAddressDialogComponent,
+    HoldLocationDialogComponent,
+    DeliveryInstructionsDialogComponent
+  ],
   templateUrl: './fedex-track-result.component.html',
   styleUrls: ['./fedex-track-result.component.scss']
 })
@@ -31,7 +48,8 @@ export class FedexTrackResultComponent implements OnInit, OnDestroy {
   constructor(
     private route: ActivatedRoute,
     private trackingService: TrackingService,
-    private analytics: AnalyticsService
+    private analytics: AnalyticsService,
+    private dialog: MatDialog
   ) {}
 
   ngOnInit(): void {
@@ -201,9 +219,30 @@ export class FedexTrackResultComponent implements OnInit, OnDestroy {
     }
   }
 
-  openDialog(name: string): void {
-    this.analytics.logAction('open_dialog', name);
-    console.log('Opening dialog', name);
+  private openAndNotify(component: any, action: string, message: string): void {
+    const ref = this.dialog.open(component);
+    ref.afterClosed().subscribe(result => {
+      if (result) {
+        this.analytics.logAction(action);
+        showNotification(message, 'success');
+      }
+    });
+  }
+
+  openScheduleDelivery(): void {
+    this.openAndNotify(ScheduleDeliveryDialogComponent, 'schedule_delivery', 'Delivery scheduled');
+  }
+
+  openChangeAddress(): void {
+    this.openAndNotify(ChangeAddressDialogComponent, 'change_address', 'Address change requested');
+  }
+
+  openHoldLocation(): void {
+    this.openAndNotify(HoldLocationDialogComponent, 'hold_location', 'Hold request submitted');
+  }
+
+  openDeliveryInstructions(): void {
+    this.openAndNotify(DeliveryInstructionsDialogComponent, 'delivery_instructions', 'Instructions saved');
   }
 
   exportData(): void {

--- a/Frontend/src/app/features/tracking/hold-location-dialog/hold-location-dialog.component.html
+++ b/Frontend/src/app/features/tracking/hold-location-dialog/hold-location-dialog.component.html
@@ -1,0 +1,6 @@
+<h2>Hold at Location</h2>
+<p>We'll hold your package at a nearby location for pickup.</p>
+<div class="actions">
+  <button mat-button (click)="cancel()">Cancel</button>
+  <button mat-raised-button color="primary" (click)="confirm()">Confirm</button>
+</div>

--- a/Frontend/src/app/features/tracking/hold-location-dialog/hold-location-dialog.component.scss
+++ b/Frontend/src/app/features/tracking/hold-location-dialog/hold-location-dialog.component.scss
@@ -1,0 +1,6 @@
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}

--- a/Frontend/src/app/features/tracking/hold-location-dialog/hold-location-dialog.component.ts
+++ b/Frontend/src/app/features/tracking/hold-location-dialog/hold-location-dialog.component.ts
@@ -1,0 +1,23 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatDialogRef, MatDialogModule } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+
+@Component({
+  selector: 'app-hold-location-dialog',
+  standalone: true,
+  imports: [CommonModule, MatDialogModule, MatButtonModule],
+  templateUrl: './hold-location-dialog.component.html',
+  styleUrls: ['./hold-location-dialog.component.scss']
+})
+export class HoldLocationDialogComponent {
+  constructor(public dialogRef: MatDialogRef<HoldLocationDialogComponent>) {}
+
+  confirm(): void {
+    this.dialogRef.close(true);
+  }
+
+  cancel(): void {
+    this.dialogRef.close();
+  }
+}

--- a/Frontend/src/app/features/tracking/schedule-delivery-dialog/schedule-delivery-dialog.component.html
+++ b/Frontend/src/app/features/tracking/schedule-delivery-dialog/schedule-delivery-dialog.component.html
@@ -1,0 +1,6 @@
+<h2>Schedule Delivery</h2>
+<p>Select a convenient delivery date with our customer service.</p>
+<div class="actions">
+  <button mat-button (click)="cancel()">Cancel</button>
+  <button mat-raised-button color="primary" (click)="confirm()">Confirm</button>
+</div>

--- a/Frontend/src/app/features/tracking/schedule-delivery-dialog/schedule-delivery-dialog.component.scss
+++ b/Frontend/src/app/features/tracking/schedule-delivery-dialog/schedule-delivery-dialog.component.scss
@@ -1,0 +1,6 @@
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}

--- a/Frontend/src/app/features/tracking/schedule-delivery-dialog/schedule-delivery-dialog.component.ts
+++ b/Frontend/src/app/features/tracking/schedule-delivery-dialog/schedule-delivery-dialog.component.ts
@@ -1,0 +1,23 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatDialogRef, MatDialogModule } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+
+@Component({
+  selector: 'app-schedule-delivery-dialog',
+  standalone: true,
+  imports: [CommonModule, MatDialogModule, MatButtonModule],
+  templateUrl: './schedule-delivery-dialog.component.html',
+  styleUrls: ['./schedule-delivery-dialog.component.scss']
+})
+export class ScheduleDeliveryDialogComponent {
+  constructor(public dialogRef: MatDialogRef<ScheduleDeliveryDialogComponent>) {}
+
+  confirm(): void {
+    this.dialogRef.close(true);
+  }
+
+  cancel(): void {
+    this.dialogRef.close();
+  }
+}


### PR DESCRIPTION
## Summary
- add schedule, change address, hold location and delivery instruction dialogs
- open these dialogs from FedEx tracking results
- show notifications when confirming

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68458cb36ac4832e8642166ae81e72a8