### PR TITLE
Add dialog buttons and export features

### DIFF
--- a/Frontend/src/app/features/tracking/fedex-track-result/change-address-dialog.component.ts
+++ b/Frontend/src/app/features/tracking/fedex-track-result/change-address-dialog.component.ts
@@ -1,0 +1,21 @@
+import { Component } from '@angular/core';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-change-address-dialog',
+  standalone: true,
+  imports: [CommonModule, MatDialogModule],
+  template: `
+    <h1 mat-dialog-title>Change Delivery Address</h1>
+    <div mat-dialog-content>
+      <p>This feature will allow updating the destination address.</p>
+    </div>
+    <div mat-dialog-actions>
+      <button mat-button mat-dialog-close>Close</button>
+    </div>
+  `
+})
+export class ChangeAddressDialogComponent {
+  constructor(public dialogRef: MatDialogRef<ChangeAddressDialogComponent>) {}
+}

--- a/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.html
+++ b/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.html
@@ -38,6 +38,10 @@
         <button type="button" (click)="shareTracking()">Share</button>
         <button type="button" (click)="printTracking()">Print</button>
         <button type="button" (click)="saveTracking()">Save</button>
+        <button type="button" (click)="openDialog('schedule')">Schedule</button>
+        <button type="button" (click)="openDialog('change-address')">Change Address</button>
+        <button type="button" (click)="exportData('pdf')">Export PDF</button>
+        <button type="button" (click)="exportData('csv')">Export CSV</button>
       </div>
     </div>
 

--- a/Frontend/src/app/features/tracking/fedex-track-result/schedule-dialog.component.ts
+++ b/Frontend/src/app/features/tracking/fedex-track-result/schedule-dialog.component.ts
@@ -1,0 +1,21 @@
+import { Component } from '@angular/core';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-schedule-dialog',
+  standalone: true,
+  imports: [CommonModule, MatDialogModule],
+  template: `
+    <h1 mat-dialog-title>Schedule Delivery</h1>
+    <div mat-dialog-content>
+      <p>Scheduling options will be available here.</p>
+    </div>
+    <div mat-dialog-actions>
+      <button mat-button mat-dialog-close>Close</button>
+    </div>
+  `
+})
+export class ScheduleDialogComponent {
+  constructor(public dialogRef: MatDialogRef<ScheduleDialogComponent>) {}
+}

--- a/Frontend/src/app/features/tracking/services/tracking.service.ts
+++ b/Frontend/src/app/features/tracking/services/tracking.service.ts
@@ -42,6 +42,11 @@ export class TrackingService {
     return this.http.get(`${this.baseUrl}/export`, { responseType: 'blob' });
   }
 
+  exportTracking(identifier: string, format: string): Observable<Blob> {
+    const url = `${this.baseUrl}/${identifier}/export?format=${format}`;
+    return this.http.get(url, { responseType: 'blob' });
+  }
+
   downloadProof(trackingNumber: string): Observable<Blob> {
     const url = `${this.baseUrl}/${trackingNumber}/proof`;
     return this.http.get(url, { responseType: 'blob' });


### PR DESCRIPTION
## Summary
- add buttons on the FedEx tracking page for scheduling and address changes
- provide Export PDF/CSV options
- open Angular Material dialogs for schedule and change address
- implement export API call in tracking service

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q` *(fails: ValueError a coroutine was expected)*

------
https://chatgpt.com/codex/tasks/task_e_6845936f7724832ea4c49084c01c509d