### PR TITLE
Add tracking sections and footer

### DIFF
--- a/Frontend/src/app/features/home/home.component.html
+++ b/Frontend/src/app/features/home/home.component.html
@@ -128,6 +128,9 @@
   </div>
 </div>
 
+<app-tracking-options></app-tracking-options>
+<app-tracking-mobile></app-tracking-mobile>
+<app-footer></app-footer>
 <!-- =======================
 🚀 SERVICES SECTION
 ======================= -->

--- a/Frontend/src/app/features/home/home.component.ts
+++ b/Frontend/src/app/features/home/home.component.ts
@@ -13,6 +13,9 @@ import { Subject, Observable } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { BrowserCodeReader, IScannerControls, BrowserMultiFormatReader } from '@zxing/browser';
 import { BarcodeUploadComponent } from '../barcode-upload/barcode-upload.component';
+import { TrackingOptionsComponent } from '../../shared/components/tracking-options/tracking-options.component';
+import { TrackingMobileComponent } from '../../shared/components/tracking-mobile/tracking-mobile.component';
+import { FooterComponent } from '../../shared/components/footer/footer.component';
 
 // Import Google Maps types
 declare global {
@@ -70,7 +73,16 @@ interface ServiceItem {
 @Component({
   selector: 'app-home',
   standalone: true,
-  imports: [CommonModule, FormsModule, ReactiveFormsModule, RouterModule, BarcodeUploadComponent],
+  imports: [
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+    RouterModule,
+    BarcodeUploadComponent,
+    TrackingOptionsComponent,
+    TrackingMobileComponent,
+    FooterComponent
+  ],
   templateUrl: './home.component.html',
   styleUrls: ['./home.component.scss'],
   animations: [

--- a/Frontend/src/app/shared/components/footer/footer.component.html
+++ b/Frontend/src/app/shared/components/footer/footer.component.html
@@ -1,0 +1,10 @@
+<footer class="footer">
+  <div class="container">
+    <div class="footer-links">
+      <a routerLink="/about">About</a>
+      <a routerLink="/help">Help</a>
+      <a routerLink="/contact">Contact</a>
+    </div>
+    <p class="copyright">© 2024 Globex</p>
+  </div>
+</footer>

--- a/Frontend/src/app/shared/components/footer/footer.component.scss
+++ b/Frontend/src/app/shared/components/footer/footer.component.scss
@@ -1,0 +1,25 @@
+@use "sass:color";
+
+$primary-color: #4D148C;
+$text-color: #333;
+
+.footer {
+  background: $primary-color;
+  color: white;
+  padding: 2rem 0;
+  text-align: center;
+
+  .footer-links {
+    margin-bottom: 1rem;
+
+    a {
+      color: white;
+      margin: 0 0.5rem;
+      text-decoration: none;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
+}

--- a/Frontend/src/app/shared/components/footer/footer.component.ts
+++ b/Frontend/src/app/shared/components/footer/footer.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+
+@Component({
+  selector: 'app-footer',
+  standalone: true,
+  imports: [CommonModule, RouterModule],
+  templateUrl: './footer.component.html',
+  styleUrls: ['./footer.component.scss']
+})
+export class FooterComponent {}

--- a/Frontend/src/app/shared/components/tracking-mobile/tracking-mobile.component.html
+++ b/Frontend/src/app/shared/components/tracking-mobile/tracking-mobile.component.html
@@ -1,0 +1,12 @@
+<section class="mobile-tracking">
+  <div class="container">
+    <div class="mobile-info">
+      <h2 class="section-title">Track on the go</h2>
+      <p>Download our mobile app to manage your shipments anywhere.</p>
+      <div class="app-links">
+        <img src="/assets/app-store-badge.png" alt="App Store">
+        <img src="/assets/google-play-badge.png" alt="Google Play">
+      </div>
+    </div>
+  </div>
+</section>

--- a/Frontend/src/app/shared/components/tracking-mobile/tracking-mobile.component.scss
+++ b/Frontend/src/app/shared/components/tracking-mobile/tracking-mobile.component.scss
@@ -1,0 +1,28 @@
+@use "sass:color";
+
+$primary-color: #4D148C;
+$secondary-color: #FF6200;
+$text-color: #333;
+$light-gray: #f5f5f5;
+
+.mobile-tracking {
+  padding: 60px 0;
+  background: white;
+
+  .mobile-info {
+    text-align: center;
+    max-width: 600px;
+    margin: 0 auto;
+  }
+
+  .app-links {
+    margin-top: 1rem;
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+
+    img {
+      height: 40px;
+    }
+  }
+}

--- a/Frontend/src/app/shared/components/tracking-mobile/tracking-mobile.component.ts
+++ b/Frontend/src/app/shared/components/tracking-mobile/tracking-mobile.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-tracking-mobile',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './tracking-mobile.component.html',
+  styleUrls: ['./tracking-mobile.component.scss']
+})
+export class TrackingMobileComponent {}

--- a/Frontend/src/app/shared/components/tracking-options/tracking-options.component.html
+++ b/Frontend/src/app/shared/components/tracking-options/tracking-options.component.html
@@ -1,0 +1,22 @@
+<section class="tracking-options">
+  <div class="container">
+    <h2 class="section-title">Tracking Options</h2>
+    <div class="options">
+      <div class="option">
+        <h3>Advanced Shipment Tracking</h3>
+        <p>Get detailed information about your shipments.</p>
+        <a routerLink="/advanced-shipment-tracking" class="link">Advanced Tracking</a>
+      </div>
+      <div class="option">
+        <h3>Track by Email</h3>
+        <p>Receive status updates directly in your inbox.</p>
+        <a routerLink="/track-by-mail" class="link">Track by Email</a>
+      </div>
+      <div class="option">
+        <h3>Notification Options</h3>
+        <p>Set up email or SMS notifications for your packages.</p>
+        <a routerLink="/services/notifications" class="link">Notification Services</a>
+      </div>
+    </div>
+  </div>
+</section>

--- a/Frontend/src/app/shared/components/tracking-options/tracking-options.component.scss
+++ b/Frontend/src/app/shared/components/tracking-options/tracking-options.component.scss
@@ -1,0 +1,45 @@
+@use "sass:color";
+
+$primary-color: #4D148C;
+$secondary-color: #FF6200;
+$text-color: #333;
+$light-gray: #f5f5f5;
+$border-color: #e0e0e0;
+
+.tracking-options {
+  padding: 60px 0;
+  background: $light-gray;
+
+  .options {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 1.5rem;
+  }
+
+  .option {
+    background: white;
+    border: 1px solid $border-color;
+    border-radius: 8px;
+    padding: 1.5rem;
+    text-align: center;
+
+    h3 {
+      color: $primary-color;
+      margin-bottom: 0.5rem;
+    }
+
+    p {
+      color: $text-color;
+      margin-bottom: 1rem;
+    }
+
+    .link {
+      color: $secondary-color;
+      text-decoration: none;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
+}

--- a/Frontend/src/app/shared/components/tracking-options/tracking-options.component.ts
+++ b/Frontend/src/app/shared/components/tracking-options/tracking-options.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+
+@Component({
+  selector: 'app-tracking-options',
+  standalone: true,
+  imports: [CommonModule, RouterModule],
+  templateUrl: './tracking-options.component.html',
+  styleUrls: ['./tracking-options.component.scss']
+})
+export class TrackingOptionsComponent {}


### PR DESCRIPTION
## Summary
- create tracking options, mobile tracking and footer components
- embed them in the home component

## Testing
- `pytest` *(fails: ValueError in test_fedex_service)*
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: Chrome binary missing)*

------
https://chatgpt.com/codex/tasks/task_e_684593801240832ea211790936c32720