### PR TITLE
Implement basic i18n with language selector

### DIFF
--- a/Frontend/angular.json
+++ b/Frontend/angular.json
@@ -13,6 +13,12 @@
       "root": "",
       "sourceRoot": "src",
       "prefix": "app",
+      "i18n": {
+        "sourceLocale": "en-US",
+        "locales": {
+          "fr": "src/locale/messages.fr.xlf"
+        }
+      },
       "architect": {
         "build": {
           "builder": "@angular-builders/custom-webpack:browser",
@@ -22,7 +28,7 @@
             },
             "outputPath": "dist/frontend",
             "index": "src/index.html",
-            "browser": "src/main.ts",
+            "main": "src/main.ts",
             "polyfills": [
               "zone.js"
             ],
@@ -83,14 +89,19 @@
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular-devkit/build-angular:extract-i18n",
+          "options": {
+            "buildTarget": "Frontend:build",
+            "outputPath": "src/locale"
+          }
         },
         "test": {
           "builder": "@angular-devkit/build-angular:karma",
           "options": {
             "polyfills": [
               "zone.js",
-              "zone.js/testing"
+              "zone.js/testing",
+              "@angular/localize/init"
             ],
             "tsConfig": "tsconfig.spec.json",
             "inlineStyleLanguage": "scss",
@@ -109,5 +120,12 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
+},
+"cli": {
+  "analytics": false
+}
 }

--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -29,6 +29,7 @@
         "@angular-devkit/build-angular": "^19.2.12",
         "@angular/cli": "^19.2.12",
         "@angular/compiler-cli": "^19.2.0",
+        "@angular/localize": "^19.2.14",
         "@types/jasmine": "~5.1.0",
         "dotenv-webpack": "^8.0.1",
         "jasmine-core": "~5.6.0",
@@ -738,6 +739,79 @@
         "@angular/core": "19.2.14",
         "@angular/platform-browser": "19.2.14",
         "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
+    "node_modules/@angular/localize": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@angular/localize/-/localize-19.2.14.tgz",
+      "integrity": "sha512-T2qPVE5N4qe1rQnx9tkxqUzXV+gUgAwSpVG+vHHRJe//jxCIVfk5zyPd2Z9nFzwGarHP61hvnEzbdbZHtCmbcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "7.26.9",
+        "@types/babel__core": "7.20.5",
+        "fast-glob": "3.3.3",
+        "yargs": "^17.2.1"
+      },
+      "bin": {
+        "localize-extract": "tools/bundles/src/extract/cli.js",
+        "localize-migrate": "tools/bundles/src/migrate/cli.js",
+        "localize-translate": "tools/bundles/src/translate/cli.js"
+      },
+      "engines": {
+        "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
+      },
+      "peerDependencies": {
+        "@angular/compiler": "19.2.14",
+        "@angular/compiler-cli": "19.2.14"
+      }
+    },
+    "node_modules/@angular/localize/node_modules/@babel/core": {
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.9.tgz",
+      "integrity": "sha512-lWBYIrF7qK5+GjY5Uy+/hEgp8OJWOD/rpy74GplYRhEauvbHDeFB8t5hPOZxCZ0Oxf4Cc36tK51/l3ymJysrKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.26.2",
+        "@babel/generator": "^7.26.9",
+        "@babel/helper-compilation-targets": "^7.26.5",
+        "@babel/helper-module-transforms": "^7.26.0",
+        "@babel/helpers": "^7.26.9",
+        "@babel/parser": "^7.26.9",
+        "@babel/template": "^7.26.9",
+        "@babel/traverse": "^7.26.9",
+        "@babel/types": "^7.26.9",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@angular/localize/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@angular/localize/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@angular/material": {
@@ -5167,6 +5241,51 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.7.tgz",
+      "integrity": "sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.20.7"
       }
     },
     "node_modules/@types/body-parser": {

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -27,18 +27,19 @@
     "zone.js": "~0.15.0"
   },
   "devDependencies": {
+    "@angular-builders/custom-webpack": "^19.0.1",
     "@angular-devkit/build-angular": "^19.2.12",
     "@angular/cli": "^19.2.12",
     "@angular/compiler-cli": "^19.2.0",
+    "@angular/localize": "^19.2.14",
     "@types/jasmine": "~5.1.0",
+    "dotenv-webpack": "^8.0.1",
     "jasmine-core": "~5.6.0",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.2.0",
     "karma-coverage": "~2.2.0",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
-    "typescript": "~5.7.2",
-    "@angular-builders/custom-webpack": "^19.0.1",
-    "dotenv-webpack": "^8.0.1"
+    "typescript": "~5.7.2"
   }
 }

--- a/Frontend/src/app/core/services/language.service.ts
+++ b/Frontend/src/app/core/services/language.service.ts
@@ -1,0 +1,81 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class LanguageService {
+  private lang = 'en';
+  private translations: Record<string, Record<string, string>> = {
+    en: {
+      HERO_TITLE: 'Track your packages in real-time',
+      HERO_SUBTITLE: 'Enter your tracking number to know the status of your delivery',
+      LOGOUT: 'Logout',
+      SCAN_BARCODE: 'Scan\nBarcode',
+      TRACK: 'TRACK',
+      OBTAIN_PROOF: 'Obtain your\nproof',
+      TRACK_PLACEHOLDER: 'Enter your tracking number',
+      PACKAGE_NAME_PLACEHOLDER: 'Package name (optional)',
+      TRACK_BUTTON: 'Track',
+      REQUIRED_ERROR: 'Tracking number is required.',
+      PATTERN_ERROR: 'Tracking number must be alphanumeric.',
+      UPLOAD_TEXT: 'Upload a barcode image or use Pro Scan to track your package.',
+      DRAG_TEXT: 'Drag and drop or click to upload',
+      STOP_SCAN: 'Stop Scan',
+      PRO_SCAN: 'Pro Scan (Webcam)',
+      ENTER_ID: 'Enter tracking ID to download your proof of delivery.',
+      ENTER_ID_PLACEHOLDER: 'Enter tracking ID',
+      DOWNLOAD_PROOF: 'Download Proof',
+      SHARE: 'Share',
+      PRINT: 'Print',
+      SAVE: 'Save',
+      COPY: 'Copy',
+      CONTACT_SUPPORT: 'Contact support',
+      GENERATE_TITLE: 'Enter a tracking ID to generate its barcode.',
+      GENERATE_PLACEHOLDER: 'Enter tracking ID',
+      GENERATE_BUTTON: 'Generate'
+    },
+    fr: {
+      HERO_TITLE: 'Suivez vos colis en temps r\u00e9el',
+      HERO_SUBTITLE: 'Saisissez votre num\u00e9ro pour conna\u00eetre le statut de votre livraison',
+      LOGOUT: 'Se d\u00e9connecter',
+      SCAN_BARCODE: 'Scanner\nle code-barres',
+      TRACK: 'SUIVRE',
+      OBTAIN_PROOF: 'Obtenir votre\npreuve',
+      TRACK_PLACEHOLDER: 'Num\u00e9ro de suivi',
+      PACKAGE_NAME_PLACEHOLDER: 'Nom du colis (optionnel)',
+      TRACK_BUTTON: 'Rechercher',
+      REQUIRED_ERROR: 'Le num\u00e9ro de suivi est obligatoire.',
+      PATTERN_ERROR: 'Le num\u00e9ro de suivi doit \u00eatre alphanum\u00e9rique.',
+      UPLOAD_TEXT: 'T\u00e9l\u00e9chargez une image de code-barres ou utilisez Pro Scan pour suivre votre colis.',
+      DRAG_TEXT: 'Glissez-d\u00e9posez ou cliquez pour importer',
+      STOP_SCAN: 'Arr\u00eater le scan',
+      PRO_SCAN: 'Pro Scan (Webcam)',
+      ENTER_ID: "Entrez l'identifiant pour t\u00e9l\u00e9charger votre preuve de livraison.",
+      ENTER_ID_PLACEHOLDER: 'ID de suivi',
+      DOWNLOAD_PROOF: 'T\u00e9l\u00e9charger la preuve',
+      SHARE: 'Partager',
+      PRINT: 'Imprimer',
+      SAVE: 'Enregistrer',
+      COPY: 'Copier',
+      CONTACT_SUPPORT: 'Contacter le support',
+      GENERATE_TITLE: 'Entrez un identifiant pour g\u00e9n\u00e9rer son code-barres.',
+      GENERATE_PLACEHOLDER: 'ID de suivi',
+      GENERATE_BUTTON: 'G\u00e9n\u00e9rer'
+    }
+  };
+
+  detectBrowserLang(): void {
+    const browserLang = navigator.language.startsWith('fr') ? 'fr' : 'en';
+    this.lang = browserLang;
+  }
+
+  setLang(lang: string): void {
+    this.lang = lang;
+  }
+
+  get currentLang(): string {
+    return this.lang;
+  }
+
+  t(key: string): string {
+    return this.translations[this.lang][key] || key;
+  }
+}

--- a/Frontend/src/app/features/home/home.component.html
+++ b/Frontend/src/app/features/home/home.component.html
@@ -3,10 +3,10 @@
 ======================= -->
 <section class="hero">
   <div class="hero__content">
-    <h1 class="hero__title">Track your packages in real-time</h1>
-    <p class="hero__subtitle">Enter your tracking number to know the status of your delivery</p>
+    <h1 class="hero__title">{{ 'HERO_TITLE' | translate }}</h1>
+    <p class="hero__subtitle">{{ 'HERO_SUBTITLE' | translate }}</p>
     <button *ngIf="isLoggedIn$ | async" class="btn btn--secondary logout-btn" (click)="logout()">
-      Logout
+      {{ 'LOGOUT' | translate }}
     </button>
 
     <div class="hero__features">
@@ -19,7 +19,7 @@
            (keydown.enter)="selectHeroFeature('barcode_scan')"
            (keydown.space)="selectHeroFeature('barcode_scan')">
         <i class="fas fa-barcode hero__feature-icon"></i>
-        <p class="hero__feature-text">Scan<br>Barcode</p>
+        <p class="hero__feature-text">{{ 'SCAN_BARCODE' | translate }}</p>
       </div>
       <div class="hero__feature-card"
            role="button"
@@ -30,7 +30,7 @@
            (keydown.enter)="selectHeroFeature(null)"
            (keydown.space)="selectHeroFeature(null)">
         <i class="fas fa-search hero__feature-icon"></i>
-        <p class="hero__feature-text">TRACK</p>
+        <p class="hero__feature-text">{{ 'TRACK' | translate }}</p>
       </div>
       <div class="hero__feature-card"
            role="button"
@@ -41,7 +41,7 @@
            (keydown.enter)="selectHeroFeature('obtain_proof')"
            (keydown.space)="selectHeroFeature('obtain_proof')">
         <i class="fas fa-file-alt hero__feature-icon"></i>
-        <p class="hero__feature-text">Obtain your<br>proof</p>
+        <p class="hero__feature-text">{{ 'OBTAIN_PROOF' | translate }}</p>
       </div>
     </div>
 
@@ -52,18 +52,18 @@
       <div *ngIf="selectedHeroFeature === null" class="tracking-form">
         <form [formGroup]="trackingForm" (ngSubmit)="onSubmit()">
           <div class="tracking-form__input-group">
-            <input type="text" formControlName="trackingNumber" class="tracking-form__input" placeholder="Enter your tracking number">
-            <input type="text" formControlName="packageName" class="tracking-form__input" placeholder="Package name (optional)">
+            <input type="text" formControlName="trackingNumber" class="tracking-form__input" [placeholder]="'TRACK_PLACEHOLDER' | translate">
+            <input type="text" formControlName="packageName" class="tracking-form__input" [placeholder]="'PACKAGE_NAME_PLACEHOLDER' | translate">
             <button type="submit" class="tracking-form__btn">
               <i class="fas fa-search"></i>
-              Track
+              {{ 'TRACK_BUTTON' | translate }}
             </button>
           </div>
           <div class="error-message" *ngIf="trackingForm.get('trackingNumber')?.errors?.required && trackingForm.get('trackingNumber')?.touched">
-            Tracking number is required.
+            {{ 'REQUIRED_ERROR' | translate }}
           </div>
           <div class="error-message" *ngIf="trackingForm.get('trackingNumber')?.errors?.pattern && trackingForm.get('trackingNumber')?.touched">
-            Tracking number must be alphanumeric.
+            {{ 'PATTERN_ERROR' | translate }}
           </div>
           <!-- Barcode scan option removed from default form -->
         </form>
@@ -71,7 +71,7 @@
 
       <!-- Barcode Scan Option -->
       <div *ngIf="selectedHeroFeature === 'barcode_scan'" class="barcode-scan-option">
-        <p>Upload a barcode image or use Pro Scan to track your package.</p>
+        <p>{{ 'UPLOAD_TEXT' | translate }}</p>
         <div class="upload-box"
              role="button"
              aria-label="Upload barcode image"
@@ -80,11 +80,11 @@
              (keydown.enter)="fileInput.click()"
              (keydown.space)="fileInput.click()">
           <i class="fas fa-cloud-upload-alt upload-icon"></i>
-          <p>Drag and drop or click to upload</p>
+          <p>{{ 'DRAG_TEXT' | translate }}</p>
           <input type="file" accept="image/*" (change)="onBarcodeFileSelected($event)" #fileInput hidden>
         </div>
         <button class="btn btn--primary mt-3" (click)="startWebcamScan()">
-          {{ isScanning ? 'Stop Scan' : 'Pro Scan (Webcam)' }}
+          {{ isScanning ? ('STOP_SCAN' | translate) : ('PRO_SCAN' | translate) }}
         </button>
         <video #videoPreview *ngIf="isScanning" class="webcam-preview" autoplay></video>
         <app-barcode-upload [control]="trackingForm.get('trackingNumber')"></app-barcode-upload>
@@ -92,20 +92,20 @@
 
       <!-- Obtain Your Proof Option -->
       <div *ngIf="selectedHeroFeature === 'obtain_proof'" class="obtain-proof-option">
-        <p>Enter tracking ID to download your proof of delivery.</p>
+        <p>{{ 'ENTER_ID' | translate }}</p>
         <form [formGroup]="trackingForm" (ngSubmit)="downloadProof()">
           <div class="tracking-form__input-group">
-            <input type="text" formControlName="trackingNumber" class="tracking-form__input" placeholder="Enter tracking ID">
+            <input type="text" formControlName="trackingNumber" class="tracking-form__input" [placeholder]="'ENTER_ID_PLACEHOLDER' | translate">
             <button type="submit" class="tracking-form__btn">
               <i class="fas fa-download"></i>
-              Download Proof
+              {{ 'DOWNLOAD_PROOF' | translate }}
             </button>
           </div>
           <div class="error-message" *ngIf="trackingForm.get('trackingNumber')?.errors?.required && trackingForm.get('trackingNumber')?.touched">
-            Tracking number is required.
+            Le numéro de suivi est obligatoire.
           </div>
           <div class="error-message" *ngIf="trackingForm.get('trackingNumber')?.errors?.pattern && trackingForm.get('trackingNumber')?.touched">
-            Tracking number must be alphanumeric.
+            Le numéro de suivi doit être alphanumérique.
           </div>
         </form>
       </div>
@@ -118,10 +118,10 @@
 🆕 GENERATE BARCODE SECTION
 ======================= -->
 <div class="generate-barcode-option">
-  <p>Enter a tracking ID to generate its barcode.</p>
+  <p>{{ 'GENERATE_TITLE' | translate }}</p>
   <form [formGroup]="barcodeForm" (ngSubmit)="generateBarcode()" class="input-group">
-    <input type="text" formControlName="trackingId" placeholder="Enter tracking ID">
-    <button type="submit" class="btn btn--primary">Generate</button>
+    <input type="text" formControlName="trackingId" [placeholder]="'GENERATE_PLACEHOLDER' | translate">
+    <button type="submit" class="btn btn--primary">{{ 'GENERATE_BUTTON' | translate }}</button>
   </form>
   <div class="barcode-display" *ngIf="barcodeImageUrl">
     <img [src]="barcodeImageUrl" alt="Generated Barcode">

--- a/Frontend/src/app/features/home/home.component.ts
+++ b/Frontend/src/app/features/home/home.component.ts
@@ -16,6 +16,8 @@ import { BarcodeUploadComponent } from '../barcode-upload/barcode-upload.compone
 import { TrackingOptionsComponent } from '../../shared/components/tracking-options/tracking-options.component';
 import { TrackingMobileComponent } from '../../shared/components/tracking-mobile/tracking-mobile.component';
 import { FooterComponent } from '../../shared/components/footer/footer.component';
+import { TranslatePipe } from '../../shared/pipes/translate.pipe';
+import { LanguageService } from '../../core/services/language.service';
 
 // Import Google Maps types
 declare global {
@@ -81,7 +83,8 @@ interface ServiceItem {
     BarcodeUploadComponent,
     TrackingOptionsComponent,
     TrackingMobileComponent,
-    FooterComponent
+    FooterComponent,
+    TranslatePipe
   ],
   templateUrl: './home.component.html',
   styleUrls: ['./home.component.scss'],
@@ -146,7 +149,8 @@ export class HomeComponent implements OnInit, OnDestroy {
     private trackingService: TrackingService,
     private notificationService: NotificationService,
     private analytics: AnalyticsService,
-    private history: TrackingHistoryService
+    private history: TrackingHistoryService,
+    private languageService: LanguageService
   ) {
     this.trackingForm = this.fb.group({
       trackingNumber: ['', [Validators.required, Validators.pattern('^[A-Z0-9]{10,}$')]],
@@ -159,6 +163,7 @@ export class HomeComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
+    this.languageService.detectBrowserLang();
     this.isLoggedIn$ = this.authService.isLoggedIn();
     this.fetchUnreadNotifications();
     this.refreshIntervalId = setInterval(() => this.fetchUnreadNotifications(), 60000);

--- a/Frontend/src/app/features/tracking/track-result/track-result.component.html
+++ b/Frontend/src/app/features/tracking/track-result/track-result.component.html
@@ -46,7 +46,7 @@
                 (click)="shareTracking()"
                 (keydown.enter)="shareTracking()"
                 (keydown.space)="shareTracking()">
-          Share
+          {{ 'SHARE' | translate }}
         </button>
         <button type="button"
                 role="button"
@@ -55,7 +55,7 @@
                 (click)="printTracking()"
                 (keydown.enter)="printTracking()"
                 (keydown.space)="printTracking()">
-          Print
+          {{ 'PRINT' | translate }}
         </button>
         <button type="button"
                 role="button"
@@ -64,7 +64,7 @@
                 (click)="saveTracking()"
                 (keydown.enter)="saveTracking()"
                 (keydown.space)="saveTracking()">
-          Save
+          {{ 'SAVE' | translate }}
         </button>
         <button type="button"
                 role="button"
@@ -73,7 +73,7 @@
                 (click)="copyTracking()"
                 (keydown.enter)="copyTracking()"
                 (keydown.space)="copyTracking()">
-          Copier
+          {{ 'COPY' | translate }}
         </button>
         <button type="button"
                 role="button"
@@ -82,7 +82,7 @@
                 (click)="downloadProof()"
                 (keydown.enter)="downloadProof()"
                 (keydown.space)="downloadProof()">
-          Télécharger la preuve
+          {{ 'DOWNLOAD_PROOF' | translate }}
         </button>
         <button type="button"
                 role="button"
@@ -91,7 +91,7 @@
                 (click)="contactSupport()"
                 (keydown.enter)="contactSupport()"
                 (keydown.space)="contactSupport()">
-          Contacter le support
+          {{ 'CONTACT_SUPPORT' | translate }}
         </button>
       </div>
     </div>

--- a/Frontend/src/app/features/tracking/track-result/track-result.component.ts
+++ b/Frontend/src/app/features/tracking/track-result/track-result.component.ts
@@ -6,6 +6,8 @@ import { TrackingService, TrackingInfo } from '../services/tracking.service';
 import { TrackingHistoryService } from '../../../core/services/tracking-history.service';
 import { AnalyticsService } from '../../../core/services/analytics.service';
 import { showNotification } from '../../../shared/services/notification.util';
+import { TranslatePipe } from '../../../shared/pipes/translate.pipe';
+import { LanguageService } from '../../../core/services/language.service';
 import { environment } from '../../../../environments/environment';
 
 declare global {
@@ -17,7 +19,7 @@ declare global {
 @Component({
   selector: 'app-track-result',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, TranslatePipe],
   templateUrl: './track-result.component.html',
   styleUrls: ['./track-result.component.scss'],
   animations: [
@@ -45,10 +47,12 @@ export class TrackResultComponent implements OnInit, OnDestroy {
     private route: ActivatedRoute,
     private trackingService: TrackingService,
     private analytics: AnalyticsService,
-    private history: TrackingHistoryService
+    private history: TrackingHistoryService,
+    private languageService: LanguageService
   ) {}
 
   ngOnInit() {
+    this.languageService.detectBrowserLang();
     this.route.params.subscribe(params => {
       const identifier = params['identifier'];
       if (identifier) {

--- a/Frontend/src/app/shared/components/navbar/navbar.component.html
+++ b/Frontend/src/app/shared/components/navbar/navbar.component.html
@@ -60,6 +60,10 @@
         <i class="fas fa-search"></i>
       </button>
       <input *ngIf="showSearch" type="text" class="search-input" placeholder="Rechercher..." />
+      <select (change)="changeLang($event.target.value)" [value]="currentLang" class="lang-select">
+        <option value="en">EN</option>
+        <option value="fr">FR</option>
+      </select>
     </div>
   </nav>
 </header>

--- a/Frontend/src/app/shared/components/navbar/navbar.component.ts
+++ b/Frontend/src/app/shared/components/navbar/navbar.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { RouterModule, Router } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { NotificationService } from '../../../core/services/notification.service';
+import { LanguageService } from '../../../core/services/language.service';
 
 @Component({
   selector: 'app-navbar',
@@ -16,12 +17,17 @@ export class NavbarComponent implements OnInit {
   showSearch = false;
   notificationCount = 0;
 
+  currentLang = 'en';
+
   constructor(
     private notificationService: NotificationService,
-    private router: Router
+    private router: Router,
+    private languageService: LanguageService
   ) {}
 
   ngOnInit(): void {
+    this.languageService.detectBrowserLang();
+    this.currentLang = this.languageService.currentLang;
     this.notificationService.getUnreadCount().subscribe((count) => {
       this.notificationCount = count;
     });
@@ -36,5 +42,10 @@ export class NavbarComponent implements OnInit {
     if (id) {
       this.router.navigate(['/track', id]);
     }
+  }
+
+  changeLang(lang: string): void {
+    this.languageService.setLang(lang);
+    this.currentLang = lang;
   }
 }

--- a/Frontend/src/app/shared/pipes/translate.pipe.ts
+++ b/Frontend/src/app/shared/pipes/translate.pipe.ts
@@ -1,0 +1,11 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { LanguageService } from '../../core/services/language.service';
+
+@Pipe({ name: 'translate', standalone: true })
+export class TranslatePipe implements PipeTransform {
+  constructor(private langService: LanguageService) {}
+
+  transform(key: string): string {
+    return this.langService.t(key);
+  }
+}

--- a/Frontend/src/locale/messages.xlf
+++ b/Frontend/src/locale/messages.xlf
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file source-language="en" datatype="plaintext" original="ng2.template">
+    <body>
+    </body>
+  </file>
+</xliff>

--- a/Frontend/tsconfig.spec.json
+++ b/Frontend/tsconfig.spec.json
@@ -6,7 +6,8 @@
     "outDir": "./out-tsc/spec",
     "types": [
       "jasmine",
-      "node"
+      "node",
+      "@angular/localize"
     ]
   },
   "include": [


### PR DESCRIPTION
## Summary
- set up i18n configuration in `angular.json`
- add `LanguageService` and `TranslatePipe`
- translate labels in `HomeComponent` and `TrackResultComponent`
- add language selector to navbar
- generate stub `messages.xlf`

## Testing
- `npm run build` *(fails: Cannot find namespace 'google' and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_6845994af568832e8f8afd085897fdbc