### PR TITLE
Display proof of delivery and show GPS coordinates

### DIFF
--- a/Frontend/src/app/features/tracking/track-result/track-result.component.html
+++ b/Frontend/src/app/features/tracking/track-result/track-result.component.html
@@ -94,6 +94,15 @@
         <button type="button"
                 role="button"
                 tabindex="0"
+                aria-label="View proof of delivery"
+                (click)="fetchProof()"
+                (keydown.enter)="fetchProof()"
+                (keydown.space)="fetchProof()">
+          Voir la preuve
+        </button>
+        <button type="button"
+                role="button"
+                tabindex="0"
                 aria-label="Contact support"
                 (click)="contactSupport()"
                 (keydown.enter)="contactSupport()"
@@ -101,6 +110,11 @@
           Contacter le support
         </button>
       </div>
+    </div>
+
+    <div *ngIf="proofUrl" class="proof-container mb-4">
+      <button class="close-proof" (click)="closeProof()" aria-label="Close proof">X</button>
+      <iframe [src]="proofUrl" class="proof-frame"></iframe>
     </div>
 
     <div class="mb-4">

--- a/Frontend/src/app/features/tracking/track-result/track-result.component.scss
+++ b/Frontend/src/app/features/tracking/track-result/track-result.component.scss
@@ -236,6 +236,26 @@
   background: #dc2626;
 }
 
+.proof-container {
+  position: relative;
+}
+
+.proof-frame {
+  width: 100%;
+  height: 400px;
+  border: none;
+}
+
+.close-proof {
+  position: absolute;
+  top: 0;
+  right: 0;
+  background: transparent;
+  border: none;
+  font-size: 1.2rem;
+  cursor: pointer;
+}
+
 @keyframes pulse {
   0% {
     transform: scale(1);


### PR DESCRIPTION
## Summary
- fetch and display proof of delivery PDF when available
- mark actual delivery coordinates on Google Maps

## Testing
- `npm test` *(fails: ng not found)*
- `pytest -q` *(fails: ModuleNotFoundError: pyotp)*

------
https://chatgpt.com/codex/tasks/task_e_6845ec784024832e9199e386fb546fde