### PR TITLE
Add accessibility attributes and keyboard handlers

### DIFF
--- a/Frontend/src/app/features/notifications/notifications.component.html
+++ b/Frontend/src/app/features/notifications/notifications.component.html
@@ -1,6 +1,12 @@
 <div class="notifications">
   <h2>Notifications</h2>
-  <button (click)="markAllAsRead()" [disabled]="notifications.length === 0">Mark all as read</button>
+  <button role="button"
+          tabindex="0"
+          aria-label="Mark all notifications as read"
+          (click)="markAllAsRead()"
+          (keydown.enter)="markAllAsRead()"
+          (keydown.space)="markAllAsRead()"
+          [disabled]="notifications.length === 0">Mark all as read</button>
   <div *ngIf="loading">Loading...</div>
   <ul *ngIf="!loading && notifications.length">
     <li *ngFor="let notif of notifications">

--- a/Frontend/src/app/features/notifications/notifications.component.scss
+++ b/Frontend/src/app/features/notifications/notifications.component.scss
@@ -16,3 +16,8 @@
   border-bottom: 1px solid #ccc;
   padding-bottom: 0.5rem;
 }
+
+.notifications button:focus {
+  outline: 2px solid #4d148c;
+  outline-offset: 2px;
+}

--- a/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.html
+++ b/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.html
@@ -35,9 +35,27 @@
         </p>
       </div>
       <div class="summary-actions">
-        <button type="button" (click)="shareTracking()">Share</button>
-        <button type="button" (click)="printTracking()">Print</button>
-        <button type="button" (click)="saveTracking()">Save</button>
+        <button type="button"
+                role="button"
+                tabindex="0"
+                aria-label="Share tracking details"
+                (click)="shareTracking()"
+                (keydown.enter)="shareTracking()"
+                (keydown.space)="shareTracking()">Share</button>
+        <button type="button"
+                role="button"
+                tabindex="0"
+                aria-label="Print tracking details"
+                (click)="printTracking()"
+                (keydown.enter)="printTracking()"
+                (keydown.space)="printTracking()">Print</button>
+        <button type="button"
+                role="button"
+                tabindex="0"
+                aria-label="Save tracking number"
+                (click)="saveTracking()"
+                (keydown.enter)="saveTracking()"
+                (keydown.space)="saveTracking()">Save</button>
       </div>
     </div>
 

--- a/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.scss
+++ b/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.scss
@@ -175,6 +175,11 @@
   padding: 0.5rem 0.75rem;
   border-radius: 4px;
   cursor: pointer;
+
+  &:focus {
+    outline: 2px solid #4d148c;
+    outline-offset: 2px;
+  }
 }
 
 /* Timeline styling */


### PR DESCRIPTION
## Summary
- add role/aria/tabindex and keyboard handlers to FedEx result actions
- add focus styles for FedEx result buttons
- make notification button accessible with key handlers
- add focus style for notification button

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: email-validator, sqlalchemy errors, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684593725fac832e861abbd21910b289