### PR TITLE
Add nickname and favorite support to tracking history

### DIFF
--- a/Frontend/src/app/features/history/history.component.html
+++ b/Frontend/src/app/features/history/history.component.html
@@ -2,8 +2,12 @@
   <h2>Tracking History</h2>
   <ng-container *ngIf="history.length; else none">
     <ul>
-      <li *ngFor="let id of history">
-        <a [routerLink]="['/track', id]">{{ id }}</a>
+      <li *ngFor="let id of history" class="history-item">
+        <button class="star" role="button" aria-label="Toggle favorite" (click)="toggleFavorite(id)">
+          <i class="fas" [ngClass]="historyService.isFavorite(id) ? 'fa-star' : 'fa-star-o'"></i>
+        </button>
+        <a [routerLink]="['/track', id]">{{ historyService.getNickname(id) || id }}</a>
+        <button role="button" (click)="editNickname(id)">Edit</button>
         <button role="button"
                 tabindex="0"
                 aria-label="Delete {{id}} from history"

--- a/Frontend/src/app/features/history/history.component.scss
+++ b/Frontend/src/app/features/history/history.component.scss
@@ -13,6 +13,16 @@
   margin-bottom: 0.5rem;
 }
 
+.history .star {
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.history .star .fa-star {
+  color: gold;
+}
+
 .history li a {
   flex: 1;
 }

--- a/Frontend/src/app/features/history/history.component.ts
+++ b/Frontend/src/app/features/history/history.component.ts
@@ -32,4 +32,17 @@ export class HistoryComponent implements OnInit {
     this.historyService.clear();
     this.loadHistory();
   }
+
+  toggleFavorite(id: string): void {
+    const newValue = !this.historyService.isFavorite(id);
+    this.historyService.setFavorite(id, newValue);
+  }
+
+  editNickname(id: string): void {
+    const current = this.historyService.getNickname(id) || '';
+    const value = window.prompt('Nickname', current);
+    if (value !== null) {
+      this.historyService.setNickname(id, value);
+    }
+  }
 }

--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -158,4 +158,6 @@ class TrackedShipmentDB(Base):
     status = Column(String, nullable=True)
     meta_data = Column(JSON, default=dict)
     note = Column(String, nullable=True)
+    nickname = Column(String, nullable=True)
+    favorite = Column(Boolean, default=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/backend/app/models/tracking_history.py
+++ b/backend/app/models/tracking_history.py
@@ -8,6 +8,8 @@ class TrackedShipmentCreate(BaseModel):
     status: Optional[str] = None
     meta_data: Optional[Dict[str, Any]] = None
     note: Optional[str] = None
+    nickname: Optional[str] = None
+    favorite: bool = False
 
 
 class TrackedShipment(BaseModel):
@@ -16,7 +18,15 @@ class TrackedShipment(BaseModel):
     status: Optional[str] = None
     meta_data: Dict[str, Any] = Field(default_factory=dict)
     note: Optional[str] = None
+    nickname: Optional[str] = None
+    favorite: bool = False
     created_at: datetime
 
     class Config:
         from_attributes = True
+
+
+class TrackedShipmentUpdate(BaseModel):
+    nickname: Optional[str] = None
+    favorite: Optional[bool] = None
+    note: Optional[str] = None

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -15,7 +15,7 @@ from backend.app.database import Base, engine, SessionLocal
 from backend.app.models.database import Base as ModelsBase, TrackedShipmentDB
 from backend.app.services.tracking_history_service import TrackingHistoryService
 from backend.app.api.v1.endpoints import history as history_router
-from backend.app.models.tracking_history import TrackedShipmentCreate
+from backend.app.models.tracking_history import TrackedShipmentCreate, TrackedShipmentUpdate
 from backend.app.services import auth
 from backend.app.models.user import UserCreate
 
@@ -43,18 +43,49 @@ def create_user(db, email="user@example.com"):
 
 def test_log_search_stores_fields(db_session):
     service = TrackingHistoryService(db_session)
-    service.log_search(1, "123", status="IN_TRANSIT", meta_data={"a": 1}, note="n")
+    service.log_search(
+        1,
+        "123",
+        status="IN_TRANSIT",
+        meta_data={"a": 1},
+        note="n",
+        nickname="pkg",
+        favorite=True,
+    )
 
     record = db_session.query(TrackedShipmentDB).first()
     assert record.tracking_number == "123"
     assert record.status == "IN_TRANSIT"
     assert record.meta_data["a"] == 1
     assert record.note == "n"
+    assert record.nickname == "pkg"
+    assert record.favorite is True
 
 
 def test_post_history_endpoint(db_session):
     user = create_user(db_session)
-    payload = TrackedShipmentCreate(tracking_number="ABC", status="OK")
+    payload = TrackedShipmentCreate(
+        tracking_number="ABC",
+        status="OK",
+        nickname="abc",
+        favorite=True,
+    )
     result = asyncio.run(history_router.add_history(payload, user, db_session))
     assert result.tracking_number == "ABC"
     assert result.status == "OK"
+    assert result.nickname == "abc"
+    assert result.favorite is True
+
+
+def test_update_history_endpoint(db_session):
+    user = create_user(db_session)
+    payload = TrackedShipmentCreate(tracking_number="XYZ")
+    record = asyncio.run(history_router.add_history(payload, user, db_session))
+
+    update = TrackedShipmentUpdate(nickname="new", favorite=True)
+    updated = asyncio.run(
+        history_router.update_history(record.id, update, user, db_session)
+    )
+
+    assert updated.nickname == "new"
+    assert updated.favorite is True


### PR DESCRIPTION
## Summary
- extend TrackedShipment DB model with `nickname` and `favorite`
- expose new fields in Pydantic models
- allow updating history records
- update Angular tracking history UI with star toggle and nickname editing
- adjust tests for added fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845ec752a08832e8ecac73564477936