### PR TITLE
Add customizable history table with saved views

### DIFF
--- a/Frontend/src/app/core/services/tracking-history.service.ts
+++ b/Frontend/src/app/core/services/tracking-history.service.ts
@@ -1,8 +1,9 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { firstValueFrom } from 'rxjs';
+import { firstValueFrom, Observable } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import { AuthService } from './auth.service';
+import { TrackedShipment } from '../../features/history/tracked-shipment';
 
 @Injectable({
   providedIn: 'root'
@@ -61,5 +62,9 @@ export class TrackingHistoryService {
     } catch {
       // ignore errors
     }
+  }
+
+  fetchDetailedHistory(): Observable<TrackedShipment[]> {
+    return this.http.get<TrackedShipment[]>(`${environment.apiUrl}/history`);
   }
 }

--- a/Frontend/src/app/core/services/view-config.service.ts
+++ b/Frontend/src/app/core/services/view-config.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@angular/core';
+
+export interface ViewConfig {
+  name: string;
+  columns: string[];
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ViewConfigService {
+  private storageKey = 'historyViewConfigs';
+  private maxViews = 10;
+
+  getConfigs(): ViewConfig[] {
+    const raw = localStorage.getItem(this.storageKey);
+    return raw ? JSON.parse(raw) as ViewConfig[] : [];
+  }
+
+  saveConfig(config: ViewConfig): void {
+    let configs = this.getConfigs().filter(c => c.name !== config.name);
+    configs.unshift(config);
+    if (configs.length > this.maxViews) {
+      configs = configs.slice(0, this.maxViews);
+    }
+    localStorage.setItem(this.storageKey, JSON.stringify(configs));
+  }
+
+  deleteConfig(name: string): void {
+    const configs = this.getConfigs().filter(c => c.name !== name);
+    localStorage.setItem(this.storageKey, JSON.stringify(configs));
+  }
+}

--- a/Frontend/src/app/features/history/history.component.html
+++ b/Frontend/src/app/features/history/history.component.html
@@ -1,25 +1,50 @@
 <div class="history">
   <h2>Tracking History</h2>
-  <ng-container *ngIf="history.length; else none">
-    <ul>
-      <li *ngFor="let id of history">
-        <a [routerLink]="['/track', id]">{{ id }}</a>
-        <button role="button"
-                tabindex="0"
-                aria-label="Delete {{id}} from history"
-                (click)="delete(id)"
-                (keydown.enter)="delete(id)"
-                (keydown.space)="delete(id)">Delete</button>
-      </li>
-    </ul>
-    <button role="button"
-            tabindex="0"
-            aria-label="Clear tracking history"
-            (click)="clear()"
-            (keydown.enter)="clear()"
-            (keydown.space)="clear()">Clear History</button>
-  </ng-container>
-  <ng-template #none>
-    <p>No history yet.</p>
-  </ng-template>
+
+  <mat-tab-group [(selectedIndex)]="selectedView">
+    <mat-tab *ngFor="let view of savedViews; let i = index" [label]="view.name" (click)="applyView(view, i)"></mat-tab>
+  </mat-tab-group>
+
+  <div class="controls">
+    <div cdkDropList (cdkDropListDropped)="drop($event)">
+      <div *ngFor="let col of availableColumns" cdkDrag>
+        <mat-checkbox [checked]="displayedColumns.includes(col)" (change)="toggleColumn(col)">{{ col }}</mat-checkbox>
+      </div>
+    </div>
+    <input [(ngModel)]="newViewName" placeholder="View name" />
+    <button (click)="saveView()">Save View</button>
+  </div>
+
+  <table mat-table [dataSource]="shipments" class="mat-elevation-z8">
+    <ng-container matColumnDef="tracking_number">
+      <th mat-header-cell *matHeaderCellDef>Tracking #</th>
+      <td mat-cell *matCellDef="let s">
+        <a [routerLink]="['/track', s.tracking_number]">{{ s.tracking_number }}</a>
+      </td>
+    </ng-container>
+    <ng-container matColumnDef="status">
+      <th mat-header-cell *matHeaderCellDef>Status</th>
+      <td mat-cell *matCellDef="let s">{{ s.status }}</td>
+    </ng-container>
+    <ng-container matColumnDef="note">
+      <th mat-header-cell *matHeaderCellDef>Note</th>
+      <td mat-cell *matCellDef="let s">{{ s.note }}</td>
+    </ng-container>
+    <ng-container matColumnDef="created_at">
+      <th mat-header-cell *matHeaderCellDef>Date</th>
+      <td mat-cell *matCellDef="let s">{{ s.created_at | date:'medium' }}</td>
+    </ng-container>
+    <ng-container matColumnDef="actions">
+      <th mat-header-cell *matHeaderCellDef></th>
+      <td mat-cell *matCellDef="let s">
+        <button (click)="delete(s.tracking_number)">Delete</button>
+      </td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+  </table>
+
+  <button *ngIf="shipments.length" (click)="clear()">Clear History</button>
+  <p *ngIf="!shipments.length">No history yet.</p>
 </div>

--- a/Frontend/src/app/features/history/history.component.scss
+++ b/Frontend/src/app/features/history/history.component.scss
@@ -2,26 +2,18 @@
   padding: 1rem;
 }
 
-.history ul {
-  list-style: none;
-  padding: 0;
-}
-
-.history li {
+.controls {
   display: flex;
   align-items: center;
-  margin-bottom: 0.5rem;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
 }
 
-.history li a {
-  flex: 1;
+.controls div[cdkDropList] {
+  display: flex;
+  gap: 0.5rem;
 }
 
-.history button {
-  margin-left: 0.5rem;
-
-  &:focus {
-    outline: 2px solid #4d148c;
-    outline-offset: 2px;
-  }
+.mat-column-actions {
+  width: 80px;
 }

--- a/Frontend/src/app/features/history/history.component.ts
+++ b/Frontend/src/app/features/history/history.component.ts
@@ -1,26 +1,57 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
+import { MatTableModule } from '@angular/material/table';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatTabsModule } from '@angular/material/tabs';
+import { DragDropModule, CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
+import { FormsModule } from '@angular/forms';
 import { TrackingHistoryService } from '../../core/services/tracking-history.service';
+import { ViewConfigService, ViewConfig } from '../../core/services/view-config.service';
+import { TrackedShipment } from './tracked-shipment';
 
 @Component({
   selector: 'app-history',
   standalone: true,
-  imports: [CommonModule, RouterModule],
+  imports: [
+    CommonModule,
+    RouterModule,
+    MatTableModule,
+    MatCheckboxModule,
+    MatTabsModule,
+    DragDropModule,
+    FormsModule
+  ],
   templateUrl: './history.component.html',
   styleUrls: ['./history.component.scss']
 })
 export class HistoryComponent implements OnInit {
-  history: string[] = [];
+  shipments: TrackedShipment[] = [];
+  availableColumns = ['tracking_number', 'status', 'note', 'created_at'];
+  displayedColumns = [...this.availableColumns, 'actions'];
 
-  constructor(private historyService: TrackingHistoryService) {}
+  savedViews: ViewConfig[] = [];
+  selectedView = 0;
+
+  newViewName = '';
+
+  constructor(
+    private historyService: TrackingHistoryService,
+    private viewConfigService: ViewConfigService
+  ) {}
 
   ngOnInit(): void {
+    this.savedViews = this.viewConfigService.getConfigs();
+    if (this.savedViews.length) {
+      this.applyView(this.savedViews[0], 0);
+    }
     this.historyService.syncWithServer().then(() => this.loadHistory());
   }
 
   private loadHistory(): void {
-    this.history = this.historyService.getHistory();
+    this.historyService.fetchDetailedHistory().subscribe(data => {
+      this.shipments = data;
+    });
   }
 
   delete(id: string): void {
@@ -31,5 +62,34 @@ export class HistoryComponent implements OnInit {
   clear(): void {
     this.historyService.clear();
     this.loadHistory();
+  }
+
+  drop(event: CdkDragDrop<string[]>) {
+    moveItemInArray(this.displayedColumns, event.previousIndex, event.currentIndex);
+  }
+
+  toggleColumn(col: string) {
+    const idx = this.displayedColumns.indexOf(col);
+    if (idx > -1) {
+      this.displayedColumns.splice(idx, 1);
+    } else {
+      this.displayedColumns.splice(this.displayedColumns.length - 1, 0, col);
+    }
+  }
+
+  saveView() {
+    if (!this.newViewName.trim()) return;
+    const config: ViewConfig = {
+      name: this.newViewName.trim(),
+      columns: this.displayedColumns.filter(c => c !== 'actions')
+    };
+    this.viewConfigService.saveConfig(config);
+    this.savedViews = this.viewConfigService.getConfigs();
+    this.newViewName = '';
+  }
+
+  applyView(view: ViewConfig, index: number) {
+    this.displayedColumns = [...view.columns, 'actions'];
+    this.selectedView = index;
   }
 }

--- a/Frontend/src/app/features/history/tracked-shipment.ts
+++ b/Frontend/src/app/features/history/tracked-shipment.ts
@@ -1,0 +1,8 @@
+export interface TrackedShipment {
+  id: string;
+  tracking_number: string;
+  status?: string;
+  meta_data: { [key: string]: any };
+  note?: string;
+  created_at: string;
+}


### PR DESCRIPTION
## Summary
- show tracking history in a material table
- allow toggling and reordering columns via drag & drop
- support saving up to 10 view configurations in localStorage
- select saved views through tabs

## Testing
- `npm test --silent` *(fails: no output)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyotp')*

------
https://chatgpt.com/codex/tasks/task_e_6845ec7183f8832e966c7e7ca9089ef4