### PR TITLE
Add reusable tracking form and tabs

### DIFF
--- a/Frontend/src/app/features/all-tracking-services/all-tracking-services.component.html
+++ b/Frontend/src/app/features/all-tracking-services/all-tracking-services.component.html
@@ -28,24 +28,12 @@
   </div>
 
   <div class="tab-content">
-    <form *ngIf="activeTab==='single'" [formGroup]="singleForm" (ngSubmit)="submitSingle()" class="single-form">
-      <div class="form-group">
-        <label>Tracking Number</label>
-        <input formControlName="trackingNumber" />
-      </div>
-      <div class="form-group">
-        <label>Package Name</label>
-        <input formControlName="packageName" />
-      </div>
-      <div class="error" *ngIf="singleForm.get('trackingNumber')?.touched && singleForm.get('trackingNumber')?.invalid">
-        Invalid tracking number
-      </div>
-      <button type="submit"
-              class="btn btn--primary"
-              role="button"
-              tabindex="0"
-              aria-label="Track single package">Track</button>
-    </form>
+    <app-tracking-form *ngIf="activeTab==='single'"
+                       class="single-form"
+                       [form]="singleForm"
+                       (formSubmit)="submitSingle()">
+      Track
+    </app-tracking-form>
 
     <form *ngIf="activeTab==='bulk'" [formGroup]="bulkForm" (ngSubmit)="submitBulk()" class="bulk-form">
       <div class="form-group">

--- a/Frontend/src/app/features/all-tracking-services/all-tracking-services.component.ts
+++ b/Frontend/src/app/features/all-tracking-services/all-tracking-services.component.ts
@@ -4,11 +4,12 @@ import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angula
 import { TrackingService } from '../tracking/services/tracking.service';
 import { AnalyticsService } from '../../core/services/analytics.service';
 import { BarcodeUploadComponent } from '../barcode-upload/barcode-upload.component';
+import { TrackingFormComponent } from '../../shared/components/tracking-form/tracking-form.component';
 
 @Component({
   selector: 'app-all-tracking-services',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, BarcodeUploadComponent],
+  imports: [CommonModule, ReactiveFormsModule, BarcodeUploadComponent, TrackingFormComponent],
   templateUrl: './all-tracking-services.component.html',
   styleUrls: ['./all-tracking-services.component.scss']
 })

--- a/Frontend/src/app/features/home/home.component.html
+++ b/Frontend/src/app/features/home/home.component.html
@@ -50,23 +50,10 @@
 
       <!-- Default tracking form (TRACK) -->
       <div *ngIf="selectedHeroFeature === null" class="tracking-form">
-        <form [formGroup]="trackingForm" (ngSubmit)="onSubmit()">
-          <div class="tracking-form__input-group">
-            <input type="text" formControlName="trackingNumber" class="tracking-form__input" placeholder="Enter your tracking number">
-            <input type="text" formControlName="packageName" class="tracking-form__input" placeholder="Package name (optional)">
-            <button type="submit" class="tracking-form__btn">
-              <i class="fas fa-search"></i>
-              Track
-            </button>
-          </div>
-          <div class="error-message" *ngIf="trackingForm.get('trackingNumber')?.errors?.required && trackingForm.get('trackingNumber')?.touched">
-            Tracking number is required.
-          </div>
-          <div class="error-message" *ngIf="trackingForm.get('trackingNumber')?.errors?.pattern && trackingForm.get('trackingNumber')?.touched">
-            Tracking number must be alphanumeric.
-          </div>
-          <!-- Barcode scan option removed from default form -->
-        </form>
+        <app-tracking-form
+          [form]="trackingForm"
+          (formSubmit)="onSubmit()"
+        >Track</app-tracking-form>
       </div>
 
       <!-- Barcode Scan Option -->
@@ -93,21 +80,12 @@
       <!-- Obtain Your Proof Option -->
       <div *ngIf="selectedHeroFeature === 'obtain_proof'" class="obtain-proof-option">
         <p>Enter tracking ID to download your proof of delivery.</p>
-        <form [formGroup]="trackingForm" (ngSubmit)="downloadProof()">
-          <div class="tracking-form__input-group">
-            <input type="text" formControlName="trackingNumber" class="tracking-form__input" placeholder="Enter tracking ID">
-            <button type="submit" class="tracking-form__btn">
-              <i class="fas fa-download"></i>
-              Download Proof
-            </button>
-          </div>
-          <div class="error-message" *ngIf="trackingForm.get('trackingNumber')?.errors?.required && trackingForm.get('trackingNumber')?.touched">
-            Tracking number is required.
-          </div>
-          <div class="error-message" *ngIf="trackingForm.get('trackingNumber')?.errors?.pattern && trackingForm.get('trackingNumber')?.touched">
-            Tracking number must be alphanumeric.
-          </div>
-        </form>
+        <app-tracking-form
+          [form]="trackingForm"
+          [includePackageName]="false"
+          buttonIcon="fas fa-download"
+          (formSubmit)="downloadProof()"
+        >Download Proof</app-tracking-form>
       </div>
 
     </div>

--- a/Frontend/src/app/features/home/home.component.ts
+++ b/Frontend/src/app/features/home/home.component.ts
@@ -16,6 +16,7 @@ import { BarcodeUploadComponent } from '../barcode-upload/barcode-upload.compone
 import { TrackingOptionsComponent } from '../../shared/components/tracking-options/tracking-options.component';
 import { TrackingMobileComponent } from '../../shared/components/tracking-mobile/tracking-mobile.component';
 import { FooterComponent } from '../../shared/components/footer/footer.component';
+import { TrackingFormComponent } from '../../shared/components/tracking-form/tracking-form.component';
 
 // Import Google Maps types
 declare global {
@@ -81,6 +82,7 @@ interface ServiceItem {
     BarcodeUploadComponent,
     TrackingOptionsComponent,
     TrackingMobileComponent,
+    TrackingFormComponent,
     FooterComponent
   ],
   templateUrl: './home.component.html',

--- a/Frontend/src/app/shared/components/tracking-form/tracking-form.component.html
+++ b/Frontend/src/app/shared/components/tracking-form/tracking-form.component.html
@@ -1,0 +1,16 @@
+<form [formGroup]="form" (ngSubmit)="submit()" class="tracking-form">
+  <div class="tracking-form__input-group">
+    <input type="text" formControlName="trackingNumber" class="tracking-form__input" placeholder="Enter your tracking number">
+    <input *ngIf="includePackageName" type="text" formControlName="packageName" class="tracking-form__input" placeholder="Package name (optional)">
+    <button type="submit" class="tracking-form__btn">
+      <i [class]="buttonIcon"></i>
+      <ng-content></ng-content>
+    </button>
+  </div>
+  <div class="error-message" *ngIf="form.get('trackingNumber')?.errors?.required && form.get('trackingNumber')?.touched">
+    Tracking number is required.
+  </div>
+  <div class="error-message" *ngIf="form.get('trackingNumber')?.errors?.pattern && form.get('trackingNumber')?.touched">
+    Tracking number must be alphanumeric.
+  </div>
+</form>

--- a/Frontend/src/app/shared/components/tracking-form/tracking-form.component.scss
+++ b/Frontend/src/app/shared/components/tracking-form/tracking-form.component.scss
@@ -1,0 +1,1 @@
+@import '../../features/home/home.component.scss';

--- a/Frontend/src/app/shared/components/tracking-form/tracking-form.component.ts
+++ b/Frontend/src/app/shared/components/tracking-form/tracking-form.component.ts
@@ -1,0 +1,22 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormGroup, ReactiveFormsModule } from '@angular/forms';
+
+@Component({
+  selector: 'app-tracking-form',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './tracking-form.component.html',
+  styleUrls: ['./tracking-form.component.scss']
+})
+export class TrackingFormComponent {
+  @Input({ required: true }) form!: FormGroup;
+  @Input() includePackageName = true;
+  @Input() buttonIcon = 'fas fa-search';
+
+  @Output() formSubmit = new EventEmitter<void>();
+
+  submit() {
+    this.formSubmit.emit();
+  }
+}

--- a/Frontend/src/app/shared/components/tracking-tabs/tracking-tabs.component.html
+++ b/Frontend/src/app/shared/components/tracking-tabs/tracking-tabs.component.html
@@ -1,0 +1,6 @@
+<div class="tracking-tabs">
+  <button class="tab" [class.active]="active==='number'" (click)="setTab('number')">Numéro</button>
+  <button class="tab" [class.active]="active==='reference'" (click)="setTab('reference')">Référence</button>
+  <button class="tab" [class.active]="active==='tcn'" (click)="setTab('tcn')">TCN</button>
+  <button class="tab" [class.active]="active==='proof'" (click)="setTab('proof')">Preuve</button>
+</div>

--- a/Frontend/src/app/shared/components/tracking-tabs/tracking-tabs.component.scss
+++ b/Frontend/src/app/shared/components/tracking-tabs/tracking-tabs.component.scss
@@ -1,0 +1,22 @@
+.tracking-tabs {
+  display: flex;
+  margin-bottom: 1rem;
+}
+
+.tab {
+  flex: 1;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  background: #f5f5f5;
+  cursor: pointer;
+  text-align: center;
+}
+
+.tab.active {
+  background: #4d148c;
+  color: #fff;
+}
+
+.tab + .tab {
+  margin-left: 5px;
+}

--- a/Frontend/src/app/shared/components/tracking-tabs/tracking-tabs.component.ts
+++ b/Frontend/src/app/shared/components/tracking-tabs/tracking-tabs.component.ts
@@ -1,0 +1,20 @@
+import { Component, EventEmitter, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-tracking-tabs',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './tracking-tabs.component.html',
+  styleUrls: ['./tracking-tabs.component.scss']
+})
+export class TrackingTabsComponent {
+  active: 'number' | 'reference' | 'tcn' | 'proof' = 'number';
+
+  @Output() tabChange = new EventEmitter<'number' | 'reference' | 'tcn' | 'proof'>();
+
+  setTab(tab: 'number' | 'reference' | 'tcn' | 'proof') {
+    this.active = tab;
+    this.tabChange.emit(this.active);
+  }
+}


### PR DESCRIPTION
## Summary
- add `TrackingTabsComponent` handling four tracking tabs and outputting the active tab
- add `TrackingFormComponent` exposing common tracking fields
- use `TrackingFormComponent` in HomeComponent and AllTrackingServicesComponent

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi_limiter')*


------
https://chatgpt.com/codex/tasks/task_e_684599351b1c832e90452b0e03aa23e5