### PR TITLE
Update shareTracking to copy link

### DIFF
--- a/Frontend/src/app/features/tracking/track-result/track-result.component.ts
+++ b/Frontend/src/app/features/tracking/track-result/track-result.component.ts
@@ -97,7 +97,8 @@ export class TrackResultComponent implements OnInit, OnDestroy {
       });
       showNotification('Share dialog opened', 'info');
     } else {
-      this.copyTracking();
+      navigator.clipboard.writeText(window.location.href);
+      showNotification('Link copied', 'success');
     }
     this.analytics.logAction('share_tracking', this.trackingInfo?.tracking_number);
   }


### PR DESCRIPTION
## Summary
- handle copying the current URL when the Web Share API isn't available

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test --silent` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684593797044832e8069d5d4be08916f