### PR TITLE
Add unified tracking tabs

### DIFF
--- a/Frontend/src/app/features/all-tracking-services/all-tracking-services.component.html
+++ b/Frontend/src/app/features/all-tracking-services/all-tracking-services.component.html
@@ -1,63 +1,28 @@
 <div class="ats">
   <h1>All Tracking Services</h1>
-  <div class="tabs">
-    <button class="tab"
-            role="button"
-            tabindex="0"
-            aria-label="Switch to single tracking"
-            [class.active]="activeTab==='single'"
-            (click)="switchTab('single')"
-            (keydown.enter)="switchTab('single')"
-            (keydown.space)="switchTab('single')">Single</button>
-    <button class="tab"
-            role="button"
-            tabindex="0"
-            aria-label="Switch to bulk tracking"
-            [class.active]="activeTab==='bulk'"
-            (click)="switchTab('bulk')"
-            (keydown.enter)="switchTab('bulk')"
-            (keydown.space)="switchTab('bulk')">Bulk</button>
-    <button class="tab"
-            role="button"
-            tabindex="0"
-            aria-label="Switch to barcode tracking"
-            [class.active]="activeTab==='barcode'"
-            (click)="switchTab('barcode')"
-            (keydown.enter)="switchTab('barcode')"
-            (keydown.space)="switchTab('barcode')">Barcode</button>
-  </div>
+  <app-tracking-tabs (tabChange)="switchTab($event)"></app-tracking-tabs>
 
   <div class="tab-content">
-    <app-tracking-form *ngIf="activeTab==='single'"
+    <app-tracking-form *ngIf="activeTab==='number'"
                        class="single-form"
                        [form]="singleForm"
                        (formSubmit)="submitSingle()">
       Track
     </app-tracking-form>
 
-    <form *ngIf="activeTab==='bulk'" [formGroup]="bulkForm" (ngSubmit)="submitBulk()" class="bulk-form">
-      <div class="form-group">
-        <label>Tracking Numbers</label>
-        <textarea formControlName="trackingNumbers" rows="5" placeholder="One ID per line"></textarea>
-      </div>
-      <button type="submit"
-              class="btn btn--primary"
-              role="button"
-              tabindex="0"
-              aria-label="Track all packages">Track All</button>
+    <form *ngIf="activeTab==='reference'" [formGroup]="referenceForm" (ngSubmit)="submitReference()" class="reference-form">
+      <input type="text" formControlName="reference" placeholder="Reference" />
+      <button type="submit" class="btn btn--primary">Track</button>
     </form>
 
-    <div *ngIf="activeTab==='barcode'" class="barcode-form">
-      <p>Scan your barcode using the camera.</p>
-      <button type="button"
-              class="btn btn--primary"
-              role="button"
-              tabindex="0"
-              aria-label="Start barcode scan"
-              (click)="startBarcodeScan()"
-              (keydown.enter)="startBarcodeScan()"
-              (keydown.space)="startBarcodeScan()">Start Scan</button>
-      <app-barcode-upload [control]="singleForm.get('trackingNumber')"></app-barcode-upload>
-    </div>
+    <form *ngIf="activeTab==='tcn'" [formGroup]="tcnForm" (ngSubmit)="submitTcn()" class="tcn-form">
+      <input type="text" formControlName="tcn" placeholder="TCN" />
+      <button type="submit" class="btn btn--primary">Track</button>
+    </form>
+
+    <form *ngIf="activeTab==='proof'" [formGroup]="proofForm" (ngSubmit)="downloadProof()" class="proof-form">
+      <input type="text" formControlName="trackingNumber" placeholder="Tracking number" />
+      <button type="submit" class="btn btn--primary">Download Proof</button>
+    </form>
   </div>
 </div>

--- a/Frontend/src/app/features/all-tracking-services/all-tracking-services.component.scss
+++ b/Frontend/src/app/features/all-tracking-services/all-tracking-services.component.scss
@@ -4,44 +4,6 @@
   padding: 20px;
 }
 
-.tabs {
-  display: flex;
-  margin-bottom: 20px;
-}
-
-.tab {
-  flex: 1;
-  padding: 10px;
-  border: 1px solid #ccc;
-  background: #f5f5f5;
-  cursor: pointer;
-  text-align: center;
-
-  &:focus {
-    outline: 2px solid #4d148c;
-    outline-offset: 2px;
-  }
-}
-
-.tab.active {
-  background: #4d148c;
-  color: #fff;
-}
-
-.tab + .tab {
-  margin-left: 5px;
-}
-
-@media (max-width: 600px) {
-  .tabs {
-    flex-direction: column;
-  }
-
-  .tab + .tab {
-    margin-left: 0;
-    margin-top: 5px;
-  }
-}
 
 @media (max-width: 480px) {
   input,
@@ -52,16 +14,18 @@
 }
 
 .single-form,
-.bulk-form,
-.barcode-form {
+.reference-form,
+.tcn-form,
+.proof-form {
   display: flex;
   flex-direction: column;
   gap: 10px;
 }
 
 .single-form button,
-.bulk-form button,
-.barcode-form button {
+.reference-form button,
+.tcn-form button,
+.proof-form button {
   &:focus {
     outline: 2px solid #4d148c;
     outline-offset: 2px;

--- a/Frontend/src/app/features/all-tracking-services/all-tracking-services.component.ts
+++ b/Frontend/src/app/features/all-tracking-services/all-tracking-services.component.ts
@@ -3,21 +3,26 @@ import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { TrackingService } from '../tracking/services/tracking.service';
 import { AnalyticsService } from '../../core/services/analytics.service';
-import { BarcodeUploadComponent } from '../barcode-upload/barcode-upload.component';
 import { TrackingFormComponent } from '../../shared/components/tracking-form/tracking-form.component';
+import { TrackingTabsComponent } from '../../shared/components/tracking-tabs/tracking-tabs.component';
 
 @Component({
   selector: 'app-all-tracking-services',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, BarcodeUploadComponent, TrackingFormComponent],
+  imports: [CommonModule,
+    ReactiveFormsModule,
+    TrackingFormComponent,
+    TrackingTabsComponent],
   templateUrl: './all-tracking-services.component.html',
   styleUrls: ['./all-tracking-services.component.scss']
 })
 export class AllTrackingServicesComponent {
-  activeTab: 'single' | 'bulk' | 'barcode' = 'single';
+  activeTab: 'number' | 'reference' | 'tcn' | 'proof' = 'number';
 
   singleForm: FormGroup;
-  bulkForm: FormGroup;
+  referenceForm: FormGroup;
+  tcnForm: FormGroup;
+  proofForm: FormGroup;
 
   constructor(
     private fb: FormBuilder,
@@ -28,12 +33,18 @@ export class AllTrackingServicesComponent {
       trackingNumber: ['', [Validators.required, Validators.pattern('^[A-Z0-9]{10,}$')]],
       packageName: ['']
     });
-    this.bulkForm = this.fb.group({
-      trackingNumbers: ['', Validators.required]
+    this.referenceForm = this.fb.group({
+      reference: ['', Validators.required]
+    });
+    this.tcnForm = this.fb.group({
+      tcn: ['', Validators.required]
+    });
+    this.proofForm = this.fb.group({
+      trackingNumber: ['', Validators.required]
     });
   }
 
-  switchTab(tab: 'single' | 'bulk' | 'barcode'): void {
+  switchTab(tab: 'number' | 'reference' | 'tcn' | 'proof'): void {
     this.activeTab = tab;
     this.analytics.logAction('switch_tab', tab);
   }
@@ -48,23 +59,33 @@ export class AllTrackingServicesComponent {
     this.trackingService.trackNumber(trackingNumber, packageName).subscribe();
   }
 
-  submitBulk(): void {
-    if (this.bulkForm.invalid) {
-      this.bulkForm.markAllAsTouched();
+  submitReference(): void {
+    if (this.referenceForm.invalid) {
+      this.referenceForm.markAllAsTouched();
       return;
     }
-    const numbers = this.bulkForm.value.trackingNumbers
-      .split(/\r?\n/)
-      .map((n: string) => n.trim())
-      .filter((n: string) => n);
-    console.log('Track bulk', numbers);
-    this.analytics.logAction('submit_bulk', numbers.length);
-    // Placeholder for bulk tracking logic
+    const ref = this.referenceForm.value.reference;
+    this.analytics.logAction('submit_reference', ref);
+    this.trackingService.trackReference(ref).subscribe();
   }
 
-  startBarcodeScan(): void {
-    // Placeholder for barcode scanning implementation
-    this.analytics.logAction('start_barcode_scan');
-    console.log('Barcode scan feature coming soon');
+  submitTcn(): void {
+    if (this.tcnForm.invalid) {
+      this.tcnForm.markAllAsTouched();
+      return;
+    }
+    const tcn = this.tcnForm.value.tcn;
+    this.analytics.logAction('submit_tcn', tcn);
+    this.trackingService.trackTcn(tcn).subscribe();
+  }
+
+  downloadProof(): void {
+    if (this.proofForm.invalid) {
+      this.proofForm.markAllAsTouched();
+      return;
+    }
+    const tn = this.proofForm.value.trackingNumber;
+    this.analytics.logAction('download_proof', tn);
+    this.trackingService.downloadProof(tn).subscribe();
   }
 }


### PR DESCRIPTION
## Summary
- replace local tab structure in all-tracking-services with shared `app-tracking-tabs`
- adjust component logic to handle tab changes and new forms
- clean old tab styles

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6845a7e72aec832ebe17f4e776530648