### PR TITLE
Improve tracking history with filters

### DIFF
--- a/Frontend/src/app/features/history/history.component.html
+++ b/Frontend/src/app/features/history/history.component.html
@@ -1,24 +1,44 @@
 <div class="history">
   <h2>Tracking History</h2>
-  <ng-container *ngIf="history.length; else none">
-    <ul>
-      <li *ngFor="let id of history">
-        <a [routerLink]="['/track', id]">{{ id }}</a>
-        <button role="button"
-                tabindex="0"
-                aria-label="Delete {{id}} from history"
-                (click)="delete(id)"
-                (keydown.enter)="delete(id)"
-                (keydown.space)="delete(id)">Delete</button>
-      </li>
-    </ul>
-    <button role="button"
-            tabindex="0"
-            aria-label="Clear tracking history"
-            (click)="clear()"
-            (keydown.enter)="clear()"
-            (keydown.space)="clear()">Clear History</button>
+
+  <div class="filters" *ngIf="history.length">
+    <input type="text" [(ngModel)]="searchTerm" (ngModelChange)="applyFilters()" placeholder="Search number" aria-label="Search tracking number">
+    <select [(ngModel)]="statusFilter" (change)="applyFilters()" aria-label="Filter by status">
+      <option value="">All statuses</option>
+      <option value="delivered">Delivered</option>
+      <option value="transit">In transit</option>
+    </select>
+  </div>
+
+  <ng-container *ngIf="filteredHistory.length; else none">
+    <div class="table-wrapper">
+      <table>
+        <thead>
+        <tr>
+          <th>Number</th>
+          <th>Sender</th>
+          <th>Date</th>
+          <th>Status</th>
+          <th class="sr-only">Actions</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr *ngFor="let item of filteredHistory" [class.delivered]="isDelivered(item)">
+          <td>{{ item.tracking_number }}</td>
+          <td>{{ item.sender || '-' }}</td>
+          <td>{{ item.last_consulted | date:'short' }}</td>
+          <td>{{ item.status || '-' }}</td>
+          <td>
+            <a [routerLink]="['/track', item.tracking_number]" class="track-btn">{{ isDelivered(item) ? 'View' : 'Track' }}</a>
+            <button role="button" aria-label="Delete {{item.tracking_number}}" (click)="delete(item.tracking_number)">Delete</button>
+          </td>
+        </tr>
+        </tbody>
+      </table>
+    </div>
+    <button role="button" class="clear-btn" (click)="clear()">Clear History</button>
   </ng-container>
+
   <ng-template #none>
     <p>No history yet.</p>
   </ng-template>

--- a/Frontend/src/app/features/history/history.component.scss
+++ b/Frontend/src/app/features/history/history.component.scss
@@ -2,26 +2,48 @@
   padding: 1rem;
 }
 
-.history ul {
-  list-style: none;
-  padding: 0;
-}
-
-.history li {
+.filters {
   display: flex;
-  align-items: center;
-  margin-bottom: 0.5rem;
-}
+  gap: 0.5rem;
+  margin-bottom: 1rem;
 
-.history li a {
-  flex: 1;
-}
-
-.history button {
-  margin-left: 0.5rem;
-
-  &:focus {
-    outline: 2px solid #4d148c;
-    outline-offset: 2px;
+  input,
+  select {
+    padding: 0.25rem 0.5rem;
   }
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+
+  th,
+  td {
+    padding: 0.5rem;
+    border-bottom: 1px solid #ddd;
+    text-align: left;
+  }
+}
+
+.track-btn {
+  margin-right: 0.5rem;
+}
+
+.clear-btn {
+  margin-top: 0.5rem;
+}
+
+.delivered td {
+  color: #0a7a0a;
+  font-weight: bold;
+}
+
+button:focus,
+a.track-btn:focus {
+  outline: 2px solid #4d148c;
+  outline-offset: 2px;
 }

--- a/Frontend/src/app/features/history/history.component.ts
+++ b/Frontend/src/app/features/history/history.component.ts
@@ -1,17 +1,21 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
-import { TrackingHistoryService } from '../../core/services/tracking-history.service';
+import { TrackingHistoryService, HistoryRecord } from '../../core/services/tracking-history.service';
 
 @Component({
   selector: 'app-history',
   standalone: true,
-  imports: [CommonModule, RouterModule],
+  imports: [CommonModule, RouterModule, FormsModule],
   templateUrl: './history.component.html',
   styleUrls: ['./history.component.scss']
 })
 export class HistoryComponent implements OnInit {
-  history: string[] = [];
+  history: HistoryRecord[] = [];
+  filteredHistory: HistoryRecord[] = [];
+  searchTerm = '';
+  statusFilter = '';
 
   constructor(private historyService: TrackingHistoryService) {}
 
@@ -21,6 +25,7 @@ export class HistoryComponent implements OnInit {
 
   private loadHistory(): void {
     this.history = this.historyService.getHistory();
+    this.applyFilters();
   }
 
   delete(id: string): void {
@@ -31,5 +36,23 @@ export class HistoryComponent implements OnInit {
   clear(): void {
     this.historyService.clear();
     this.loadHistory();
+  }
+
+  applyFilters(): void {
+    this.filteredHistory = this.history
+      .filter(item => {
+        const matchesSearch = !this.searchTerm || item.tracking_number.toLowerCase().includes(this.searchTerm.toLowerCase());
+        const matchesStatus = !this.statusFilter || (item.status || '').toLowerCase().includes(this.statusFilter.toLowerCase());
+        return matchesSearch && matchesStatus;
+      })
+      .sort((a, b) => {
+        const da = new Date(a.last_consulted || '').getTime();
+        const db = new Date(b.last_consulted || '').getTime();
+        return db - da;
+      });
+  }
+
+  isDelivered(item: HistoryRecord): boolean {
+    return (item.status || '').toLowerCase().includes('delivered');
   }
 }

--- a/Frontend/src/app/features/home/home.component.ts
+++ b/Frontend/src/app/features/home/home.component.ts
@@ -383,7 +383,7 @@ export class HomeComponent implements OnInit, OnDestroy {
     this.trackingService.trackNumber(identifier, name).subscribe({
       next: (response) => {
         if (response.success && response.data) {
-          this.history.addIdentifier(identifier);
+          this.history.addIdentifier(identifier, { status: response.data.status?.status });
           this.router.navigate(['/track', identifier]);
           } else {
           this.addNotification('error', 'Erreur', response.error || 'Erreur inconnue');

--- a/Frontend/src/app/features/track-by-mail/track-by-mail.component.ts
+++ b/Frontend/src/app/features/track-by-mail/track-by-mail.component.ts
@@ -32,8 +32,8 @@ export class TrackByMailComponent {
       return;
     }
     const { trackingNumber, email, packageName } = this.form.value;
-    this.trackingService.trackNumber(trackingNumber, packageName).subscribe(() => {
-      this.history.addIdentifier(trackingNumber);
+    this.trackingService.trackNumber(trackingNumber, packageName).subscribe(res => {
+      this.history.addIdentifier(trackingNumber, { status: res.data?.status?.status });
       this.trackingService.trackByEmail(trackingNumber, email).subscribe(res => {
         this.result = res;
       });

--- a/Frontend/src/app/features/tracking/track-result/track-result.component.ts
+++ b/Frontend/src/app/features/tracking/track-result/track-result.component.ts
@@ -82,7 +82,7 @@ export class TrackResultComponent implements OnInit, OnDestroy {
       next: (response) => {
         if (response.success && response.data) {
           this.trackingInfo = response.data;
-          this.history.addIdentifier(identifier);
+          this.history.addIdentifier(identifier, { status: response.data.status?.status });
           this.waitForGoogleMaps().then(() => this.initializeMap());
         } else {
           this.error = response.error || 'Impossible de récupérer les informations de suivi';
@@ -143,7 +143,7 @@ export class TrackResultComponent implements OnInit, OnDestroy {
       error: (err) => {
         this.error = err.error?.error || 'Aucune preuve de livraison disponible';
         console.error('Erreur de preuve:', err);
-        showNotification(this.error, 'error');
+        showNotification(this.error || '', 'error');
       }
     });
   }
@@ -244,11 +244,12 @@ export class TrackResultComponent implements OnInit, OnDestroy {
         strokeOpacity: 1.0,
         strokeWeight: 2
       });
-      this.polyline.setMap(this.map);
-
-      const bounds = new window.google.maps.LatLngBounds();
-      path.forEach(p => bounds.extend(p));
-      this.map.fitBounds(bounds);
+      if (this.map && this.polyline) {
+        this.polyline.setMap(this.map);
+        const bounds = new window.google.maps.LatLngBounds();
+        path.forEach(p => bounds.extend(p));
+        this.map.fitBounds(bounds);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- extend TrackingHistoryService to persist details like status and last consulted
- render history as a responsive table with search and filter controls
- update tracking pages to store status in history
- show delivered rows in green

## Testing
- `pytest -q`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*


------
https://chatgpt.com/codex/tasks/task_e_6845e7edfba8832e9adf974f8a92002b