### PR TITLE
Add dialog validation tests

### DIFF
--- a/Frontend/src/app/features/tracking/fedex-track-result/change-address-dialog.component.spec.ts
+++ b/Frontend/src/app/features/tracking/fedex-track-result/change-address-dialog.component.spec.ts
@@ -1,0 +1,39 @@
+import { TestBed } from '@angular/core/testing';
+import { MatDialogRef } from '@angular/material/dialog';
+import { ChangeAddressDialogComponent } from './change-address-dialog.component';
+import * as notificationUtil from '../../../shared/services/notification.util';
+
+describe('ChangeAddressDialogComponent', () => {
+  let component: ChangeAddressDialogComponent;
+  let dialogRef: jasmine.SpyObj<MatDialogRef<ChangeAddressDialogComponent>>;
+
+  beforeEach(async () => {
+    dialogRef = jasmine.createSpyObj('MatDialogRef', ['close']);
+
+    await TestBed.configureTestingModule({
+      imports: [ChangeAddressDialogComponent],
+      providers: [{ provide: MatDialogRef, useValue: dialogRef }]
+    }).compileComponents();
+
+    component = TestBed.createComponent(ChangeAddressDialogComponent).componentInstance;
+    spyOn(notificationUtil, 'showNotification');
+  });
+
+  afterEach(() => {
+    (notificationUtil.showNotification as jasmine.Spy).calls.reset();
+    dialogRef.close.calls.reset();
+  });
+
+  it('should not close dialog when form invalid', () => {
+    component.confirm();
+    expect(dialogRef.close).not.toHaveBeenCalled();
+    expect(notificationUtil.showNotification).not.toHaveBeenCalled();
+  });
+
+  it('should close dialog and show notification on confirm', () => {
+    component.form.setValue({ name: 'n', street: 's', city: 'c', postal: 'p' });
+    component.confirm();
+    expect(dialogRef.close).toHaveBeenCalledWith({ name: 'n', street: 's', city: 'c', postal: 'p' });
+    expect(notificationUtil.showNotification).toHaveBeenCalledWith('Address updated', 'success');
+  });
+});

--- a/Frontend/src/app/features/tracking/fedex-track-result/delivery-instructions-dialog.component.spec.ts
+++ b/Frontend/src/app/features/tracking/fedex-track-result/delivery-instructions-dialog.component.spec.ts
@@ -1,0 +1,39 @@
+import { TestBed } from '@angular/core/testing';
+import { MatDialogRef } from '@angular/material/dialog';
+import { DeliveryInstructionsDialogComponent } from './delivery-instructions-dialog.component';
+import * as notificationUtil from '../../../shared/services/notification.util';
+
+describe('DeliveryInstructionsDialogComponent', () => {
+  let component: DeliveryInstructionsDialogComponent;
+  let dialogRef: jasmine.SpyObj<MatDialogRef<DeliveryInstructionsDialogComponent>>;
+
+  beforeEach(async () => {
+    dialogRef = jasmine.createSpyObj('MatDialogRef', ['close']);
+
+    await TestBed.configureTestingModule({
+      imports: [DeliveryInstructionsDialogComponent],
+      providers: [{ provide: MatDialogRef, useValue: dialogRef }]
+    }).compileComponents();
+
+    component = TestBed.createComponent(DeliveryInstructionsDialogComponent).componentInstance;
+    spyOn(notificationUtil, 'showNotification');
+  });
+
+  afterEach(() => {
+    (notificationUtil.showNotification as jasmine.Spy).calls.reset();
+    dialogRef.close.calls.reset();
+  });
+
+  it('should not close dialog when form invalid', () => {
+    component.confirm();
+    expect(dialogRef.close).not.toHaveBeenCalled();
+    expect(notificationUtil.showNotification).not.toHaveBeenCalled();
+  });
+
+  it('should close dialog and show notification on confirm', () => {
+    component.form.setValue({ instructions: 'test' });
+    component.confirm();
+    expect(dialogRef.close).toHaveBeenCalledWith({ instructions: 'test' });
+    expect(notificationUtil.showNotification).toHaveBeenCalledWith('Instructions saved', 'success');
+  });
+});

--- a/Frontend/src/app/features/tracking/fedex-track-result/hold-location-dialog.component.spec.ts
+++ b/Frontend/src/app/features/tracking/fedex-track-result/hold-location-dialog.component.spec.ts
@@ -1,0 +1,39 @@
+import { TestBed } from '@angular/core/testing';
+import { MatDialogRef } from '@angular/material/dialog';
+import { HoldLocationDialogComponent } from './hold-location-dialog.component';
+import * as notificationUtil from '../../../shared/services/notification.util';
+
+describe('HoldLocationDialogComponent', () => {
+  let component: HoldLocationDialogComponent;
+  let dialogRef: jasmine.SpyObj<MatDialogRef<HoldLocationDialogComponent>>;
+
+  beforeEach(async () => {
+    dialogRef = jasmine.createSpyObj('MatDialogRef', ['close']);
+
+    await TestBed.configureTestingModule({
+      imports: [HoldLocationDialogComponent],
+      providers: [{ provide: MatDialogRef, useValue: dialogRef }]
+    }).compileComponents();
+
+    component = TestBed.createComponent(HoldLocationDialogComponent).componentInstance;
+    spyOn(notificationUtil, 'showNotification');
+  });
+
+  afterEach(() => {
+    (notificationUtil.showNotification as jasmine.Spy).calls.reset();
+    dialogRef.close.calls.reset();
+  });
+
+  it('should not close dialog when form invalid', () => {
+    component.confirm();
+    expect(dialogRef.close).not.toHaveBeenCalled();
+    expect(notificationUtil.showNotification).not.toHaveBeenCalled();
+  });
+
+  it('should close dialog and show notification on confirm', () => {
+    component.form.setValue({ location: 'loc', date: '2024-01-01' });
+    component.confirm();
+    expect(dialogRef.close).toHaveBeenCalledWith({ location: 'loc', date: '2024-01-01' });
+    expect(notificationUtil.showNotification).toHaveBeenCalledWith('Hold location saved', 'success');
+  });
+});

--- a/Frontend/src/app/features/tracking/fedex-track-result/schedule-dialog.component.spec.ts
+++ b/Frontend/src/app/features/tracking/fedex-track-result/schedule-dialog.component.spec.ts
@@ -1,0 +1,39 @@
+import { TestBed } from '@angular/core/testing';
+import { MatDialogRef } from '@angular/material/dialog';
+import { ScheduleDialogComponent } from './schedule-dialog.component';
+import * as notificationUtil from '../../../shared/services/notification.util';
+
+describe('ScheduleDialogComponent', () => {
+  let component: ScheduleDialogComponent;
+  let dialogRef: jasmine.SpyObj<MatDialogRef<ScheduleDialogComponent>>;
+
+  beforeEach(async () => {
+    dialogRef = jasmine.createSpyObj('MatDialogRef', ['close']);
+
+    await TestBed.configureTestingModule({
+      imports: [ScheduleDialogComponent],
+      providers: [{ provide: MatDialogRef, useValue: dialogRef }]
+    }).compileComponents();
+
+    component = TestBed.createComponent(ScheduleDialogComponent).componentInstance;
+    spyOn(notificationUtil, 'showNotification');
+  });
+
+  afterEach(() => {
+    (notificationUtil.showNotification as jasmine.Spy).calls.reset();
+    dialogRef.close.calls.reset();
+  });
+
+  it('should not close dialog when form invalid', () => {
+    component.confirm();
+    expect(dialogRef.close).not.toHaveBeenCalled();
+    expect(notificationUtil.showNotification).not.toHaveBeenCalled();
+  });
+
+  it('should close dialog and show notification on confirm', () => {
+    component.form.setValue({ date: '2024-01-01', time: '12:00' });
+    component.confirm();
+    expect(dialogRef.close).toHaveBeenCalledWith({ date: '2024-01-01', time: '12:00' });
+    expect(notificationUtil.showNotification).toHaveBeenCalledWith('Schedule saved', 'success');
+  });
+});

--- a/Frontend/src/app/shared/components/tracking-form/tracking-form.component.scss
+++ b/Frontend/src/app/shared/components/tracking-form/tracking-form.component.scss
@@ -1,1 +1,1 @@
-@import '../../features/home/home.component.scss';
+// @import '../../features/home/home.component.scss';


### PR DESCRIPTION
## Summary
- add unit tests for FedEx dialog components
- comment out unused SCSS import breaking tests

## Testing
- `npm test --silent -- --browsers=ChromeHeadless --watch=false --progress=false` *(fails: No Chrome binary)*
- `pytest -q` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6845aad30274832eb7c6b567e36ccf35