### PR TITLE
Fix error feedback in track result

### DIFF
--- a/Frontend/src/app/features/tracking/track-result/track-result.component.ts
+++ b/Frontend/src/app/features/tracking/track-result/track-result.component.ts
@@ -95,6 +95,7 @@ export class TrackResultComponent implements OnInit, OnDestroy {
         this.loading = false;
         this.refreshing = false;
         console.error('Erreur de suivi:', err);
+        showNotification(this.error, 'error');
       }
     });
   }
@@ -141,6 +142,7 @@ export class TrackResultComponent implements OnInit, OnDestroy {
       error: (err) => {
         this.error = err.error?.error || 'Aucune preuve de livraison disponible';
         console.error('Erreur de preuve:', err);
+        showNotification(this.error, 'error');
       }
     });
   }


### PR DESCRIPTION
## Summary
- surface errors from tracking API and proof download as UI notifications

## Testing
- `npm install --prefix Frontend`
- `python3 -m pip install -r backend/requirements.txt`
- `pytest -q`
- `npm test --prefix Frontend` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6845b1cca56c832e927fc5097f98ab22