### PR TITLE
Improve barcode upload styling

### DIFF
--- a/Frontend/src/app/features/barcode-upload/barcode-upload.component.html
+++ b/Frontend/src/app/features/barcode-upload/barcode-upload.component.html
@@ -1,4 +1,9 @@
-<div class="upload-wrapper" (dragover)="onDragOver($event)" (drop)="onDrop($event)">
+<div class="upload-wrapper"
+     [class.drag-over]="isDragOver"
+     [class.file-selected]="fileSelected"
+     (dragover)="onDragOver($event)"
+     (dragleave)="onDragLeave($event)"
+     (drop)="onDrop($event)">
   <p>Déposez une image ou choisissez un fichier :</p>
   <input type="file" accept="image/*" (change)="onFileSelected($event)" />
 </div>

--- a/Frontend/src/app/features/barcode-upload/barcode-upload.component.scss
+++ b/Frontend/src/app/features/barcode-upload/barcode-upload.component.scss
@@ -1,6 +1,29 @@
+@use "sass:color";
+
+$primary-color: #4d148c; // FedEx purple
+$light-gray: #f5f5f5;
+
 .upload-wrapper {
-  border: 2px dashed #ccc;
+  border: 2px dashed $primary-color;
   padding: 1rem;
   text-align: center;
   cursor: pointer;
+  background-color: $light-gray;
+  font-family: Roboto, "Helvetica Neue", sans-serif;
+  transition: border-color 0.3s ease, background-color 0.3s ease;
+
+  &:hover,
+  &.drag-over {
+    border-color: color.mix($primary-color, black, 10%);
+    background-color: color.mix($light-gray, $primary-color, 10%);
+  }
+
+  &.file-selected {
+    border-style: solid;
+    background-color: color.mix($light-gray, $primary-color, 20%);
+  }
+
+  input[type='file'] {
+    font-family: inherit;
+  }
 }

--- a/Frontend/src/app/features/barcode-upload/barcode-upload.component.ts
+++ b/Frontend/src/app/features/barcode-upload/barcode-upload.component.ts
@@ -13,11 +13,14 @@ import { showNotification } from '../../shared/services/notification.util';
 })
 export class BarcodeUploadComponent {
   @Input() control: AbstractControl | null = null;
+  isDragOver = false;
+  fileSelected = false;
 
   constructor(private trackingService: TrackingService) {}
 
   onFileSelected(event: any): void {
     const file: File = event.target.files?.[0];
+    this.fileSelected = !!file;
     if (file) {
       this.decode(file);
     }
@@ -25,7 +28,9 @@ export class BarcodeUploadComponent {
 
   onDrop(event: DragEvent): void {
     event.preventDefault();
+    this.isDragOver = false;
     const file = event.dataTransfer?.files?.[0];
+    this.fileSelected = !!file;
     if (file) {
       this.decode(file);
     }
@@ -33,6 +38,12 @@ export class BarcodeUploadComponent {
 
   onDragOver(event: DragEvent): void {
     event.preventDefault();
+    this.isDragOver = true;
+  }
+
+  onDragLeave(event: DragEvent): void {
+    event.preventDefault();
+    this.isDragOver = false;
   }
 
   private decode(file: File) {


### PR DESCRIPTION
## Summary
- adjust barcode upload styles
- update barcode upload markup and ts logic for drag/selected states

## Testing
- `pytest -q`
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845b2a080b0832eaa7d6e875d684a8d