### PR TITLE
Update tracking endpoints

### DIFF
--- a/Frontend/src/app/features/tracking/services/tracking.service.ts
+++ b/Frontend/src/app/features/tracking/services/tracking.service.ts
@@ -25,11 +25,11 @@ export class TrackingService {
   }
 
   trackReference(reference: string): Observable<TrackingResponse> {
-    return this.trackPackage(reference);
+    return this.http.get<TrackingResponse>(`${this.baseUrl}/reference/${reference}`);
   }
 
   trackTcn(tcn: string): Observable<TrackingResponse> {
-    return this.trackPackage(tcn);
+    return this.http.get<TrackingResponse>(`${this.baseUrl}/tcn/${tcn}`);
   }
 
   decodeBarcodeServer(file: File): Observable<{ value: string }> {


### PR DESCRIPTION
## Summary
- use explicit `/reference` and `/tcn` endpoints when tracking by reference or TCN

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845a38a9374832ea34126918e5f20dd