### PR TITLE
Update FedEx tracking refresh logic

### DIFF
--- a/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.ts
+++ b/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.ts
@@ -106,14 +106,27 @@ export class FedexTrackResultComponent implements OnInit, OnDestroy {
   private updateLocation(): void {
     this.trackingService.trackPackage(this.identifier).subscribe({
       next: res => {
-        const loc = (res.data as FedexTrackingInfo | undefined)?.currentLocation;
-        if (loc && this.marker && this.map) {
-          const position = { lat: loc.latitude, lng: loc.longitude };
-          this.marker.setPosition(position);
-          this.map.panTo(position);
+        const data = res.data as FedexTrackingInfo | undefined;
+        if (res.success && data && this.trackingData) {
+          this.trackingData.status = data.status;
+          this.trackingData.tracking_history = data.tracking_history;
+          this.trackingData.currentLocation = data.currentLocation;
+
+          const loc = data.currentLocation;
+          if (loc && this.marker && this.map) {
+            const position = { lat: loc.latitude, lng: loc.longitude };
+            this.marker.setPosition(position);
+            this.map.panTo(position);
+          }
+
+          this.updateProgressBar();
+        } else if (!res.success) {
+          showNotification('Location update failed', 'error');
         }
       },
-      error: () => {}
+      error: () => {
+        showNotification('Location update failed', 'error');
+      }
     });
   }
 


### PR DESCRIPTION
## Summary
- update tracking data on `updateLocation()`
- recompute progress indicators after refresh
- notify when location update fails
- test progress and error handling

## Testing
- `npm test --prefix Frontend` *(fails: No binary for Chrome)*
- `pytest -q` *(fails: ModuleNotFoundError: sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_6845a377e418832eb2395cf8bb1375d0