### PR TITLE
Enhance tracking history logging

### DIFF
--- a/Frontend/src/app/core/services/tracking-history.service.ts
+++ b/Frontend/src/app/core/services/tracking-history.service.ts
@@ -18,13 +18,23 @@ export class TrackingHistoryService {
     return raw ? JSON.parse(raw) as string[] : [];
   }
 
-  addIdentifier(id: string): void {
+  addIdentifier(id: string, status?: string, note?: string, metaData?: any): void {
     const history = this.getHistory().filter(item => item !== id);
     history.unshift(id);
     if (history.length > this.maxItems) {
       history.pop();
     }
     localStorage.setItem(this.storageKey, JSON.stringify(history));
+
+    const payload: any = { tracking_number: id };
+    if (status !== undefined) payload.status = status;
+    if (note !== undefined) payload.note = note;
+    if (metaData !== undefined) payload.meta_data = metaData;
+
+    this.http.post(`${environment.apiUrl}/history`, payload).subscribe({
+      next: () => {},
+      error: () => {}
+    });
   }
 
   removeIdentifier(id: string): void {

--- a/backend/app/api/v1/endpoints/history.py
+++ b/backend/app/api/v1/endpoints/history.py
@@ -4,15 +4,33 @@ from ....services.auth import get_current_active_user
 from ....database import get_db
 from ....models.user import UserDB
 from ....services.tracking_history_service import TrackingHistoryService
-from ....models.tracking_history import TrackedShipment
+from ....models.tracking_history import TrackedShipment, TrackedShipmentCreate
 
 router = APIRouter()
+
 
 @router.get("/", response_model=list[TrackedShipment])
 async def get_history(
     current_user: UserDB = Depends(get_current_active_user),
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
 ):
     service = TrackingHistoryService(db)
     records = service.get_history(current_user.id)
     return records
+
+
+@router.post("/", response_model=TrackedShipment)
+async def add_history(
+    shipment: TrackedShipmentCreate,
+    current_user: UserDB = Depends(get_current_active_user),
+    db: Session = Depends(get_db),
+):
+    service = TrackingHistoryService(db)
+    record = service.log_search(
+        user_id=current_user.id,
+        tracking_number=shipment.tracking_number,
+        status=shipment.status,
+        meta_data=shipment.meta_data,
+        note=shipment.note,
+    )
+    return record

--- a/backend/app/api/v1/endpoints/tracking.py
+++ b/backend/app/api/v1/endpoints/tracking.py
@@ -89,7 +89,12 @@ async def create_package(
         if request:
             try:
                 user = await get_current_user(request, db, token)
-                TrackingHistoryService(db).log_search(user.id, colis_data.id)
+                TrackingHistoryService(db).log_search(
+                    user.id,
+                    colis_data.id,
+                    status=response.data.status if response.data else None,
+                    meta_data=response.metadata,
+                )
             except Exception:
                 pass
 
@@ -180,7 +185,12 @@ async def track_package(
         if request:
             try:
                 user = await get_current_user(request, db, token)
-                TrackingHistoryService(db).log_search(user.id, identifier)
+                TrackingHistoryService(db).log_search(
+                    user.id,
+                    identifier,
+                    status=response.data.status if response.data else None,
+                    meta_data=response.metadata,
+                )
             except Exception:
                 pass
 

--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -1,4 +1,14 @@
-from sqlalchemy import Column, String, Boolean, DateTime, JSON, Enum as SQLEnum, ForeignKey, Float, Integer
+from sqlalchemy import (
+    Column,
+    String,
+    Boolean,
+    DateTime,
+    JSON,
+    Enum as SQLEnum,
+    ForeignKey,
+    Float,
+    Integer,
+)
 from sqlalchemy.orm import relationship, declarative_base
 from datetime import datetime
 from .notification import NotificationType, NotificationPriority
@@ -7,6 +17,7 @@ from sqlalchemy.sql import func
 import uuid
 
 Base = declarative_base()
+
 
 class NotificationDB(Base):
     __tablename__ = "notifications"
@@ -21,7 +32,6 @@ class NotificationDB(Base):
     created_at = Column(DateTime, default=datetime.now)
     read_at = Column(DateTime, nullable=True)
     meta_data = Column(JSON, default=dict)
-
 
 
 class ColisDB(Base):
@@ -41,8 +51,13 @@ class ColisDB(Base):
 
     # Relations
     tracking_events = relationship("TrackingEventDB", back_populates="colis")
-    package_details = relationship("PackageDetailsDB", back_populates="colis", uselist=False)
-    delivery_details = relationship("DeliveryDetailsDB", back_populates="colis", uselist=False)
+    package_details = relationship(
+        "PackageDetailsDB", back_populates="colis", uselist=False
+    )
+    delivery_details = relationship(
+        "DeliveryDetailsDB", back_populates="colis", uselist=False
+    )
+
 
 class LocationDB(Base):
     __tablename__ = "locations"
@@ -55,6 +70,7 @@ class LocationDB(Base):
     latitude = Column(Float)
     longitude = Column(Float)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
+
 
 class TrackingEventDB(Base):
     __tablename__ = "tracking_events"
@@ -73,6 +89,7 @@ class TrackingEventDB(Base):
     tracking = relationship("TrackingDB", back_populates="events")
     location = relationship("LocationDB")
 
+
 class PackageDetailsDB(Base):
     __tablename__ = "package_details"
 
@@ -87,6 +104,7 @@ class PackageDetailsDB(Base):
     # Relations
     colis = relationship("ColisDB", back_populates="package_details")
     tracking = relationship("TrackingDB", back_populates="package_details")
+
 
 class DeliveryDetailsDB(Base):
     __tablename__ = "delivery_details"
@@ -111,16 +129,24 @@ class TrackingDB(Base):
     id = Column(String, primary_key=True, index=True, default=lambda: str(uuid.uuid4()))
     tracking_number = Column(String, unique=True, index=True, nullable=False)
     carrier = Column(String, nullable=False)
-    status = Column(SQLEnum(PackageStatus), nullable=False, default=PackageStatus.PENDING)
+    status = Column(
+        SQLEnum(PackageStatus), nullable=False, default=PackageStatus.PENDING
+    )
     package_type = Column(SQLEnum(PackageType), default=PackageType.UNKNOWN)
     meta_data = Column(JSON, default=dict)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
 
     # Relations
     events = relationship("TrackingEventDB", back_populates="tracking")
-    package_details = relationship("PackageDetailsDB", back_populates="tracking", uselist=False)
-    delivery_details = relationship("DeliveryDetailsDB", back_populates="tracking", uselist=False)
+    package_details = relationship(
+        "PackageDetailsDB", back_populates="tracking", uselist=False
+    )
+    delivery_details = relationship(
+        "DeliveryDetailsDB", back_populates="tracking", uselist=False
+    )
 
 
 class TrackedShipmentDB(Base):
@@ -129,5 +155,7 @@ class TrackedShipmentDB(Base):
     id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
     user_id = Column(Integer, nullable=False)
     tracking_number = Column(String, nullable=False)
+    status = Column(String, nullable=True)
+    meta_data = Column(JSON, default=dict)
+    note = Column(String, nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
-

--- a/backend/app/models/tracking_history.py
+++ b/backend/app/models/tracking_history.py
@@ -1,9 +1,21 @@
 from datetime import datetime
-from pydantic import BaseModel
+from typing import Optional, Dict, Any
+from pydantic import BaseModel, Field
+
+
+class TrackedShipmentCreate(BaseModel):
+    tracking_number: str
+    status: Optional[str] = None
+    meta_data: Optional[Dict[str, Any]] = None
+    note: Optional[str] = None
+
 
 class TrackedShipment(BaseModel):
     id: str
     tracking_number: str
+    status: Optional[str] = None
+    meta_data: Dict[str, Any] = Field(default_factory=dict)
+    note: Optional[str] = None
     created_at: datetime
 
     class Config:

--- a/backend/app/services/tracking_history_service.py
+++ b/backend/app/services/tracking_history_service.py
@@ -4,18 +4,37 @@ from ..models.database import TrackedShipmentDB
 
 logger = logging.getLogger(__name__)
 
+
 class TrackingHistoryService:
     def __init__(self, db: Session):
         self.db = db
 
-    def log_search(self, user_id: int, tracking_number: str) -> None:
+    def log_search(
+        self,
+        user_id: int,
+        tracking_number: str,
+        *,
+        status: str | None = None,
+        meta_data: dict | None = None,
+        note: str | None = None,
+    ) -> TrackedShipmentDB | None:
+        """Persist a search in the user's tracking history."""
         try:
-            record = TrackedShipmentDB(user_id=user_id, tracking_number=tracking_number)
+            record = TrackedShipmentDB(
+                user_id=user_id,
+                tracking_number=tracking_number,
+                status=status,
+                meta_data=meta_data or {},
+                note=note,
+            )
             self.db.add(record)
             self.db.commit()
+            self.db.refresh(record)
+            return record
         except Exception as e:
             self.db.rollback()
             logger.error(f"Failed to log tracking search: {e}")
+            return None
 
     def get_history(self, user_id: int):
         return (

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,60 @@
+import os
+import sys
+import asyncio
+
+# Set required env vars before importing the app modules
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("FEDEX_CLIENT_ID", "dummy")
+os.environ.setdefault("FEDEX_CLIENT_SECRET", "dummy")
+os.environ.setdefault("FEDEX_ACCOUNT_NUMBER", "dummy")
+os.environ.setdefault("SECRET_KEY", "testsecret")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from backend.app.database import Base, engine, SessionLocal
+from backend.app.models.database import Base as ModelsBase, TrackedShipmentDB
+from backend.app.services.tracking_history_service import TrackingHistoryService
+from backend.app.api.v1.endpoints import history as history_router
+from backend.app.models.tracking_history import TrackedShipmentCreate
+from backend.app.services import auth
+from backend.app.models.user import UserCreate
+
+import pytest
+
+
+@pytest.fixture
+def db_session():
+    Base.metadata.drop_all(bind=engine)
+    ModelsBase.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    ModelsBase.metadata.create_all(bind=engine)
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def create_user(db, email="user@example.com"):
+    return auth.create_user(
+        db, UserCreate(email=email, full_name="U", password="Password1")
+    )
+
+
+def test_log_search_stores_fields(db_session):
+    service = TrackingHistoryService(db_session)
+    service.log_search(1, "123", status="IN_TRANSIT", meta_data={"a": 1}, note="n")
+
+    record = db_session.query(TrackedShipmentDB).first()
+    assert record.tracking_number == "123"
+    assert record.status == "IN_TRANSIT"
+    assert record.meta_data["a"] == 1
+    assert record.note == "n"
+
+
+def test_post_history_endpoint(db_session):
+    user = create_user(db_session)
+    payload = TrackedShipmentCreate(tracking_number="ABC", status="OK")
+    result = asyncio.run(history_router.add_history(payload, user, db_session))
+    assert result.tracking_number == "ABC"
+    assert result.status == "OK"


### PR DESCRIPTION
## Summary
- track shipments with status, metadata and notes in `TrackedShipmentDB`
- expose POST `/history` for recording user lookups
- include extra data when logging searches from tracking endpoints
- sync frontend history service with the new endpoint
- add tests for tracking history service and endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845e7ed3448832ead023da747de6e5b