### PR TITLE
Add Playwright e2e tests

### DIFF
--- a/Frontend/e2e/tracking.spec.ts
+++ b/Frontend/e2e/tracking.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test';
+
+// Mock response for the tracking API
+const mockTracking = {
+  success: true,
+  data: {
+    tracking_number: 'FEDEXID',
+    carrier: 'FedEx',
+    status: { status: 'In transit', description: 'On the way', is_delivered: false },
+    tracking_history: [{ status: 'In transit', description: 'Departed', timestamp: '2024-01-01T00:00:00Z' }],
+    currentLocation: { latitude: 33.5, longitude: -7.6 }
+  }
+};
+
+test('tracking flow', async ({ page }) => {
+  // Intercept backend call and return mock data
+  await page.route('**/api/v1/tracking/*', route => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(mockTracking)
+    });
+  });
+
+  await page.goto('/tracking/FEDEXID');
+
+  // Wait for timeline
+  await expect(page.getByRole('list', { name: 'Historique du suivi' })).toBeVisible();
+  // Map region
+  await expect(page.getByRole('region', { name: 'Tracking map' })).toBeVisible();
+
+  // Open and close a modal
+  await page.getByRole('button', { name: 'Schedule' }).click();
+  await expect(page.getByRole('dialog')).toBeVisible();
+  await page.keyboard.press('Escape');
+
+  // Test share button
+  await page.evaluate(() => {
+    (navigator as any).share = () => Promise.resolve();
+  });
+  await page.getByRole('button', { name: 'Share' }).click();
+
+  // Print button
+  await page.evaluate(() => { window.print = () => {}; });
+  await page.getByRole('button', { name: 'Print' }).click();
+
+  // Save button
+  await page.getByRole('button', { name: 'Save' }).click();
+  const saved = await page.evaluate(() => localStorage.getItem('savedTrackingNumbers'));
+  expect(saved).toContain('FEDEXID');
+
+  // Export PDF
+  await page.route('**/export?format=pdf', route => route.fulfill({ status: 200, body: '' }));
+  await page.getByRole('button', { name: 'Export PDF' }).click();
+
+  // Export CSV
+  await page.route('**/export?format=csv', route => route.fulfill({ status: 200, body: '' }));
+  await page.getByRole('button', { name: 'Export CSV' }).click();
+});

--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -29,6 +29,7 @@
         "@angular-devkit/build-angular": "^19.2.12",
         "@angular/cli": "^19.2.12",
         "@angular/compiler-cli": "^19.2.0",
+        "@playwright/test": "^1.42.1",
         "@types/jasmine": "~5.1.0",
         "dotenv-webpack": "^8.0.1",
         "jasmine-core": "~5.6.0",
@@ -4691,6 +4692,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.52.0.tgz",
+      "integrity": "sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -11684,6 +11701,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0.tgz",
+      "integrity": "sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0.tgz",
+      "integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -6,7 +6,8 @@
     "start": "ng serve",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test"
+    "test": "ng test",
+    "test:e2e": "playwright test"
   },
   "private": true,
   "dependencies": {
@@ -40,5 +41,6 @@
     "typescript": "~5.7.2",
     "@angular-builders/custom-webpack": "^19.0.1",
     "dotenv-webpack": "^8.0.1"
+    ,"@playwright/test": "^1.42.1"
   }
 }

--- a/Frontend/playwright.config.ts
+++ b/Frontend/playwright.config.ts
@@ -1,0 +1,11 @@
+import { PlaywrightTestConfig } from '@playwright/test';
+
+const config: PlaywrightTestConfig = {
+  testDir: './e2e',
+  use: {
+    headless: true,
+    baseURL: 'http://localhost:4200',
+  },
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- set up Playwright for Angular app
- add tracking flow test covering timeline, map, modals and buttons

## Testing
- `pytest -q`
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6845aad455b8832e8016f93791ada284