### PR TITLE
Add history export and management

### DIFF
--- a/Frontend/src/app/core/services/tracking-history.service.ts
+++ b/Frontend/src/app/core/services/tracking-history.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { firstValueFrom } from 'rxjs';
+import { firstValueFrom, Observable } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import { AuthService } from './auth.service';
 
@@ -12,6 +12,22 @@ export class TrackingHistoryService {
   private maxItems = 10;
 
   constructor(private http: HttpClient, private auth: AuthService) {}
+
+  getServerHistory(): Observable<HistoryRecord[]> {
+    return this.http.get<HistoryRecord[]>(`${environment.apiUrl}/history`);
+  }
+
+  updateRecord(id: string, data: Partial<HistoryRecord>): Observable<HistoryRecord> {
+    return this.http.patch<HistoryRecord>(`${environment.apiUrl}/history/${id}`, data);
+  }
+
+  exportHistory(format: 'csv' | 'pdf'): Observable<Blob> {
+    return this.http.get(`${environment.apiUrl}/history/export?format=${format}`, { responseType: 'blob' });
+  }
+
+  deleteAll(): Observable<any> {
+    return this.http.delete(`${environment.apiUrl}/history`);
+  }
 
   getHistory(): string[] {
     const raw = localStorage.getItem(this.storageKey);
@@ -52,4 +68,12 @@ export class TrackingHistoryService {
       // ignore errors
     }
   }
+}
+
+export interface HistoryRecord {
+  id: string;
+  tracking_number: string;
+  pinned: boolean;
+  note?: string;
+  created_at: string;
 }

--- a/Frontend/src/app/features/history/history.component.html
+++ b/Frontend/src/app/features/history/history.component.html
@@ -2,22 +2,21 @@
   <h2>Tracking History</h2>
   <ng-container *ngIf="history.length; else none">
     <ul>
-      <li *ngFor="let id of history">
-        <a [routerLink]="['/track', id]">{{ id }}</a>
+      <li *ngFor="let rec of history">
+        <a [routerLink]="['/track', rec.tracking_number]">{{ rec.tracking_number }}</a>
+        <button (click)="togglePin(rec)" [attr.aria-label]="rec.pinned ? 'Unpin' : 'Pin'">{{ rec.pinned ? 'Unpin' : 'Pin' }}</button>
+        <input [(ngModel)]="rec.note" (blur)="saveNote(rec)" placeholder="Add note" />
         <button role="button"
                 tabindex="0"
-                aria-label="Delete {{id}} from history"
-                (click)="delete(id)"
-                (keydown.enter)="delete(id)"
-                (keydown.space)="delete(id)">Delete</button>
+                aria-label="Delete {{rec.tracking_number}} from history"
+                (click)="delete(rec.id)"
+                (keydown.enter)="delete(rec.id)"
+                (keydown.space)="delete(rec.id)">Delete</button>
       </li>
     </ul>
-    <button role="button"
-            tabindex="0"
-            aria-label="Clear tracking history"
-            (click)="clear()"
-            (keydown.enter)="clear()"
-            (keydown.space)="clear()">Clear History</button>
+    <button (click)="clear()">Delete all history</button>
+    <button (click)="historyService.exportHistory('csv').subscribe(blob => download(blob, 'history.csv'))">Export CSV</button>
+    <button (click)="historyService.exportHistory('pdf').subscribe(blob => download(blob, 'history.pdf'))">Export PDF</button>
   </ng-container>
   <ng-template #none>
     <p>No history yet.</p>

--- a/backend/app/api/v1/endpoints/history.py
+++ b/backend/app/api/v1/endpoints/history.py
@@ -1,12 +1,23 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
 from ....services.auth import get_current_active_user
 from ....database import get_db
 from ....models.user import UserDB
 from ....services.tracking_history_service import TrackingHistoryService
 from ....models.tracking_history import TrackedShipment
+from pydantic import BaseModel
+import io
+import csv
+from reportlab.pdfgen import canvas
+from reportlab.lib.pagesizes import letter
 
 router = APIRouter()
+
+
+class HistoryUpdate(BaseModel):
+    pinned: bool | None = None
+    note: str | None = None
 
 @router.get("/", response_model=list[TrackedShipment])
 async def get_history(
@@ -16,3 +27,66 @@ async def get_history(
     service = TrackingHistoryService(db)
     records = service.get_history(current_user.id)
     return records
+
+
+@router.get("/export")
+async def export_history(
+    format: str = "csv",
+    current_user: UserDB = Depends(get_current_active_user),
+    db: Session = Depends(get_db)
+):
+    service = TrackingHistoryService(db)
+    records = service.get_history(current_user.id)
+
+    if format.lower() == "pdf":
+        buffer = io.BytesIO()
+        pdf = canvas.Canvas(buffer, pagesize=letter)
+        y = 750
+        pdf.drawString(50, y, "Tracking history")
+        y -= 20
+        for r in records:
+            text = f"{r.created_at} - {r.tracking_number}"
+            if r.note:
+                text += f" - {r.note}"
+            pdf.drawString(50, y, text)
+            y -= 15
+            if y < 50:
+                pdf.showPage()
+                y = 750
+        pdf.save()
+        buffer.seek(0)
+        headers = {"Content-Disposition": "attachment; filename=history.pdf"}
+        return StreamingResponse(buffer, media_type="application/pdf", headers=headers)
+
+    out = io.StringIO()
+    writer = csv.writer(out)
+    writer.writerow(["created_at", "tracking_number", "pinned", "note"])
+    for r in records:
+        writer.writerow([r.created_at, r.tracking_number, r.pinned, r.note or ""])
+    out.seek(0)
+    headers = {"Content-Disposition": "attachment; filename=history.csv"}
+    return StreamingResponse(io.BytesIO(out.getvalue().encode()), media_type="text/csv", headers=headers)
+
+
+@router.delete("/")
+async def clear_history(
+    current_user: UserDB = Depends(get_current_active_user),
+    db: Session = Depends(get_db)
+):
+    service = TrackingHistoryService(db)
+    service.delete_all(current_user.id)
+    return {"success": True}
+
+
+@router.patch("/{record_id}", response_model=TrackedShipment)
+async def update_history_record(
+    record_id: str,
+    update: HistoryUpdate,
+    current_user: UserDB = Depends(get_current_active_user),
+    db: Session = Depends(get_db)
+):
+    service = TrackingHistoryService(db)
+    record = service.update_record(record_id, current_user.id, pinned=update.pinned, note=update.note)
+    if not record:
+        raise HTTPException(status_code=404, detail="Record not found")
+    return record

--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -129,5 +129,7 @@ class TrackedShipmentDB(Base):
     id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
     user_id = Column(Integer, nullable=False)
     tracking_number = Column(String, nullable=False)
+    pinned = Column(Boolean, default=False)
+    note = Column(String, nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 

--- a/backend/app/models/tracking_history.py
+++ b/backend/app/models/tracking_history.py
@@ -4,6 +4,8 @@ from pydantic import BaseModel
 class TrackedShipment(BaseModel):
     id: str
     tracking_number: str
+    pinned: bool = False
+    note: str | None = None
     created_at: datetime
 
     class Config:

--- a/backend/app/services/tracking_history_service.py
+++ b/backend/app/services/tracking_history_service.py
@@ -24,3 +24,28 @@ class TrackingHistoryService:
             .order_by(TrackedShipmentDB.created_at.desc())
             .all()
         )
+
+    def update_record(self, record_id: str, user_id: int, pinned: bool | None = None, note: str | None = None):
+        record = (
+            self.db.query(TrackedShipmentDB)
+            .filter(TrackedShipmentDB.id == record_id, TrackedShipmentDB.user_id == user_id)
+            .first()
+        )
+        if not record:
+            return None
+        if pinned is not None:
+            record.pinned = pinned
+        if note is not None:
+            record.note = note
+        self.db.commit()
+        self.db.refresh(record)
+        return record
+
+    def delete_all(self, user_id: int) -> int:
+        deleted = (
+            self.db.query(TrackedShipmentDB)
+            .filter(TrackedShipmentDB.user_id == user_id)
+            .delete()
+        )
+        self.db.commit()
+        return deleted

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,59 @@
+import os
+import sys
+import asyncio
+import pytest
+
+# Set required env vars before importing the app modules
+os.environ.setdefault('DATABASE_URL', 'sqlite:///:memory:')
+os.environ.setdefault('FEDEX_CLIENT_ID', 'dummy')
+os.environ.setdefault('FEDEX_CLIENT_SECRET', 'dummy')
+os.environ.setdefault('FEDEX_ACCOUNT_NUMBER', 'dummy')
+os.environ.setdefault('SECRET_KEY', 'testsecret')
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from backend.app.database import Base, engine, SessionLocal
+from backend.app.models.database import Base as ModelsBase
+from backend.app.services import auth
+from backend.app.models.user import UserCreate
+from backend.app.services.tracking_history_service import TrackingHistoryService
+from backend.app.api.v1.endpoints import history as history_router
+from fastapi.responses import StreamingResponse
+
+@pytest.fixture
+def db_session():
+    Base.metadata.drop_all(bind=engine)
+    ModelsBase.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    ModelsBase.metadata.create_all(bind=engine)
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def create_user(db):
+    return auth.create_user(db, UserCreate(email='h@example.com', full_name='H', password='Password1'))
+
+
+def setup_history(db, user):
+    service = TrackingHistoryService(db)
+    service.log_search(user.id, 'ONE')
+    service.log_search(user.id, 'TWO')
+
+
+def test_export_history_csv(db_session):
+    user = create_user(db_session)
+    setup_history(db_session, user)
+    resp = asyncio.run(history_router.export_history('csv', user, db_session))
+    assert isinstance(resp, StreamingResponse)
+    assert resp.headers['Content-Disposition'].endswith('.csv')
+
+
+def test_clear_history(db_session):
+    user = create_user(db_session)
+    setup_history(db_session, user)
+    asyncio.run(history_router.clear_history(user, db_session))
+    records = asyncio.run(history_router.get_history(user, db_session))
+    assert records == []


### PR DESCRIPTION
## Summary
- extend tracking history tables with pinned state and notes
- implement history management endpoints (export PDF/CSV, update, delete all)
- update Angular history component to pin items, add notes, delete all, and export
- expose history API helpers in tracking-history service
- add regression tests for history export and deletion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845e7ef1b9c832ea344902e1fb7bf25