### PR TITLE
Add Fedex track result dialog and export tests

### DIFF
--- a/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.spec.ts
+++ b/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.spec.ts
@@ -2,10 +2,12 @@
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { of, throwError } from 'rxjs';
 import { ActivatedRoute } from '@angular/router';
+import { MatDialog } from '@angular/material/dialog';
 
 import { FedexTrackResultComponent } from './fedex-track-result.component';
 import { TrackingService } from '../services/tracking.service';
 import { AnalyticsService } from '../../../core/services/analytics.service';
+import { ScheduleDialogComponent } from './schedule-dialog.component';
 import * as notificationUtil from '../../../shared/services/notification.util';
 
 declare const google: any;
@@ -15,17 +17,20 @@ describe('FedexTrackResultComponent', () => {
   let fixture: ComponentFixture<FedexTrackResultComponent>;
   let trackingService: jasmine.SpyObj<TrackingService>;
   let analytics: jasmine.SpyObj<AnalyticsService>;
+  let dialog: jasmine.SpyObj<MatDialog>;
 
   beforeEach(async () => {
-    trackingService = jasmine.createSpyObj('TrackingService', ['trackPackage']);
+    trackingService = jasmine.createSpyObj('TrackingService', ['trackPackage', 'exportTracking']);
     analytics = jasmine.createSpyObj('AnalyticsService', ['logAction']);
+    dialog = jasmine.createSpyObj('MatDialog', ['open']);
 
     await TestBed.configureTestingModule({
       imports: [FedexTrackResultComponent],
       providers: [
         { provide: TrackingService, useValue: trackingService },
         { provide: AnalyticsService, useValue: analytics },
-        { provide: ActivatedRoute, useValue: { params: of({ identifier: 'FEDEXID' }) } }
+        { provide: ActivatedRoute, useValue: { params: of({ identifier: 'FEDEXID' }) } },
+        { provide: MatDialog, useValue: dialog }
       ]
     }).compileComponents();
 
@@ -97,4 +102,34 @@ describe('FedexTrackResultComponent', () => {
     expect(component.trackingData?.carrier).toBe('FedEx');
     expect(component.trackingData?.tracking_number).toBe('FEDEXID');
   }));
+
+  it("openDialog('schedule') should open ScheduleDialogComponent and log action", () => {
+    component.openDialog('schedule');
+
+    expect(dialog.open).toHaveBeenCalledWith(ScheduleDialogComponent, { width: '400px' });
+    expect(analytics.logAction).toHaveBeenCalledWith('open_dialog', 'schedule');
+  });
+
+  it("exportData('pdf') should trigger a download and log action", () => {
+    component.trackingData = {
+      tracking_number: 'FEDEXID',
+      carrier: 'FedEx',
+      status: { status: 'In transit', description: '', is_delivered: false },
+      tracking_history: []
+    } as any;
+
+    const blob = new Blob(['data'], { type: 'application/pdf' });
+    trackingService.exportTracking.and.returnValue(of(blob));
+
+    const clickSpy = jasmine.createSpy('click');
+    spyOn(document, 'createElement').and.returnValue({ click: clickSpy } as any);
+    spyOn(window.URL, 'createObjectURL').and.returnValue('blob:url');
+    spyOn(window.URL, 'revokeObjectURL');
+
+    component.exportData('pdf');
+
+    expect(trackingService.exportTracking).toHaveBeenCalledWith('FEDEXID', 'pdf');
+    expect(clickSpy).toHaveBeenCalled();
+    expect(analytics.logAction).toHaveBeenCalledWith('export_data', 'pdf');
+  });
 });


### PR DESCRIPTION
## Summary
- extend FedEx tracking result tests with dialog and export scenarios

## Testing
- `npm test` *(fails: No binary for Chrome browser)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6845992c8344832e9068134e06f3c010