### PR TITLE
Enhance history view

### DIFF
--- a/Frontend/src/app/features/history/history.component.html
+++ b/Frontend/src/app/features/history/history.component.html
@@ -1,17 +1,42 @@
 <div class="history">
   <h2>Tracking History</h2>
-  <ng-container *ngIf="history.length; else none">
-    <ul>
-      <li *ngFor="let id of history">
-        <a [routerLink]="['/track', id]">{{ id }}</a>
-        <button role="button"
-                tabindex="0"
-                aria-label="Delete {{id}} from history"
-                (click)="delete(id)"
-                (keydown.enter)="delete(id)"
-                (keydown.space)="delete(id)">Delete</button>
-      </li>
-    </ul>
+
+  <div class="filters">
+    <input type="text" placeholder="Search" [(ngModel)]="searchTerm">
+    <input type="text" placeholder="Status" [(ngModel)]="filterStatus">
+    <input type="date" [(ngModel)]="filterDate">
+  </div>
+
+  <ng-container *ngIf="sortedHistory.length; else none">
+    <table>
+      <thead>
+        <tr>
+          <th>Tracking #</th>
+          <th>Status</th>
+          <th (click)="toggleSort()" class="sortable">
+            Date
+            <span *ngIf="sortAsc">&#9650;</span>
+            <span *ngIf="!sortAsc">&#9660;</span>
+          </th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let item of sortedHistory">
+          <td><a [routerLink]="['/track', item.tracking_number]">{{item.tracking_number}}</a></td>
+          <td>{{item.status || '-'}}</td>
+          <td>{{item.created_at | date:'short'}}</td>
+          <td>
+            <button role="button"
+                    tabindex="0"
+                    aria-label="Delete {{item.tracking_number}} from history"
+                    (click)="delete(item.tracking_number)"
+                    (keydown.enter)="delete(item.tracking_number)"
+                    (keydown.space)="delete(item.tracking_number)">Delete</button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
     <button role="button"
             tabindex="0"
             aria-label="Clear tracking history"

--- a/Frontend/src/app/features/history/history.component.scss
+++ b/Frontend/src/app/features/history/history.component.scss
@@ -2,19 +2,21 @@
   padding: 1rem;
 }
 
-.history ul {
-  list-style: none;
-  padding: 0;
+.history table {
+  width: 100%;
+  border-collapse: collapse;
 }
 
-.history li {
+.history th,
+.history td {
+  padding: 0.5rem;
+  border-bottom: 1px solid #ccc;
+}
+
+.history .filters {
+  margin-bottom: 1rem;
   display: flex;
-  align-items: center;
-  margin-bottom: 0.5rem;
-}
-
-.history li a {
-  flex: 1;
+  gap: 0.5rem;
 }
 
 .history button {
@@ -24,4 +26,8 @@
     outline: 2px solid #4d148c;
     outline-offset: 2px;
   }
+}
+
+.sortable {
+  cursor: pointer;
 }

--- a/Frontend/src/app/features/history/history.component.ts
+++ b/Frontend/src/app/features/history/history.component.ts
@@ -1,17 +1,22 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
-import { TrackingHistoryService } from '../../core/services/tracking-history.service';
+import { FormsModule } from '@angular/forms';
+import { TrackingHistoryService, TrackedShipment } from '../../core/services/tracking-history.service';
 
 @Component({
   selector: 'app-history',
   standalone: true,
-  imports: [CommonModule, RouterModule],
+  imports: [CommonModule, RouterModule, FormsModule],
   templateUrl: './history.component.html',
   styleUrls: ['./history.component.scss']
 })
 export class HistoryComponent implements OnInit {
-  history: string[] = [];
+  history: TrackedShipment[] = [];
+  searchTerm = '';
+  filterStatus = '';
+  filterDate: string | null = null;
+  sortAsc = false;
 
   constructor(private historyService: TrackingHistoryService) {}
 
@@ -21,6 +26,27 @@ export class HistoryComponent implements OnInit {
 
   private loadHistory(): void {
     this.history = this.historyService.getHistory();
+  }
+
+  get filteredHistory(): TrackedShipment[] {
+    return this.history.filter(item => {
+      const matchSearch = !this.searchTerm || item.tracking_number.toLowerCase().includes(this.searchTerm.toLowerCase());
+      const matchStatus = !this.filterStatus || (item.status || '').toLowerCase().includes(this.filterStatus.toLowerCase());
+      const matchDate = !this.filterDate || (item.created_at || '').startsWith(this.filterDate);
+      return matchSearch && matchStatus && matchDate;
+    });
+  }
+
+  get sortedHistory(): TrackedShipment[] {
+    return [...this.filteredHistory].sort((a, b) => {
+      const da = new Date(a.created_at || '').getTime();
+      const db = new Date(b.created_at || '').getTime();
+      return this.sortAsc ? da - db : db - da;
+    });
+  }
+
+  toggleSort() {
+    this.sortAsc = !this.sortAsc;
   }
 
   delete(id: string): void {


### PR DESCRIPTION
## Summary
- return detailed shipment history in `TrackingHistoryService`
- show date and status on History page
- enable filtering and sorting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845ebd117a4832eaa328d1cbc61b7ed