### PR TITLE
Add FedEx delivery option dialogs

### DIFF
--- a/Frontend/src/app/features/tracking/fedex-track-result/delivery-instructions-dialog.component.ts
+++ b/Frontend/src/app/features/tracking/fedex-track-result/delivery-instructions-dialog.component.ts
@@ -1,0 +1,51 @@
+import { Component } from '@angular/core';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { showNotification } from '../../../shared/services/notification.util';
+
+@Component({
+  selector: 'app-delivery-instructions-dialog',
+  standalone: true,
+  imports: [CommonModule, MatDialogModule, ReactiveFormsModule],
+  template: `
+    <h1 mat-dialog-title>Delivery Instructions</h1>
+    <form [formGroup]="form" (ngSubmit)="confirm()">
+      <div mat-dialog-content>
+        <label>
+          Instructions
+          <textarea formControlName="instructions" rows="4"></textarea>
+        </label>
+        <div class="error" *ngIf="form.get('instructions')?.touched && form.get('instructions')?.invalid">
+          Instructions required
+        </div>
+      </div>
+      <div mat-dialog-actions>
+        <button mat-button type="button" (click)="close()">Cancel</button>
+        <button mat-button color="primary" type="submit">Save</button>
+      </div>
+    </form>
+  `
+})
+export class DeliveryInstructionsDialogComponent {
+  form: FormGroup;
+
+  constructor(public dialogRef: MatDialogRef<DeliveryInstructionsDialogComponent>, private fb: FormBuilder) {
+    this.form = this.fb.group({
+      instructions: ['', Validators.required]
+    });
+  }
+
+  confirm(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+    showNotification('Instructions saved', 'success');
+    this.dialogRef.close(this.form.value);
+  }
+
+  close(): void {
+    this.dialogRef.close();
+  }
+}

--- a/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.html
+++ b/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.html
@@ -40,6 +40,8 @@
         <button type="button" (click)="saveTracking()">Save</button>
         <button type="button" (click)="openDialog('schedule')">Schedule</button>
         <button type="button" (click)="openDialog('change-address')">Change Address</button>
+        <button type="button" (click)="openDialog('hold-location')">Hold Location</button>
+        <button type="button" (click)="openDialog('instructions')">Add Instructions</button>
         <button type="button" (click)="exportData('pdf')">Export PDF</button>
         <button type="button" (click)="exportData('csv')">Export CSV</button>
       </div>

--- a/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.spec.ts
+++ b/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.spec.ts
@@ -8,6 +8,8 @@ import { FedexTrackResultComponent } from './fedex-track-result.component';
 import { TrackingService } from '../services/tracking.service';
 import { AnalyticsService } from '../../../core/services/analytics.service';
 import { ScheduleDialogComponent } from './schedule-dialog.component';
+import { HoldLocationDialogComponent } from './hold-location-dialog.component';
+import { DeliveryInstructionsDialogComponent } from './delivery-instructions-dialog.component';
 import * as notificationUtil from '../../../shared/services/notification.util';
 
 declare const google: any;
@@ -124,6 +126,20 @@ describe('FedexTrackResultComponent', () => {
 
     expect(dialog.open).toHaveBeenCalledWith(ScheduleDialogComponent, { width: '400px' });
     expect(analytics.logAction).toHaveBeenCalledWith('open_dialog', 'schedule');
+  });
+
+  it("openDialog('hold-location') should open HoldLocationDialogComponent and log action", () => {
+    component.openDialog('hold-location');
+
+    expect(dialog.open).toHaveBeenCalledWith(HoldLocationDialogComponent, { width: '400px' });
+    expect(analytics.logAction).toHaveBeenCalledWith('open_dialog', 'hold-location');
+  });
+
+  it("openDialog('instructions') should open DeliveryInstructionsDialogComponent and log action", () => {
+    component.openDialog('instructions');
+
+    expect(dialog.open).toHaveBeenCalledWith(DeliveryInstructionsDialogComponent, { width: '400px' });
+    expect(analytics.logAction).toHaveBeenCalledWith('open_dialog', 'instructions');
   });
 
   it("exportData('pdf') should trigger a download and log action", () => {

--- a/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.ts
+++ b/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.ts
@@ -10,6 +10,8 @@ import { catchError } from 'rxjs/operators';
 import { throwError } from 'rxjs';
 import { ScheduleDialogComponent } from './schedule-dialog.component';
 import { ChangeAddressDialogComponent } from './change-address-dialog.component';
+import { HoldLocationDialogComponent } from './hold-location-dialog.component';
+import { DeliveryInstructionsDialogComponent } from './delivery-instructions-dialog.component';
 
 interface FedexTrackingInfo extends TrackingInfo {
   currentLocation?: {
@@ -26,7 +28,9 @@ interface FedexTrackingInfo extends TrackingInfo {
     MatButtonModule,
     MatDialogModule,
     ScheduleDialogComponent,
-    ChangeAddressDialogComponent
+    ChangeAddressDialogComponent,
+    HoldLocationDialogComponent,
+    DeliveryInstructionsDialogComponent
   ],
   templateUrl: './fedex-track-result.component.html',
   styleUrls: ['./fedex-track-result.component.scss']
@@ -260,6 +264,12 @@ export class FedexTrackResultComponent implements OnInit, OnDestroy {
         break;
       case 'change-address':
         component = ChangeAddressDialogComponent;
+        break;
+      case 'hold-location':
+        component = HoldLocationDialogComponent;
+        break;
+      case 'instructions':
+        component = DeliveryInstructionsDialogComponent;
         break;
       default:
         component = null;

--- a/Frontend/src/app/features/tracking/fedex-track-result/hold-location-dialog.component.ts
+++ b/Frontend/src/app/features/tracking/fedex-track-result/hold-location-dialog.component.ts
@@ -1,0 +1,59 @@
+import { Component } from '@angular/core';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { showNotification } from '../../../shared/services/notification.util';
+
+@Component({
+  selector: 'app-hold-location-dialog',
+  standalone: true,
+  imports: [CommonModule, MatDialogModule, ReactiveFormsModule],
+  template: `
+    <h1 mat-dialog-title>Hold at Location</h1>
+    <form [formGroup]="form" (ngSubmit)="confirm()">
+      <div mat-dialog-content>
+        <label>
+          Location
+          <input formControlName="location" />
+        </label>
+        <div class="error" *ngIf="form.get('location')?.touched && form.get('location')?.invalid">
+          Location required
+        </div>
+        <label>
+          Date
+          <input type="date" formControlName="date" />
+        </label>
+        <div class="error" *ngIf="form.get('date')?.touched && form.get('date')?.invalid">
+          Date required
+        </div>
+      </div>
+      <div mat-dialog-actions>
+        <button mat-button type="button" (click)="close()">Cancel</button>
+        <button mat-button color="primary" type="submit">Confirm</button>
+      </div>
+    </form>
+  `
+})
+export class HoldLocationDialogComponent {
+  form: FormGroup;
+
+  constructor(public dialogRef: MatDialogRef<HoldLocationDialogComponent>, private fb: FormBuilder) {
+    this.form = this.fb.group({
+      location: ['', Validators.required],
+      date: ['', Validators.required]
+    });
+  }
+
+  confirm(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+    showNotification('Hold location saved', 'success');
+    this.dialogRef.close(this.form.value);
+  }
+
+  close(): void {
+    this.dialogRef.close();
+  }
+}


### PR DESCRIPTION
## Summary
- add hold-location and delivery-instructions dialog components
- extend FedEx dialog selection logic
- expose new dialog actions in the results page
- cover dialog paths with unit tests

## Testing
- `npm test --silent` *(fails: No Chrome binary)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68459d6761ec832e90b7075ac03ab2c9