### PR TITLE
Fix asynchronous FedEx tracking calls

### DIFF
--- a/backend/app/api/v1/endpoints/tracking.py
+++ b/backend/app/api/v1/endpoints/tracking.py
@@ -67,7 +67,7 @@ async def create_package(
 
         # Track the newly created package
         fedex_service = FedExService()
-        response = fedex_service.track_package(colis.id)
+        response = await fedex_service.track_package(colis.id)
 
         # Add metadata about the identifier used
         if response.metadata:
@@ -158,7 +158,7 @@ async def track_package(
         fedex_id = colis.id
 
         # Track via FedEx
-        response = fedex_service.track_package(fedex_id)
+        response = await fedex_service.track_package(fedex_id)
 
         # Add metadata about the identifier used
         if response.metadata:
@@ -220,7 +220,7 @@ async def track_by_email(
 ):
     """Track a package and send the result via email."""
     fedex_service = FedExService()
-    response = fedex_service.track_package(request.tracking_number)
+    response = await fedex_service.track_package(request.tracking_number)
     if response.success:
         status = response.data.status if response.data else ""
         try:

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -45,7 +45,7 @@ class DummyFedExService:
     def __init__(self, *a, **k):
         pass
 
-    def track_package(self, tracking_number: str) -> TrackingResponse:
+    async def track_package(self, tracking_number: str) -> TrackingResponse:
         return TrackingResponse(success=True, data=None, error=None, metadata={})
 
 


### PR DESCRIPTION
## Summary
- await FedEx tracking API calls in tracking endpoints
- adjust test double to match async interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845a3876dd0832e8acd75b9db8e2020