### PR TITLE
Remove stray await in proof-of-delivery endpoint

### DIFF
--- a/backend/app/api/v1/endpoints/tracking.py
+++ b/backend/app/api/v1/endpoints/tracking.py
@@ -371,7 +371,7 @@ async def get_proof_of_delivery(identifier: str, db: Session = Depends(get_db)):
     colis_service = ColisService(db)
     fedex_service = FedExService()
 
-    colis = await colis_service.get_colis_by_identifier(identifier)
+    colis = colis_service.get_colis_by_identifier(identifier)
     tracking_number = colis.id if colis else identifier
 
     try:


### PR DESCRIPTION
## Summary
- remove `await` when calling `get_colis_by_identifier`

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845acf6212c832eae3b99ab8af589e9