### PR TITLE
Add shipments calendar view

### DIFF
--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -20,6 +20,8 @@
         "@angular/router": "^19.2.0",
         "@types/google.maps": "^3.58.1",
         "@zxing/browser": "0.1.5",
+        "angular-calendar": "^0.31.1",
+        "date-fns": "^4.1.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.15.0"
@@ -3631,6 +3633,12 @@
         "win32"
       ]
     },
+    "node_modules/@mattlewis92/dom-autoscroller": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@mattlewis92/dom-autoscroller/-/dom-autoscroller-2.4.2.tgz",
+      "integrity": "sha512-YbrUWREPGEjE/FU6foXcAT1YbVwqD/jkYnY1dFb0o4AxtP3s4xKBthlELjndZih8uwsDWgQZx1eNskRNe2BgZQ==",
+      "license": "MIT"
+    },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
@@ -4991,6 +4999,13 @@
         "win32"
       ]
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@schematics/angular": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-19.2.14.tgz",
@@ -5821,6 +5836,51 @@
         "ajv": "^8.8.2"
       }
     },
+    "node_modules/angular-calendar": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/angular-calendar/-/angular-calendar-0.31.1.tgz",
+      "integrity": "sha512-pjSIpoAaUzS/gx+14eOr4hPZhlQ8HxpiZypCSGqJNptq5PD+vOdVQ3h/Aaqnk86GraVcAQPXqfu64MtdKwTVNw==",
+      "license": "MIT",
+      "dependencies": {
+        "@scarf/scarf": "^1.1.1",
+        "angular-draggable-droppable": "^8.0.0",
+        "angular-resizable-element": "^7.0.0",
+        "calendar-utils": "^0.10.4",
+        "positioning": "^2.0.1",
+        "tslib": "^2.4.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mattlewis92"
+      },
+      "peerDependencies": {
+        "@angular/core": ">=15.0.0"
+      }
+    },
+    "node_modules/angular-draggable-droppable": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/angular-draggable-droppable/-/angular-draggable-droppable-8.0.0.tgz",
+      "integrity": "sha512-+gpSNBbygjV1pxTxsM3UPJKcXHXJabYoTtKcgQe74rGnb1umKc07XCBD1qDzvlG/kocthvhQ12qfYOYzHnE3ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@mattlewis92/dom-autoscroller": "^2.4.2",
+        "tslib": "^2.4.1"
+      },
+      "peerDependencies": {
+        "@angular/core": ">=15.0.0"
+      }
+    },
+    "node_modules/angular-resizable-element": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/angular-resizable-element/-/angular-resizable-element-7.0.2.tgz",
+      "integrity": "sha512-/BGuNiA38n9klexHO1xgnsA3VYigj9v+jUGjKtBRgfB26bCxZKsNWParSu2k3EqbATrfAJC4Nl8f7cORpJFf4w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/core": ">=15.0.0"
+      }
+    },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -6451,6 +6511,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/calendar-utils": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/calendar-utils/-/calendar-utils-0.10.4.tgz",
+      "integrity": "sha512-gBK4xCJ42yjaUKwuUha6cZOfxAmGzvSgbdAaX3xLRioeKbYoOK1x1qeD6dch72rsMZlTgATPbBBx42bnkStqgQ==",
+      "license": "MIT"
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
@@ -7176,6 +7242,16 @@
       "integrity": "sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
     },
     "node_modules/date-format": {
       "version": "4.0.14",
@@ -11749,6 +11825,12 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/positioning": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/positioning/-/positioning-2.0.1.tgz",
+      "integrity": "sha512-DsAgM42kV/ObuwlRpAzDTjH9E8fGKkMDJHWFX+kfNXSxh7UCCQxEmdjv/Ws5Ft1XDnt3JT8fIDYeKNSE2TbttA==",
+      "license": "MIT"
     },
     "node_modules/postcss": {
       "version": "8.5.2",

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -23,24 +23,26 @@
     "@angular/router": "^19.2.0",
     "@types/google.maps": "^3.58.1",
     "@zxing/browser": "0.1.5",
+    "angular-calendar": "^0.31.1",
+    "date-fns": "^4.1.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"
   },
   "devDependencies": {
+    "@angular-builders/custom-webpack": "^19.0.1",
     "@angular-devkit/build-angular": "^19.2.12",
     "@angular/cli": "^19.2.12",
     "@angular/compiler-cli": "^19.2.0",
+    "@playwright/test": "^1.42.1",
     "@types/jasmine": "~5.1.0",
+    "dotenv-webpack": "^8.0.1",
     "jasmine-core": "~5.6.0",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.2.0",
     "karma-coverage": "~2.2.0",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
-    "typescript": "~5.7.2",
-    "@angular-builders/custom-webpack": "^19.0.1",
-    "dotenv-webpack": "^8.0.1"
-    ,"@playwright/test": "^1.42.1"
+    "typescript": "~5.7.2"
   }
 }

--- a/Frontend/src/app/app.routes.ts
+++ b/Frontend/src/app/app.routes.ts
@@ -19,6 +19,7 @@ import { VerifyTwofaComponent } from './features/auth/verify-twofa/verify-twofa.
 import { ResendVerificationComponent } from './features/auth/resend-verification/resend-verification.component';
 import { NewsDetailComponent } from './features/news/news-detail.component';
 import { HistoryComponent } from './features/history/history.component';
+import { ShipmentsComponent } from './features/shipments/shipments.component';
 import { NotFoundComponent } from './shared/not-found.component';
 
 // Assuming you might have other standalone components or lazy-loaded routes
@@ -40,6 +41,7 @@ export const routes: Routes = [
   { path: 'track/:identifier', component: TrackResultComponent, canActivate: [AuthGuard] },
   { path: 'fedex-track/:identifier', component: FedexTrackResultComponent, canActivate: [AuthGuard] },
   { path: 'notifications', component: NotificationsComponent, canActivate: [AuthGuard] },
+  { path: 'shipments', component: ShipmentsComponent, canActivate: [AuthGuard] },
   { path: 'history', component: HistoryComponent, canActivate: [AuthGuard] },
   // Service routes
   { path: 'services/track-by-mail', component: TrackByMailComponent, canActivate: [AuthGuard] },

--- a/Frontend/src/app/core/services/shipment.service.ts
+++ b/Frontend/src/app/core/services/shipment.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+
+export interface Shipment {
+  id: string;
+  description?: string;
+  status: string;
+  estimated_delivery?: string;
+  created_at: string;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ShipmentService {
+  private baseUrl = `${environment.apiUrl}/colis`;
+
+  constructor(private http: HttpClient) {}
+
+  getShipments(): Observable<Shipment[]> {
+    return this.http.get<Shipment[]>(this.baseUrl);
+  }
+}

--- a/Frontend/src/app/features/shipments/shipments.component.html
+++ b/Frontend/src/app/features/shipments/shipments.component.html
@@ -1,0 +1,20 @@
+<div class="toggle-buttons">
+  <button (click)="setView('list')" [disabled]="viewMode === 'list'">List</button>
+  <button (click)="setView('calendar')" [disabled]="viewMode === 'calendar'">Calendar</button>
+</div>
+<div class="filter-box">
+  <input type="text" [(ngModel)]="filterText" (ngModelChange)="applyFilter()" placeholder="Filter shipments" />
+</div>
+
+<div *ngIf="viewMode === 'list'">
+  <ul class="shipments-list">
+    <li *ngFor="let s of filtered">
+      <strong>{{ s.description || s.id }}</strong>
+      <span>- {{ s.status }} - {{ s.estimated_delivery | date:'mediumDate' }}</span>
+    </li>
+  </ul>
+</div>
+
+<div *ngIf="viewMode === 'calendar'">
+  <mwl-calendar-month-view [viewDate]="viewDate" [events]="events"></mwl-calendar-month-view>
+</div>

--- a/Frontend/src/app/features/shipments/shipments.component.scss
+++ b/Frontend/src/app/features/shipments/shipments.component.scss
@@ -1,0 +1,14 @@
+.toggle-buttons {
+  margin-bottom: 1rem;
+  button {
+    margin-right: 0.5rem;
+  }
+}
+.shipments-list {
+  list-style: none;
+  padding: 0;
+  li {
+    padding: 0.5rem 0;
+    border-bottom: 1px solid #ddd;
+  }
+}

--- a/Frontend/src/app/features/shipments/shipments.component.ts
+++ b/Frontend/src/app/features/shipments/shipments.component.ts
@@ -1,0 +1,56 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { CalendarModule, CalendarEvent } from 'angular-calendar';
+import { startOfDay } from 'date-fns';
+import { ShipmentService, Shipment } from '../../core/services/shipment.service';
+
+@Component({
+  selector: 'app-shipments',
+  standalone: true,
+  imports: [CommonModule, FormsModule, CalendarModule],
+  templateUrl: './shipments.component.html',
+  styleUrls: ['./shipments.component.scss']
+})
+export class ShipmentsComponent implements OnInit {
+  shipments: Shipment[] = [];
+  filtered: Shipment[] = [];
+  events: CalendarEvent[] = [];
+  filterText = '';
+  viewMode: 'list' | 'calendar' = 'list';
+  viewDate: Date = new Date();
+
+  constructor(private shipmentService: ShipmentService) {}
+
+  ngOnInit() {
+    this.loadShipments();
+  }
+
+  loadShipments() {
+    this.shipmentService.getShipments().subscribe(sh => {
+      this.shipments = sh;
+      this.applyFilter();
+    });
+  }
+
+  applyFilter() {
+    const term = this.filterText.toLowerCase();
+    this.filtered = this.shipments.filter(s =>
+      (!term || s.description?.toLowerCase().includes(term) || s.status.toLowerCase().includes(term))
+    ).sort((a, b) => {
+      const da = a.estimated_delivery || a.created_at;
+      const db = b.estimated_delivery || b.created_at;
+      return da.localeCompare(db);
+    });
+    this.events = this.filtered
+      .filter(s => !!s.estimated_delivery)
+      .map(s => ({
+        start: startOfDay(new Date(s.estimated_delivery!)),
+        title: s.description || s.id
+      }));
+  }
+
+  setView(mode: 'list' | 'calendar') {
+    this.viewMode = mode;
+  }
+}

--- a/Frontend/src/app/shared/components/navbar/navbar.component.html
+++ b/Frontend/src/app/shared/components/navbar/navbar.component.html
@@ -25,6 +25,7 @@
       </li>
 
       <li><a routerLink="/history">History</a></li>
+      <li><a routerLink="/shipments">Shipments</a></li>
 
       <li class="dropdown">
         <a href="#">Help <i class="fas fa-chevron-down"></i></a>


### PR DESCRIPTION
## Summary
- install `angular-calendar` and `date-fns`
- create `ShipmentService`
- add shipments list/calendar component with toggle
- expose new route and navbar link

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6845ec743410832eb40a788fa19eefe2