### PR TITLE
Fix barcode decode response key

### DIFF
--- a/Frontend/src/app/features/barcode-upload/barcode-upload.component.ts
+++ b/Frontend/src/app/features/barcode-upload/barcode-upload.component.ts
@@ -37,9 +37,9 @@ export class BarcodeUploadComponent {
 
   private decode(file: File) {
     this.trackingService.decodeBarcodeServer(file).subscribe({
-      next: ({ value }) => {
+      next: ({ barcode }) => {
         if (this.control) {
-          this.control.setValue(value);
+          this.control.setValue(barcode);
           this.control.markAsTouched();
           this.control.updateValueAndValidity();
         }

--- a/Frontend/src/app/features/tracking/services/tracking.service.ts
+++ b/Frontend/src/app/features/tracking/services/tracking.service.ts
@@ -32,10 +32,10 @@ export class TrackingService {
     return this.http.get<TrackingResponse>(`${this.baseUrl}/tcn/${tcn}`);
   }
 
-  decodeBarcodeServer(file: File): Observable<{ value: string }> {
+  decodeBarcodeServer(file: File): Observable<{ barcode: string }> {
     const formData = new FormData();
     formData.append('file', file);
-    return this.http.post<{ value: string }>(`${this.baseUrl}/barcode/decode`, formData);
+    return this.http.post<{ barcode: string }>(`${this.baseUrl}/barcode/decode`, formData);
   }
 
 


### PR DESCRIPTION
## Summary
- handle `{ barcode }` response in barcode upload component
- return observable with `barcode` from tracking service

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845acf55088832ebf9ac158f58e1939