### PR TITLE
Update SECRET_KEY error message

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -27,7 +27,9 @@ class Settings(BaseSettings):
     # Security
     SECRET_KEY: Optional[str] = os.environ.get("SECRET_KEY")
     if not SECRET_KEY:
-        raise ValueError("SECRET_KEY must be set")
+        raise ValueError(
+            "SECRET_KEY must be set (see README: Environment Variables)"
+        )
     ALGORITHM: str = "HS256"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
     REFRESH_TOKEN_EXPIRE_DAYS: int = 7

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,20 @@
+import importlib
+import os
+import pytest
+
+# Ensure other required env vars are present
+os.environ.setdefault('FEDEX_CLIENT_ID', 'dummy')
+os.environ.setdefault('FEDEX_CLIENT_SECRET', 'dummy')
+os.environ.setdefault('FEDEX_ACCOUNT_NUMBER', 'dummy')
+
+import backend.app.config as config_module
+
+
+def test_secret_key_required(monkeypatch):
+    monkeypatch.delenv('SECRET_KEY', raising=False)
+    with pytest.raises(ValueError) as excinfo:
+        importlib.reload(config_module)
+    assert (
+        "SECRET_KEY must be set (see README: Environment Variables)"
+        in str(excinfo.value)
+    )


### PR DESCRIPTION
## Summary
- mention README in missing SECRET_KEY error
- add a unit test covering the new message

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845d62bff74832eae2f5fcff751da4d