### PR TITLE
Add ARIA and focus to FedEx map container

### DIFF
--- a/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.html
+++ b/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.html
@@ -91,7 +91,7 @@
     </div>
 
     <div class="grid md:grid-cols-2 gap-4 mb-4">
-      <div id="fedex-map" class="h-64 w-full bg-gray-200 rounded" *ngIf="trackingData">
+      <div id="fedex-map" role="region" aria-label="Tracking map" tabindex="0" class="h-64 w-full bg-gray-200 rounded" *ngIf="trackingData">
         <!-- Google Map will be rendered here -->
       </div>
       <div>


### PR DESCRIPTION
## Summary
- make the FedEx map container a region with a label
- allow focus on the map container when interactive

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845a37d7e04832e8bad9c82697390a1