### PR TITLE
Improve accessibility for tracking timelines

### DIFF
--- a/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.html
+++ b/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.html
@@ -14,7 +14,7 @@
 
   <!-- Tracking information -->
   <div *ngIf="!loading && trackingData">
-    <div class="summary-card mb-4">
+    <div class="summary-card mb-4" aria-label="Carte de suivi" role="region">
       <div class="summary-header">
         <h3>#{{ trackingData.tracking_number }}</h3>
         <span>{{ trackingData.carrier }} {{ trackingData.service_type }}</span>
@@ -95,8 +95,8 @@
 
     <div *ngIf="trackingData.tracking_history?.length">
       <h3 class="font-bold mb-2">Historique</h3>
-      <div class="timeline">
-        <div *ngFor="let event of trackingData.tracking_history; let i = index" [ngClass]="getItemClasses(event, i)">
+      <div class="timeline" role="list" aria-label="Historique du suivi">
+        <div *ngFor="let event of trackingData.tracking_history; let i = index" [ngClass]="getItemClasses(event, i)" role="listitem" tabindex="0">
           <div class="timeline-icon">
             <span class="material-icons">local_shipping</span>
           </div>

--- a/Frontend/src/app/features/tracking/track-result/track-result.component.html
+++ b/Frontend/src/app/features/tracking/track-result/track-result.component.html
@@ -14,7 +14,7 @@
 
   <!-- Tracking information -->
   <div *ngIf="!loading && trackingInfo">
-    <div class="summary-card mb-4">
+    <div class="summary-card mb-4" aria-label="Carte de suivi" role="region">
       <div class="summary-header">
         <h3>#{{ trackingInfo.tracking_number }}</h3>
         <span>{{ trackingInfo.carrier }} {{ trackingInfo.service_type }}</span>
@@ -146,10 +146,12 @@
 
     <div *ngIf="trackingInfo.tracking_history?.length">
       <h3 class="font-bold mb-2">Historique</h3>
-      <div class="timeline">
+      <div class="timeline" role="list" aria-label="Historique du suivi">
         <div *ngFor="let event of trackingInfo.tracking_history; let i = index"
              [ngClass]="getItemClasses(event, i)"
-             @timelineAnimation>
+             @timelineAnimation
+             role="listitem"
+             tabindex="0">
           <div class="timeline-icon">
             <span class="material-icons">local_shipping</span>
           </div>


### PR DESCRIPTION
## Summary
- mark timeline containers as lists and list items
- add screen reader label on summary card

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6845992e5900832eb6d5c949048ab467