### PR TITLE
Add advanced shipment tracking with backend search/export

### DIFF
--- a/Frontend/src/app/app.routes.ts
+++ b/Frontend/src/app/app.routes.ts
@@ -19,6 +19,7 @@ import { VerifyTwofaComponent } from './features/auth/verify-twofa/verify-twofa.
 import { ResendVerificationComponent } from './features/auth/resend-verification/resend-verification.component';
 import { NewsDetailComponent } from './features/news/news-detail.component';
 import { HistoryComponent } from './features/history/history.component';
+import { AdvancedShipmentTrackingComponent } from './features/advanced-shipment-tracking/advanced-shipment-tracking.component';
 import { NotFoundComponent } from './shared/not-found.component';
 
 // Assuming you might have other standalone components or lazy-loaded routes
@@ -41,6 +42,7 @@ export const routes: Routes = [
   { path: 'fedex-track/:identifier', component: FedexTrackResultComponent, canActivate: [AuthGuard] },
   { path: 'notifications', component: NotificationsComponent, canActivate: [AuthGuard] },
   { path: 'history', component: HistoryComponent, canActivate: [AuthGuard] },
+  { path: 'advanced-shipment-tracking', component: AdvancedShipmentTrackingComponent, canActivate: [AuthGuard] },
   // Service routes
   { path: 'services/track-by-mail', component: TrackByMailComponent, canActivate: [AuthGuard] },
   { path: 'services/notifications', component: NotificationOptionsComponent, canActivate: [AuthGuard] },

--- a/Frontend/src/app/features/advanced-shipment-tracking/advanced-shipment-tracking.component.html
+++ b/Frontend/src/app/features/advanced-shipment-tracking/advanced-shipment-tracking.component.html
@@ -1,0 +1,53 @@
+<div class="advanced-tracking">
+  <form [formGroup]="form" (ngSubmit)="search()" class="search-form">
+    <mat-form-field>
+      <input matInput placeholder="Tracking number" formControlName="tracking_number">
+    </mat-form-field>
+    <mat-form-field>
+      <input matInput placeholder="Reference" formControlName="reference">
+    </mat-form-field>
+    <mat-form-field>
+      <input matInput placeholder="Sender" formControlName="sender">
+    </mat-form-field>
+    <mat-form-field>
+      <input matInput placeholder="Recipient" formControlName="recipient">
+    </mat-form-field>
+    <mat-form-field>
+      <input matInput [matDatepicker]="startPicker" placeholder="Start date" formControlName="start_date">
+      <mat-datepicker-toggle matSuffix [for]="startPicker"></mat-datepicker-toggle>
+      <mat-datepicker #startPicker></mat-datepicker>
+    </mat-form-field>
+    <mat-form-field>
+      <input matInput [matDatepicker]="endPicker" placeholder="End date" formControlName="end_date">
+      <mat-datepicker-toggle matSuffix [for]="endPicker"></mat-datepicker-toggle>
+      <mat-datepicker #endPicker></mat-datepicker>
+    </mat-form-field>
+    <button mat-raised-button color="primary" type="submit">Search</button>
+    <button mat-button type="button" (click)="export('csv')">CSV</button>
+    <button mat-button type="button" (click)="export('excel')">Excel</button>
+    <button mat-button type="button" (click)="export('xml')">XML</button>
+  </form>
+
+  <table mat-table [dataSource]="dataSource" matSort class="mat-elevation-z8">
+    <ng-container matColumnDef="tracking_number">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header>Tracking #</th>
+      <td mat-cell *matCellDef="let row">{{row.tracking_number}}</td>
+    </ng-container>
+    <ng-container matColumnDef="status">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header>Status</th>
+      <td mat-cell *matCellDef="let row">{{row.status}}</td>
+    </ng-container>
+    <ng-container matColumnDef="carrier">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header>Carrier</th>
+      <td mat-cell *matCellDef="let row">{{row.carrier}}</td>
+    </ng-container>
+    <ng-container matColumnDef="created_at">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header>Created</th>
+      <td mat-cell *matCellDef="let row">{{row.created_at | date:'short'}}</td>
+    </ng-container>
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+  </table>
+
+  <mat-paginator [length]="total" [pageSize]="10" [pageSizeOptions]="[5,10,20]" showFirstLastButtons></mat-paginator>
+</div>

--- a/Frontend/src/app/features/advanced-shipment-tracking/advanced-shipment-tracking.component.scss
+++ b/Frontend/src/app/features/advanced-shipment-tracking/advanced-shipment-tracking.component.scss
@@ -1,0 +1,9 @@
+.advanced-tracking {
+  padding: 1rem;
+}
+.search-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}

--- a/Frontend/src/app/features/advanced-shipment-tracking/advanced-shipment-tracking.component.ts
+++ b/Frontend/src/app/features/advanced-shipment-tracking/advanced-shipment-tracking.component.ts
@@ -1,0 +1,85 @@
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup } from '@angular/forms';
+import { MatTableDataSource, MatTableModule } from '@angular/material/table';
+import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
+import { MatSort, MatSortModule } from '@angular/material/sort';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MatNativeDateModule } from '@angular/material/core';
+import { TrackingService } from '../tracking/services/tracking.service';
+
+@Component({
+  selector: 'app-advanced-shipment-tracking',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatTableModule,
+    MatPaginatorModule,
+    MatSortModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatDatepickerModule,
+    MatNativeDateModule
+  ],
+  templateUrl: './advanced-shipment-tracking.component.html',
+  styleUrls: ['./advanced-shipment-tracking.component.scss']
+})
+export class AdvancedShipmentTrackingComponent implements OnInit {
+  form: FormGroup;
+  dataSource = new MatTableDataSource<any>([]);
+  displayedColumns = ['tracking_number', 'status', 'carrier', 'created_at'];
+  total = 0;
+
+  @ViewChild(MatPaginator) paginator!: MatPaginator;
+  @ViewChild(MatSort) sort!: MatSort;
+
+  constructor(private fb: FormBuilder, private service: TrackingService) {
+    this.form = this.fb.group({
+      tracking_number: [''],
+      reference: [''],
+      sender: [''],
+      recipient: [''],
+      start_date: [''],
+      end_date: ['']
+    });
+  }
+
+  ngOnInit(): void {
+    this.search();
+  }
+
+  search(): void {
+    const filters = {
+      tracking_number: this.form.value.tracking_number || undefined,
+      reference: this.form.value.reference || undefined,
+      sender: this.form.value.sender || undefined,
+      recipient: this.form.value.recipient || undefined,
+      start_date: this.form.value.start_date || undefined,
+      end_date: this.form.value.end_date || undefined,
+      page: this.paginator ? this.paginator.pageIndex + 1 : 1,
+      page_size: this.paginator ? this.paginator.pageSize : 10,
+      sort_by: this.sort ? this.sort.active : undefined,
+      sort_order: this.sort && this.sort.direction ? this.sort.direction : 'desc'
+    } as any;
+    this.service.searchShipments(filters).subscribe(res => {
+      this.dataSource.data = res.items;
+      this.total = res.total;
+    });
+  }
+
+  export(format: string): void {
+    const filters = this.form.value;
+    this.service.exportShipments(filters, format).subscribe(blob => {
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `shipments.${format === 'excel' ? 'xlsx' : format}`;
+      a.click();
+      window.URL.revokeObjectURL(url);
+    });
+  }
+}

--- a/Frontend/src/app/features/tracking/services/tracking.service.ts
+++ b/Frontend/src/app/features/tracking/services/tracking.service.ts
@@ -10,6 +10,7 @@ import { TrackingInfo, TrackingResponse } from '../models/tracking';
 })
 export class TrackingService {
   private baseUrl = `${environment.apiUrl}/track`;
+  private shipmentUrl = `${environment.apiUrl}/shipments`;
 
   constructor(private http: HttpClient) {}
 
@@ -56,6 +57,14 @@ export class TrackingService {
 
   trackByEmail(tracking_number: string, email: string): Observable<TrackingResponse> {
     return this.http.post<TrackingResponse>(`${this.baseUrl}/email`, { tracking_number, email });
+  }
+
+  searchShipments(filters: any): Observable<any> {
+    return this.http.post<any>(`${this.shipmentUrl}/search`, filters);
+  }
+
+  exportShipments(filters: any, format: string): Observable<Blob> {
+    return this.http.post(`${this.shipmentUrl}/export?format=${format}`, filters, { responseType: 'blob' });
   }
 
   decodeBarcodeClient(file: File): Promise<string> {

--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter
-from .endpoints import tracking, notifications, colis, history
+from .endpoints import tracking, notifications, colis, history, shipments
 
 api_router = APIRouter(prefix="/api/v1")
 
@@ -25,4 +25,10 @@ api_router.include_router(
     history.router,
     prefix="/history",
     tags=["history"]
+)
+
+api_router.include_router(
+    shipments.router,
+    prefix="/shipments",
+    tags=["shipments"]
 )

--- a/backend/app/api/v1/endpoints/__init__.py
+++ b/backend/app/api/v1/endpoints/__init__.py
@@ -1,3 +1,3 @@
-from . import notifications, tracking, colis, history
+from . import notifications, tracking, colis, history, shipments
 
-__all__ = ["notifications", "tracking", "colis", "history"]
+__all__ = ["notifications", "tracking", "colis", "history", "shipments"]

--- a/backend/app/api/v1/endpoints/shipments.py
+++ b/backend/app/api/v1/endpoints/shipments.py
@@ -1,0 +1,77 @@
+from fastapi import APIRouter, HTTPException, Depends
+from sqlalchemy.orm import Session
+from typing import Dict, Any
+from ....models.tracking import TrackingFilter
+from ....services.tracking_service import TrackingService
+from ....database import get_db
+import csv
+import io
+import xml.etree.ElementTree as ET
+import openpyxl
+from fastapi.responses import StreamingResponse
+
+router = APIRouter()
+
+@router.post("/search", response_model=Dict[str, Any])
+async def search_shipments(filters: TrackingFilter, db: Session = Depends(get_db)):
+    service = TrackingService(db)
+    try:
+        results, total = service.search_trackings(filters)
+        return {
+            "items": results,
+            "total": total,
+            "page": filters.page,
+            "page_size": filters.page_size,
+            "total_pages": (total + filters.page_size - 1) // filters.page_size,
+        }
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@router.post("/export")
+async def export_shipments(
+    filters: TrackingFilter,
+    format: str = "csv",
+    db: Session = Depends(get_db),
+):
+    service = TrackingService(db)
+    results, _ = service.search_trackings(filters)
+    if format == "csv":
+        out = io.StringIO()
+        writer = csv.writer(out)
+        writer.writerow(["tracking_number", "status", "carrier"])
+        for r in results:
+            writer.writerow([r.tracking_number, r.status, r.carrier])
+        out.seek(0)
+        return StreamingResponse(
+            io.BytesIO(out.getvalue().encode()),
+            media_type="text/csv",
+            headers={"Content-Disposition": "attachment; filename=shipments.csv"},
+        )
+    if format == "xml":
+        root = ET.Element("shipments")
+        for r in results:
+            item = ET.SubElement(root, "shipment")
+            ET.SubElement(item, "tracking_number").text = r.tracking_number
+            ET.SubElement(item, "status").text = r.status
+            ET.SubElement(item, "carrier").text = r.carrier
+        data = ET.tostring(root, encoding="utf-8")
+        return StreamingResponse(
+            io.BytesIO(data),
+            media_type="application/xml",
+            headers={"Content-Disposition": "attachment; filename=shipments.xml"},
+        )
+    if format == "excel":
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.append(["tracking_number", "status", "carrier"])
+        for r in results:
+            ws.append([r.tracking_number, r.status, r.carrier])
+        bio = io.BytesIO()
+        wb.save(bio)
+        bio.seek(0)
+        return StreamingResponse(
+            bio,
+            media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            headers={"Content-Disposition": "attachment; filename=shipments.xlsx"},
+        )
+    raise HTTPException(status_code=400, detail="Unsupported format")

--- a/backend/app/models/tracking.py
+++ b/backend/app/models/tracking.py
@@ -112,6 +112,9 @@ class TrackingResponse(BaseModel):
 
 class TrackingFilter(BaseModel):
     tracking_number: Optional[str] = None
+    reference: Optional[str] = None
+    sender: Optional[str] = None
+    recipient: Optional[str] = None
     status: Optional[PackageStatus] = None
     carrier: Optional[str] = None
     start_date: Optional[datetime] = None

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -22,3 +22,4 @@ redis>=4.2.0
 pyotp==2.9.0
 pyzbar==0.1.9
 reportlab==4.0.6
+openpyxl==3.1.2


### PR DESCRIPTION
## Summary
- support CSV/Excel/XML exports for shipment search
- expose `/shipments` API endpoints
- extend tracking filters for sender, recipient and reference
- implement Angular component for advanced shipment listing
- add routes and service methods

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845ec702cb4832eb6634881033f981d