### PR TITLE
Add history export and delete-all

### DIFF
--- a/Frontend/src/app/core/services/tracking-history.service.ts
+++ b/Frontend/src/app/core/services/tracking-history.service.ts
@@ -46,6 +46,19 @@ export class TrackingHistoryService {
     localStorage.removeItem(this.storageKey);
   }
 
+  deleteAll(): void {
+    this.clear();
+    this.http.delete(`${environment.apiUrl}/history`).subscribe({
+      next: () => {},
+      error: () => {}
+    });
+  }
+
+  exportHistory(format: 'csv' | 'pdf' = 'csv') {
+    const url = `${environment.apiUrl}/history/export?format=${format}`;
+    return this.http.get(url, { responseType: 'blob' });
+  }
+
   async syncWithServer(): Promise<void> {
     const loggedIn = await firstValueFrom(this.auth.isLoggedIn());
     if (!loggedIn) {

--- a/Frontend/src/app/features/history/history.component.html
+++ b/Frontend/src/app/features/history/history.component.html
@@ -14,10 +14,16 @@
     </ul>
     <button role="button"
             tabindex="0"
-            aria-label="Clear tracking history"
+            aria-label="Delete all tracking history"
             (click)="clear()"
             (keydown.enter)="clear()"
-            (keydown.space)="clear()">Clear History</button>
+            (keydown.space)="clear()">Delete All</button>
+    <button role="button"
+            tabindex="0"
+            aria-label="Export tracking history"
+            (click)="export('csv')"
+            (keydown.enter)="export('csv')"
+            (keydown.space)="export('csv')">Export</button>
   </ng-container>
   <ng-template #none>
     <p>No history yet.</p>

--- a/Frontend/src/app/features/history/history.component.ts
+++ b/Frontend/src/app/features/history/history.component.ts
@@ -29,7 +29,18 @@ export class HistoryComponent implements OnInit {
   }
 
   clear(): void {
-    this.historyService.clear();
+    this.historyService.deleteAll();
     this.loadHistory();
+  }
+
+  export(format: 'csv' | 'pdf' = 'csv'): void {
+    this.historyService.exportHistory(format).subscribe(blob => {
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `history.${format}`;
+      a.click();
+      window.URL.revokeObjectURL(url);
+    });
   }
 }

--- a/backend/app/api/v1/endpoints/history.py
+++ b/backend/app/api/v1/endpoints/history.py
@@ -1,4 +1,9 @@
 from fastapi import APIRouter, Depends
+from fastapi.responses import StreamingResponse
+import io
+import csv
+from reportlab.lib.pagesizes import letter
+from reportlab.pdfgen import canvas
 from sqlalchemy.orm import Session
 from ....services.auth import get_current_active_user
 from ....database import get_db
@@ -34,3 +39,55 @@ async def add_history(
         note=shipment.note,
     )
     return record
+
+
+@router.delete("/")
+async def delete_history(
+    current_user: UserDB = Depends(get_current_active_user),
+    db: Session = Depends(get_db),
+):
+    """Delete all history items for the current user."""
+    service = TrackingHistoryService(db)
+    deleted = service.clear_history(current_user.id)
+    return {"deleted": deleted}
+
+
+@router.get("/export")
+async def export_history(
+    format: str = "csv",
+    current_user: UserDB = Depends(get_current_active_user),
+    db: Session = Depends(get_db),
+):
+    """Export the user's history in CSV or PDF format."""
+    service = TrackingHistoryService(db)
+    records = service.get_history(current_user.id)
+
+    if format.lower() == "pdf":
+        buffer = io.BytesIO()
+        pdf = canvas.Canvas(buffer, pagesize=letter)
+        y = 750
+        pdf.drawString(50, y, "Tracking history")
+        y -= 20
+        for rec in records:
+            pdf.drawString(
+                50,
+                y,
+                f"{rec.created_at} - {rec.tracking_number} - {rec.status or ''}",
+            )
+            y -= 15
+            if y < 50:
+                pdf.showPage()
+                y = 750
+        pdf.save()
+        buffer.seek(0)
+        headers = {"Content-Disposition": "attachment; filename=history.pdf"}
+        return StreamingResponse(buffer, media_type="application/pdf", headers=headers)
+
+    out = io.StringIO()
+    writer = csv.writer(out)
+    writer.writerow(["created_at", "tracking_number", "status", "note"])
+    for rec in records:
+        writer.writerow([rec.created_at, rec.tracking_number, rec.status, rec.note])
+    out.seek(0)
+    headers = {"Content-Disposition": "attachment; filename=history.csv"}
+    return StreamingResponse(io.BytesIO(out.getvalue().encode()), media_type="text/csv", headers=headers)

--- a/backend/app/services/tracking_history_service.py
+++ b/backend/app/services/tracking_history_service.py
@@ -43,3 +43,13 @@ class TrackingHistoryService:
             .order_by(TrackedShipmentDB.created_at.desc())
             .all()
         )
+
+    def clear_history(self, user_id: int) -> int:
+        """Delete all history records for the given user."""
+        count = (
+            self.db.query(TrackedShipmentDB)
+            .filter(TrackedShipmentDB.user_id == user_id)
+            .delete()
+        )
+        self.db.commit()
+        return count

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -58,3 +58,14 @@ def test_post_history_endpoint(db_session):
     result = asyncio.run(history_router.add_history(payload, user, db_session))
     assert result.tracking_number == "ABC"
     assert result.status == "OK"
+
+
+def test_delete_history_endpoint(db_session):
+    user = create_user(db_session)
+    service = TrackingHistoryService(db_session)
+    service.log_search(user.id, "1")
+    service.log_search(user.id, "2")
+
+    asyncio.run(history_router.delete_history(user, db_session))
+    remaining = service.get_history(user.id)
+    assert remaining == []


### PR DESCRIPTION
## Summary
- add clear_history function in service
- provide DELETE /history endpoint
- add /history/export endpoint for CSV or PDF output
- expose deleteAll and exportHistory from Angular service
- add Delete All and Export buttons on history page
- test clearing history

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845ebd5026c832e9cc7eb8323e19f87