### PR TITLE
Implement reference & TCN tracking tabs

### DIFF
--- a/Frontend/src/app/features/all-tracking-services/all-tracking-services.component.html
+++ b/Frontend/src/app/features/all-tracking-services/all-tracking-services.component.html
@@ -1,63 +1,26 @@
 <div class="ats">
   <h1>All Tracking Services</h1>
-  <div class="tabs">
-    <button class="tab"
-            role="button"
-            tabindex="0"
-            aria-label="Switch to single tracking"
-            [class.active]="activeTab==='single'"
-            (click)="switchTab('single')"
-            (keydown.enter)="switchTab('single')"
-            (keydown.space)="switchTab('single')">Single</button>
-    <button class="tab"
-            role="button"
-            tabindex="0"
-            aria-label="Switch to bulk tracking"
-            [class.active]="activeTab==='bulk'"
-            (click)="switchTab('bulk')"
-            (keydown.enter)="switchTab('bulk')"
-            (keydown.space)="switchTab('bulk')">Bulk</button>
-    <button class="tab"
-            role="button"
-            tabindex="0"
-            aria-label="Switch to barcode tracking"
-            [class.active]="activeTab==='barcode'"
-            (click)="switchTab('barcode')"
-            (keydown.enter)="switchTab('barcode')"
-            (keydown.space)="switchTab('barcode')">Barcode</button>
-  </div>
+  <app-tracking-tabs (tabChange)="switchTab($event)"></app-tracking-tabs>
 
   <div class="tab-content">
-    <app-tracking-form *ngIf="activeTab==='single'"
-                       class="single-form"
-                       [form]="singleForm"
-                       (formSubmit)="submitSingle()">
+    <app-tracking-form *ngIf="activeTab==='number'"
+                       [form]="numberForm"
+                       (formSubmit)="submitNumber()">
       Track
     </app-tracking-form>
 
-    <form *ngIf="activeTab==='bulk'" [formGroup]="bulkForm" (ngSubmit)="submitBulk()" class="bulk-form">
-      <div class="form-group">
-        <label>Tracking Numbers</label>
-        <textarea formControlName="trackingNumbers" rows="5" placeholder="One ID per line"></textarea>
-      </div>
-      <button type="submit"
-              class="btn btn--primary"
-              role="button"
-              tabindex="0"
-              aria-label="Track all packages">Track All</button>
-    </form>
+    <app-tracking-form *ngIf="activeTab==='reference'"
+                       [form]="referenceForm"
+                       [includePackageName]="false"
+                       (formSubmit)="submitReference()">
+      Track
+    </app-tracking-form>
 
-    <div *ngIf="activeTab==='barcode'" class="barcode-form">
-      <p>Scan your barcode using the camera.</p>
-      <button type="button"
-              class="btn btn--primary"
-              role="button"
-              tabindex="0"
-              aria-label="Start barcode scan"
-              (click)="startBarcodeScan()"
-              (keydown.enter)="startBarcodeScan()"
-              (keydown.space)="startBarcodeScan()">Start Scan</button>
-      <app-barcode-upload [control]="singleForm.get('trackingNumber')"></app-barcode-upload>
-    </div>
+    <app-tracking-form *ngIf="activeTab==='tcn'"
+                       [form]="tcnForm"
+                       [includePackageName]="false"
+                       (formSubmit)="submitTcn()">
+      Track
+    </app-tracking-form>
   </div>
 </div>

--- a/Frontend/src/app/features/all-tracking-services/all-tracking-services.component.scss
+++ b/Frontend/src/app/features/all-tracking-services/all-tracking-services.component.scss
@@ -4,44 +4,7 @@
   padding: 20px;
 }
 
-.tabs {
-  display: flex;
-  margin-bottom: 20px;
-}
 
-.tab {
-  flex: 1;
-  padding: 10px;
-  border: 1px solid #ccc;
-  background: #f5f5f5;
-  cursor: pointer;
-  text-align: center;
-
-  &:focus {
-    outline: 2px solid #4d148c;
-    outline-offset: 2px;
-  }
-}
-
-.tab.active {
-  background: #4d148c;
-  color: #fff;
-}
-
-.tab + .tab {
-  margin-left: 5px;
-}
-
-@media (max-width: 600px) {
-  .tabs {
-    flex-direction: column;
-  }
-
-  .tab + .tab {
-    margin-left: 0;
-    margin-top: 5px;
-  }
-}
 
 @media (max-width: 480px) {
   input,
@@ -51,22 +14,7 @@
   }
 }
 
-.single-form,
-.bulk-form,
-.barcode-form {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
 
-.single-form button,
-.bulk-form button,
-.barcode-form button {
-  &:focus {
-    outline: 2px solid #4d148c;
-    outline-offset: 2px;
-  }
-}
 
 .error {
   color: #d9534f;


### PR DESCRIPTION
## Summary
- enable `TrackingTabsComponent` for AllTrackingServicesComponent
- add forms for tracking by number, reference and TCN
- navigate to `TrackResultComponent` after submissions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6845a7e54db8832eb2b39dd94145b376