### PR TITLE
Improve FedEx progress bar display

### DIFF
--- a/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.html
+++ b/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.html
@@ -51,6 +51,24 @@
       <p class="text-sm text-gray-600">{{ trackingData.status.description }}</p>
     </div>
 
+    <div class="progress-container mb-6">
+      <div class="progress-line">
+        <div class="progress-line-fill" [style.width]="progressWidth"></div>
+      </div>
+      <div class="progress-steps">
+        <div
+          *ngFor="let step of progressSteps; let i = index"
+          class="progress-step"
+          [ngClass]="getProgressClasses(i)"
+        >
+          <div class="step-icon">
+            <span class="material-icons">{{ progressIcons[i] }}</span>
+          </div>
+          <div class="step-label">{{ step }}</div>
+        </div>
+      </div>
+    </div>
+
     <div class="grid grid-cols-2 gap-4 mb-4" *ngIf="trackingData.origin || trackingData.destination">
       <div *ngIf="trackingData.origin">
         <h3 class="font-bold mb-2">Origine</h3>

--- a/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.scss
+++ b/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.scss
@@ -177,6 +177,68 @@
   cursor: pointer;
 }
 
+/* Progress bar */
+.progress-container {
+  position: relative;
+  margin-top: 1rem;
+}
+
+.progress-line {
+  position: absolute;
+  top: 1.25rem;
+  left: 0;
+  right: 0;
+  height: 4px;
+  background: #e5e7eb;
+  border-radius: 2px;
+}
+
+.progress-line-fill {
+  height: 100%;
+  background: #4d148c;
+  width: 0;
+  transition: width 0.3s ease;
+  border-radius: 2px;
+}
+
+.progress-steps {
+  display: flex;
+  justify-content: space-between;
+  position: relative;
+}
+
+.progress-step {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 20%;
+  text-align: center;
+}
+
+.step-icon {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  background: #e5e7eb;
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 0.25rem;
+}
+
+.progress-step.completed .step-icon {
+  background: #4d148c;
+}
+
+.progress-step.current .step-icon {
+  background: #ff6600;
+}
+
+.progress-step.exception .step-icon {
+  background: #dc2626;
+}
+
 /* Timeline styling */
 .timeline {
   position: relative;

--- a/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.ts
+++ b/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.ts
@@ -40,9 +40,11 @@ export class FedexTrackResultComponent implements OnInit, OnDestroy {
   private identifier = '';
 
   // Progress bar related
-  progressSteps = ['Pending', 'In Transit', 'Delivered'];
+  progressSteps = ['Order Processed', 'Picked Up', 'In Transit', 'Out for Delivery', 'Delivered'];
+  progressIcons = ['receipt_long', 'inventory_2', 'local_shipping', 'home', 'check_circle'];
   currentStepIndex = 0;
   hasException = false;
+  progressWidth = '0%';
 
   constructor(
     private route: ActivatedRoute,
@@ -178,6 +180,7 @@ export class FedexTrackResultComponent implements OnInit, OnDestroy {
     if (!this.trackingData) {
       this.currentStepIndex = 0;
       this.hasException = false;
+      this.progressWidth = '0%';
       return;
     }
 
@@ -185,12 +188,19 @@ export class FedexTrackResultComponent implements OnInit, OnDestroy {
     this.hasException = status.includes('exception');
 
     if (status.includes('delivered')) {
-      this.currentStepIndex = 2;
+      this.currentStepIndex = 4;
+    } else if (status.includes('out for delivery')) {
+      this.currentStepIndex = 3;
     } else if (status.includes('in transit')) {
+      this.currentStepIndex = 2;
+    } else if (status.includes('picked up')) {
       this.currentStepIndex = 1;
     } else {
       this.currentStepIndex = 0;
     }
+
+    const progress = (this.currentStepIndex / (this.progressSteps.length - 1)) * 100;
+    this.progressWidth = `${progress}%`;
   }
 
   private waitForGoogleMaps(): Promise<void> {


### PR DESCRIPTION
## Summary
- implement new FedEx progress steps
- show a progress bar with icons
- style progress bar

## Testing
- `pip install -r backend/requirements.txt`
- `npm install --silent`
- `python -m backend.app.init_db`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684599291394832e8aaead2c47fcfc48