### PR TITLE
Add barcode upload to tracking services

### DIFF
--- a/Frontend/src/app/features/all-tracking-services/all-tracking-services.component.html
+++ b/Frontend/src/app/features/all-tracking-services/all-tracking-services.component.html
@@ -8,6 +8,7 @@
                        (formSubmit)="submitNumber()">
       Track
     </app-tracking-form>
+    <app-barcode-upload *ngIf="activeTab==='number'" [control]="numberForm.get('trackingNumber')"></app-barcode-upload>
 
     <app-tracking-form *ngIf="activeTab==='reference'"
                        [form]="referenceForm"

--- a/Frontend/src/app/features/all-tracking-services/all-tracking-services.component.ts
+++ b/Frontend/src/app/features/all-tracking-services/all-tracking-services.component.ts
@@ -6,6 +6,7 @@ import { TrackingService } from '../tracking/services/tracking.service';
 import { AnalyticsService } from '../../core/services/analytics.service';
 import { TrackingFormComponent } from '../../shared/components/tracking-form/tracking-form.component';
 import { TrackingTabsComponent } from '../../shared/components/tracking-tabs/tracking-tabs.component';
+import { BarcodeUploadComponent } from '../barcode-upload/barcode-upload.component';
 
 @Component({
   selector: 'app-all-tracking-services',
@@ -15,7 +16,8 @@ import { TrackingTabsComponent } from '../../shared/components/tracking-tabs/tra
     ReactiveFormsModule,
     RouterModule,
     TrackingFormComponent,
-    TrackingTabsComponent
+    TrackingTabsComponent,
+    BarcodeUploadComponent
   ],
   templateUrl: './all-tracking-services.component.html',
   styleUrls: ['./all-tracking-services.component.scss']


### PR DESCRIPTION
## Summary
- integrate `BarcodeUploadComponent` within `AllTrackingServicesComponent`
- show barcode file upload below the tracking-number form

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845acf7c988832e9f21aea57a0f4481