### PR TITLE
Update tracking endpoint base URL

### DIFF
--- a/Frontend/src/app/features/tracking/services/tracking.service.ts
+++ b/Frontend/src/app/features/tracking/services/tracking.service.ts
@@ -9,7 +9,7 @@ import { TrackingInfo, TrackingResponse } from '../models/tracking';
   providedIn: 'root'
 })
 export class TrackingService {
-  private baseUrl = `${environment.apiUrl}/tracking`;
+  private baseUrl = `${environment.apiUrl}/track`;
 
   constructor(private http: HttpClient) {}
 


### PR DESCRIPTION
## Summary
- adjust frontend tracking service to use `/track` endpoint

## Testing
- `npm install`
- `pytest`
- ⚠️ `uvicorn` server failed to start locally due to missing Redis instance

------
https://chatgpt.com/codex/tasks/task_e_68459debcde8832e90877657cdea0c58