### PR TITLE
Add help resources and tracking glossary

### DIFF
--- a/Frontend/src/app/features/home/home.component.html
+++ b/Frontend/src/app/features/home/home.component.html
@@ -225,6 +225,11 @@
 </section>
 
 <!-- =======================
+📖 GLOSSARY SECTION
+======================= -->
+<app-glossary></app-glossary>
+
+<!-- =======================
 📞 CTA SECTION
 ======================= -->
 <section class="cta">
@@ -239,6 +244,12 @@
       <a href="/support" class="btn btn--secondary">
         <i class="fas fa-question-circle"></i>
         Help Center
+      </a>
+      <a href="https://www.fedex.com/en-us/tracking/faq.html" class="btn btn--secondary" target="_blank" rel="noopener">
+        Need help?
+      </a>
+      <a href="https://www.youtube.com/watch?v=Wzj6pHk9-cM" class="btn btn--secondary" target="_blank" rel="noopener">
+        Setting up Advanced Tracking
       </a>
     </div>
   </div>

--- a/Frontend/src/app/features/home/home.component.ts
+++ b/Frontend/src/app/features/home/home.component.ts
@@ -17,6 +17,7 @@ import { TrackingOptionsComponent } from '../../shared/components/tracking-optio
 import { TrackingMobileComponent } from '../../shared/components/tracking-mobile/tracking-mobile.component';
 import { FooterComponent } from '../../shared/components/footer/footer.component';
 import { TrackingFormComponent } from '../../shared/components/tracking-form/tracking-form.component';
+import { GlossaryComponent } from '../../shared/components/glossary/glossary.component';
 
 // Import Google Maps types
 declare global {
@@ -83,7 +84,8 @@ interface ServiceItem {
     TrackingOptionsComponent,
     TrackingMobileComponent,
     TrackingFormComponent,
-    FooterComponent
+    FooterComponent,
+    GlossaryComponent
   ],
   templateUrl: './home.component.html',
   styleUrls: ['./home.component.scss'],

--- a/Frontend/src/app/shared/components/glossary/glossary.component.html
+++ b/Frontend/src/app/shared/components/glossary/glossary.component.html
@@ -1,0 +1,11 @@
+<section class="glossary">
+  <div class="container">
+    <h2 class="section-title">Tracking Status Glossary</h2>
+    <ul class="status-list">
+      <li *ngFor="let item of statuses">
+        <span class="status-term">{{ item.term }}:</span>
+        <span class="status-def">{{ item.description }}</span>
+      </li>
+    </ul>
+  </div>
+</section>

--- a/Frontend/src/app/shared/components/glossary/glossary.component.scss
+++ b/Frontend/src/app/shared/components/glossary/glossary.component.scss
@@ -1,0 +1,16 @@
+.glossary {
+  padding: 40px 0;
+
+  .status-list {
+    list-style: none;
+    padding: 0;
+
+    li {
+      margin-bottom: 0.5rem;
+
+      .status-term {
+        font-weight: bold;
+      }
+    }
+  }
+}

--- a/Frontend/src/app/shared/components/glossary/glossary.component.ts
+++ b/Frontend/src/app/shared/components/glossary/glossary.component.ts
@@ -1,0 +1,24 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+interface GlossaryItem {
+  term: string;
+  description: string;
+}
+
+@Component({
+  selector: 'app-glossary',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './glossary.component.html',
+  styleUrls: ['./glossary.component.scss']
+})
+export class GlossaryComponent {
+  statuses: GlossaryItem[] = [
+    { term: 'Label created', description: 'Shipping label has been created.' },
+    { term: 'In transit', description: 'Package is moving within the FedEx network.' },
+    { term: 'Out for delivery', description: 'Courier is delivering the package today.' },
+    { term: 'Delivered', description: 'Package delivered to the recipient.' },
+    { term: 'Exception', description: 'An unexpected event is delaying delivery.' }
+  ];
+}


### PR DESCRIPTION
## Summary
- show glossary of tracking statuses on home page
- add FedEx FAQ and advanced tracking video links

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845ec7dff44832e878ee8cbb0c9c59c