### PR TITLE
Add change-address dialog test

### DIFF
--- a/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.spec.ts
+++ b/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.spec.ts
@@ -8,6 +8,7 @@ import { FedexTrackResultComponent } from './fedex-track-result.component';
 import { TrackingService } from '../services/tracking.service';
 import { AnalyticsService } from '../../../core/services/analytics.service';
 import { ScheduleDialogComponent } from './schedule-dialog.component';
+import { ChangeAddressDialogComponent } from './change-address-dialog.component';
 import { HoldLocationDialogComponent } from './hold-location-dialog.component';
 import { DeliveryInstructionsDialogComponent } from './delivery-instructions-dialog.component';
 import * as notificationUtil from '../../../shared/services/notification.util';
@@ -126,6 +127,13 @@ describe('FedexTrackResultComponent', () => {
 
     expect(dialog.open).toHaveBeenCalledWith(ScheduleDialogComponent, { width: '400px' });
     expect(analytics.logAction).toHaveBeenCalledWith('open_dialog', 'schedule');
+  });
+
+  it("openDialog('change-address') should open ChangeAddressDialogComponent and log action", () => {
+    component.openDialog('change-address');
+
+    expect(dialog.open).toHaveBeenCalledWith(ChangeAddressDialogComponent, { width: '400px' });
+    expect(analytics.logAction).toHaveBeenCalledWith('open_dialog', 'change-address');
   });
 
   it("openDialog('hold-location') should open HoldLocationDialogComponent and log action", () => {


### PR DESCRIPTION
## Summary
- test `openDialog('change-address')` to open the correct dialog and log the action

## Testing
- `pytest -q`
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a37a547c832eafcc0a6c0384cac3