### PR TITLE
Add export error handling

### DIFF
--- a/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.spec.ts
+++ b/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.spec.ts
@@ -17,7 +17,7 @@ describe('FedexTrackResultComponent', () => {
   let analytics: jasmine.SpyObj<AnalyticsService>;
 
   beforeEach(async () => {
-    trackingService = jasmine.createSpyObj('TrackingService', ['trackPackage']);
+    trackingService = jasmine.createSpyObj('TrackingService', ['trackPackage', 'exportTracking']);
     analytics = jasmine.createSpyObj('AnalyticsService', ['logAction']);
 
     await TestBed.configureTestingModule({
@@ -83,6 +83,22 @@ describe('FedexTrackResultComponent', () => {
     expect(saved).toContain('FEDEXID');
     expect(notificationUtil.showNotification).toHaveBeenCalledWith('Tracking saved', 'success');
     expect(analytics.logAction).toHaveBeenCalledWith('save_tracking', 'FEDEXID');
+  });
+
+  it('exportData() should notify on error', () => {
+    component.trackingData = {
+      tracking_number: 'FEDEXID',
+      carrier: 'FedEx',
+      status: { status: 'In transit', description: '', is_delivered: false },
+      tracking_history: []
+    } as any;
+
+    trackingService.exportTracking.and.returnValue(throwError(() => new Error('fail')));
+
+    component.exportData('pdf');
+
+    expect(notificationUtil.showNotification).toHaveBeenCalledWith('Export failed', 'error');
+    expect(analytics.logAction).toHaveBeenCalledWith('export_data', 'pdf');
   });
 
   it('should use fallback data when service fails', fakeAsync(() => {

--- a/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.ts
+++ b/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.ts
@@ -6,6 +6,8 @@ import { ActivatedRoute } from '@angular/router';
 import { TrackingService, TrackingInfo } from '../services/tracking.service';
 import { AnalyticsService } from '../../../core/services/analytics.service';
 import { showNotification } from '../../../shared/services/notification.util';
+import { catchError } from 'rxjs/operators';
+import { throwError } from 'rxjs';
 import { ScheduleDialogComponent } from './schedule-dialog.component';
 import { ChangeAddressDialogComponent } from './change-address-dialog.component';
 
@@ -266,6 +268,12 @@ export class FedexTrackResultComponent implements OnInit, OnDestroy {
 
     this.trackingService
       .exportTracking(this.trackingData.tracking_number, format)
+      .pipe(
+        catchError(error => {
+          showNotification('Export failed', 'error');
+          return throwError(() => error);
+        })
+      )
       .subscribe(blob => {
         const url = window.URL.createObjectURL(blob);
         const a = document.createElement('a');


### PR DESCRIPTION
## Summary
- handle export failure in FedEx tracking component
- test export error notification

## Testing
- `pytest -q`
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6845992b42e4832e809b93323b52b92a