### PR TITLE
Implement actual forms for FedEx dialogs

### DIFF
--- a/Frontend/src/app/features/tracking/fedex-track-result/change-address-dialog.component.ts
+++ b/Frontend/src/app/features/tracking/fedex-track-result/change-address-dialog.component.ts
@@ -1,21 +1,75 @@
 import { Component } from '@angular/core';
 import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { showNotification } from '../../../shared/services/notification.util';
 
 @Component({
   selector: 'app-change-address-dialog',
   standalone: true,
-  imports: [CommonModule, MatDialogModule],
+  imports: [CommonModule, MatDialogModule, ReactiveFormsModule],
   template: `
     <h1 mat-dialog-title>Change Delivery Address</h1>
-    <div mat-dialog-content>
-      <p>This feature will allow updating the destination address.</p>
-    </div>
-    <div mat-dialog-actions>
-      <button mat-button mat-dialog-close>Close</button>
-    </div>
+    <form [formGroup]="form" (ngSubmit)="confirm()">
+      <div mat-dialog-content>
+        <label>
+          Name
+          <input formControlName="name" />
+        </label>
+        <div class="error" *ngIf="form.get('name')?.touched && form.get('name')?.invalid">
+          Name required
+        </div>
+        <label>
+          Street
+          <input formControlName="street" />
+        </label>
+        <div class="error" *ngIf="form.get('street')?.touched && form.get('street')?.invalid">
+          Street required
+        </div>
+        <label>
+          City
+          <input formControlName="city" />
+        </label>
+        <div class="error" *ngIf="form.get('city')?.touched && form.get('city')?.invalid">
+          City required
+        </div>
+        <label>
+          Postal Code
+          <input formControlName="postal" />
+        </label>
+        <div class="error" *ngIf="form.get('postal')?.touched && form.get('postal')?.invalid">
+          Postal code required
+        </div>
+      </div>
+      <div mat-dialog-actions>
+        <button mat-button type="button" (click)="close()">Cancel</button>
+        <button mat-button color="primary" type="submit">Save</button>
+      </div>
+    </form>
   `
 })
 export class ChangeAddressDialogComponent {
-  constructor(public dialogRef: MatDialogRef<ChangeAddressDialogComponent>) {}
+  form: FormGroup;
+
+  constructor(public dialogRef: MatDialogRef<ChangeAddressDialogComponent>, private fb: FormBuilder) {
+    this.form = this.fb.group({
+      name: ['', Validators.required],
+      street: ['', Validators.required],
+      city: ['', Validators.required],
+      postal: ['', Validators.required]
+    });
+  }
+
+  confirm(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+    showNotification('Address updated', 'success');
+    this.dialogRef.close(this.form.value);
+  }
+
+  close(): void {
+    this.dialogRef.close();
+  }
 }

--- a/Frontend/src/app/features/tracking/fedex-track-result/schedule-dialog.component.ts
+++ b/Frontend/src/app/features/tracking/fedex-track-result/schedule-dialog.component.ts
@@ -1,21 +1,59 @@
 import { Component } from '@angular/core';
 import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { showNotification } from '../../../shared/services/notification.util';
 
 @Component({
   selector: 'app-schedule-dialog',
   standalone: true,
-  imports: [CommonModule, MatDialogModule],
+  imports: [CommonModule, MatDialogModule, ReactiveFormsModule],
   template: `
     <h1 mat-dialog-title>Schedule Delivery</h1>
-    <div mat-dialog-content>
-      <p>Scheduling options will be available here.</p>
-    </div>
-    <div mat-dialog-actions>
-      <button mat-button mat-dialog-close>Close</button>
-    </div>
+    <form [formGroup]="form" (ngSubmit)="confirm()">
+      <div mat-dialog-content>
+        <label>
+          Date
+          <input type="date" formControlName="date" />
+        </label>
+        <div class="error" *ngIf="form.get('date')?.touched && form.get('date')?.invalid">
+          Date required
+        </div>
+        <label>
+          Time
+          <input type="time" formControlName="time" />
+        </label>
+        <div class="error" *ngIf="form.get('time')?.touched && form.get('time')?.invalid">
+          Time required
+        </div>
+      </div>
+      <div mat-dialog-actions>
+        <button mat-button type="button" (click)="close()">Cancel</button>
+        <button mat-button color="primary" type="submit">Confirm</button>
+      </div>
+    </form>
   `
 })
 export class ScheduleDialogComponent {
-  constructor(public dialogRef: MatDialogRef<ScheduleDialogComponent>) {}
+  form: FormGroup;
+
+  constructor(public dialogRef: MatDialogRef<ScheduleDialogComponent>, private fb: FormBuilder) {
+    this.form = this.fb.group({
+      date: ['', Validators.required],
+      time: ['', Validators.required]
+    });
+  }
+
+  confirm(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+    showNotification('Schedule saved', 'success');
+    this.dialogRef.close(this.form.value);
+  }
+
+  close(): void {
+    this.dialogRef.close();
+  }
 }


### PR DESCRIPTION
## Summary
- implement schedule form with date/time fields
- implement change address form with validations
- display success notifications on confirmation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684599277f18832eb88b89f06b7c90dc