### PR TITLE
Add tracking history feature

### DIFF
--- a/Frontend/src/app/features/history/history.component.ts
+++ b/Frontend/src/app/features/history/history.component.ts
@@ -16,7 +16,7 @@ export class HistoryComponent implements OnInit {
   constructor(private historyService: TrackingHistoryService) {}
 
   ngOnInit(): void {
-    this.loadHistory();
+    this.historyService.syncWithServer().then(() => this.loadHistory());
   }
 
   private loadHistory(): void {

--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter
-from .endpoints import tracking, notifications, colis
+from .endpoints import tracking, notifications, colis, history
 
 api_router = APIRouter(prefix="/api/v1")
 
@@ -19,4 +19,10 @@ api_router.include_router(
     colis.router,
     prefix="/colis",
     tags=["colis"]
-) 
+)
+
+api_router.include_router(
+    history.router,
+    prefix="/history",
+    tags=["history"]
+)

--- a/backend/app/api/v1/endpoints/__init__.py
+++ b/backend/app/api/v1/endpoints/__init__.py
@@ -1,3 +1,3 @@
-from . import notifications, tracking
+from . import notifications, tracking, colis, history
 
-__all__ = ["notifications", "tracking"]
+__all__ = ["notifications", "tracking", "colis", "history"]

--- a/backend/app/api/v1/endpoints/history.py
+++ b/backend/app/api/v1/endpoints/history.py
@@ -1,0 +1,18 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from ....services.auth import get_current_active_user
+from ....database import get_db
+from ....models.user import UserDB
+from ....services.tracking_history_service import TrackingHistoryService
+from ....models.tracking_history import TrackedShipment
+
+router = APIRouter()
+
+@router.get("/", response_model=list[TrackedShipment])
+async def get_history(
+    current_user: UserDB = Depends(get_current_active_user),
+    db: Session = Depends(get_db)
+):
+    service = TrackingHistoryService(db)
+    records = service.get_history(current_user.id)
+    return records

--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, String, Boolean, DateTime, JSON, Enum as SQLEnum, ForeignKey, Float
+from sqlalchemy import Column, String, Boolean, DateTime, JSON, Enum as SQLEnum, ForeignKey, Float, Integer
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
 from datetime import datetime
@@ -122,3 +122,13 @@ class TrackingDB(Base):
     events = relationship("TrackingEventDB", back_populates="tracking")
     package_details = relationship("PackageDetailsDB", back_populates="tracking", uselist=False)
     delivery_details = relationship("DeliveryDetailsDB", back_populates="tracking", uselist=False)
+
+
+class TrackedShipmentDB(Base):
+    __tablename__ = "tracked_shipments"
+
+    id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
+    user_id = Column(Integer, nullable=False)
+    tracking_number = Column(String, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+

--- a/backend/app/models/tracking_history.py
+++ b/backend/app/models/tracking_history.py
@@ -1,0 +1,10 @@
+from datetime import datetime
+from pydantic import BaseModel
+
+class TrackedShipment(BaseModel):
+    id: str
+    tracking_number: str
+    created_at: datetime
+
+    class Config:
+        from_attributes = True

--- a/backend/app/services/tracking_history_service.py
+++ b/backend/app/services/tracking_history_service.py
@@ -1,0 +1,26 @@
+import logging
+from sqlalchemy.orm import Session
+from ..models.database import TrackedShipmentDB
+
+logger = logging.getLogger(__name__)
+
+class TrackingHistoryService:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def log_search(self, user_id: int, tracking_number: str) -> None:
+        try:
+            record = TrackedShipmentDB(user_id=user_id, tracking_number=tracking_number)
+            self.db.add(record)
+            self.db.commit()
+        except Exception as e:
+            self.db.rollback()
+            logger.error(f"Failed to log tracking search: {e}")
+
+    def get_history(self, user_id: int):
+        return (
+            self.db.query(TrackedShipmentDB)
+            .filter(TrackedShipmentDB.user_id == user_id)
+            .order_by(TrackedShipmentDB.created_at.desc())
+            .all()
+        )

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -2,6 +2,7 @@ import os
 import sys
 import asyncio
 import pytest
+from starlette.requests import Request
 
 # Set required env vars before importing the app modules
 os.environ.setdefault('DATABASE_URL', 'sqlite:///:memory:')
@@ -52,6 +53,15 @@ def test_track_package_by_id(db_session, monkeypatch):
     colis_id = setup_colis(db_session, monkeypatch)
     monkeypatch.setattr(tracking_router, "FedExService", DummyFedExService)
 
-    resp = asyncio.run(tracking_router.track_package(colis_id, db_session))
+    scope = {
+        "type": "http",
+        "headers": [],
+        "query_string": b"",
+        "path": "/",
+        "scheme": "http",
+        "server": ("testserver", 80),
+    }
+    req = Request(scope)
+    resp = asyncio.run(tracking_router.track_package(colis_id, req, db_session))
     assert resp.success is True
     assert resp.metadata["identifier"] == colis_id


### PR DESCRIPTION
## Summary
- log tracked shipments with new `TrackedShipmentDB` model
- add service and endpoint to list search history
- record history when tracking packages
- sync history to frontend when logged in

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845938371b8832e91772e4a795a66db