### PR TITLE
Add tracking dashboard with map and analytics

### DIFF
--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -18,8 +18,10 @@
         "@angular/platform-browser": "^19.2.0",
         "@angular/platform-browser-dynamic": "^19.2.0",
         "@angular/router": "^19.2.0",
+        "@googlemaps/markerclusterer": "^2.0.15",
         "@types/google.maps": "^3.58.1",
         "@zxing/browser": "0.1.5",
+        "chart.js": "^4.4.1",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.15.0"
@@ -2965,6 +2967,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/@googlemaps/markerclusterer": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@googlemaps/markerclusterer/-/markerclusterer-2.5.3.tgz",
+      "integrity": "sha512-x7lX0R5yYOoiNectr10wLgCBasNcXFHiADIBdmn7jQllF2B5ENQw5XtZK+hIw4xnV0Df0xhN4LN98XqA5jaiOw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "supercluster": "^8.0.1"
+      }
+    },
     "node_modules/@inquirer/checkbox": {
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.1.8.tgz",
@@ -3500,6 +3512,12 @@
       "peerDependencies": {
         "tslib": "2"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.5",
@@ -6538,6 +6556,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/chart.js": {
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.9.tgz",
+      "integrity": "sha512-EyZ9wWKgpAU0fLJ43YAEIF8sr5F2W3LqbS40ZJyHIner2lY14ufqv2VMp69MAiZ2rpwxEUxEhIH/0U3xyRynxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
+    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -8013,7 +8043,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -9825,6 +9854,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/kdbush": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
+      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
+      "license": "ISC"
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -13465,6 +13500,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/supercluster": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
+      "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
+      "license": "ISC",
+      "dependencies": {
+        "kdbush": "^4.0.2"
       }
     },
     "node_modules/supports-color": {

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -23,6 +23,8 @@
     "@angular/router": "^19.2.0",
     "@types/google.maps": "^3.58.1",
     "@zxing/browser": "0.1.5",
+    "@googlemaps/markerclusterer": "^2.0.15",
+    "chart.js": "^4.4.1",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"

--- a/Frontend/src/app/app.routes.ts
+++ b/Frontend/src/app/app.routes.ts
@@ -19,6 +19,7 @@ import { VerifyTwofaComponent } from './features/auth/verify-twofa/verify-twofa.
 import { ResendVerificationComponent } from './features/auth/resend-verification/resend-verification.component';
 import { NewsDetailComponent } from './features/news/news-detail.component';
 import { HistoryComponent } from './features/history/history.component';
+import { TrackingDashboardComponent } from './features/tracking-dashboard/tracking-dashboard.component';
 import { NotFoundComponent } from './shared/not-found.component';
 
 // Assuming you might have other standalone components or lazy-loaded routes
@@ -41,6 +42,7 @@ export const routes: Routes = [
   { path: 'fedex-track/:identifier', component: FedexTrackResultComponent, canActivate: [AuthGuard] },
   { path: 'notifications', component: NotificationsComponent, canActivate: [AuthGuard] },
   { path: 'history', component: HistoryComponent, canActivate: [AuthGuard] },
+  { path: 'dashboard', component: TrackingDashboardComponent, canActivate: [AuthGuard] },
   // Service routes
   { path: 'services/track-by-mail', component: TrackByMailComponent, canActivate: [AuthGuard] },
   { path: 'services/notifications', component: NotificationOptionsComponent, canActivate: [AuthGuard] },

--- a/Frontend/src/app/features/tracking-dashboard/tracking-dashboard.component.html
+++ b/Frontend/src/app/features/tracking-dashboard/tracking-dashboard.component.html
@@ -1,0 +1,4 @@
+<div id="dashboard-map" class="map"></div>
+<div class="charts">
+  <canvas id="status-chart"></canvas>
+</div>

--- a/Frontend/src/app/features/tracking-dashboard/tracking-dashboard.component.scss
+++ b/Frontend/src/app/features/tracking-dashboard/tracking-dashboard.component.scss
@@ -1,0 +1,10 @@
+.map {
+  width: 100%;
+  height: 400px;
+  margin-bottom: 1rem;
+}
+
+.charts {
+  width: 100%;
+  max-width: 400px;
+}

--- a/Frontend/src/app/features/tracking-dashboard/tracking-dashboard.component.ts
+++ b/Frontend/src/app/features/tracking-dashboard/tracking-dashboard.component.ts
@@ -1,0 +1,97 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TrackingService } from '../tracking/services/tracking.service';
+import { Subscription } from 'rxjs';
+import Chart from 'chart.js/auto';
+import { MarkerClusterer } from '@googlemaps/markerclusterer';
+
+@Component({
+  selector: 'app-tracking-dashboard',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './tracking-dashboard.component.html',
+  styleUrls: ['./tracking-dashboard.component.scss']
+})
+export class TrackingDashboardComponent implements OnInit, OnDestroy {
+  map: google.maps.Map | null = null;
+  markers: google.maps.Marker[] = [];
+  cluster: MarkerClusterer | null = null;
+  stats: any;
+  private subs: Subscription[] = [];
+
+  constructor(private trackingService: TrackingService) {}
+
+  ngOnInit(): void {
+    this.waitForGoogleMaps().then(() => {
+      this.initializeMap();
+      this.loadShipments();
+      this.loadStats();
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.subs.forEach(s => s.unsubscribe());
+    this.markers.forEach(m => m.setMap(null));
+    if (this.cluster) { this.cluster.clearMarkers(); }
+    this.map = null;
+  }
+
+  private initializeMap(): void {
+    this.map = new window.google.maps.Map(
+      document.getElementById('dashboard-map') as HTMLElement,
+      { center: { lat: 0, lng: 0 }, zoom: 2 }
+    );
+  }
+
+  private loadShipments(): void {
+    const sub = this.trackingService.getActiveShipments().subscribe(data => {
+      this.markers = data.map(item => new window.google.maps.Marker({
+        position: { lat: item.lat, lng: item.lng },
+        label: item.tracking_number
+      }));
+      if (this.cluster) {
+        this.cluster.clearMarkers();
+      }
+      if (this.map) {
+        this.cluster = new MarkerClusterer({ map: this.map, markers: this.markers });
+      }
+    });
+    this.subs.push(sub);
+  }
+
+  private loadStats(): void {
+    const sub = this.trackingService.getTrackingStats().subscribe(stats => {
+      this.stats = stats;
+      this.renderChart();
+    });
+    this.subs.push(sub);
+  }
+
+  private renderChart(): void {
+    const ctx = (document.getElementById('status-chart') as HTMLCanvasElement).getContext('2d');
+    if (!ctx || !this.stats) return;
+    new Chart(ctx, {
+      type: 'doughnut',
+      data: {
+        labels: ['Delivered', 'In Transit', 'Exception'],
+        datasets: [{
+          data: [this.stats.delivered_trackings, this.stats.in_transit_trackings, this.stats.exception_trackings],
+          backgroundColor: ['#4caf50', '#ffa726', '#ef5350']
+        }]
+      }
+    });
+  }
+
+  private waitForGoogleMaps(): Promise<void> {
+    return new Promise(resolve => {
+      const check = () => {
+        if (typeof window !== 'undefined' && (window as any).google && (window as any).google.maps) {
+          resolve();
+        } else {
+          setTimeout(check, 100);
+        }
+      };
+      check();
+    });
+  }
+}

--- a/Frontend/src/app/features/tracking/services/tracking.service.ts
+++ b/Frontend/src/app/features/tracking/services/tracking.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { Observable, map } from 'rxjs';
 import { BrowserMultiFormatReader } from '@zxing/browser';
 import { environment } from '../../../../environments/environment';
 import { TrackingInfo, TrackingResponse } from '../models/tracking';
@@ -56,6 +56,18 @@ export class TrackingService {
 
   trackByEmail(tracking_number: string, email: string): Observable<TrackingResponse> {
     return this.http.post<TrackingResponse>(`${this.baseUrl}/email`, { tracking_number, email });
+  }
+
+  getActiveShipments(): Observable<any[]> {
+    return this.http.get<{ success: boolean; data: any[] }>(`${this.baseUrl}/active`).pipe(
+      map(res => res.data)
+    );
+  }
+
+  getTrackingStats(): Observable<any> {
+    return this.http.get<{ success: boolean; data: any }>(`${this.baseUrl}/stats`).pipe(
+      map(res => res.data)
+    );
   }
 
   decodeBarcodeClient(file: File): Promise<string> {

--- a/README.md
+++ b/README.md
@@ -165,6 +165,12 @@ curl -X POST http://localhost:8000/api/v1/auth/resend-verification \
 L'interface Angular propose un formulaire accessible à l'adresse
 `/auth/resend-verification` pour effectuer cette action.
 
+## Tracking Dashboard
+
+The `/dashboard` route displays a real‑time map of all active shipments. Markers
+are clustered automatically and the page also shows charts summarizing delivery
+statistics.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/backend/app/api/v1/endpoints/tracking.py
+++ b/backend/app/api/v1/endpoints/tracking.py
@@ -280,6 +280,22 @@ async def get_tracking_stats(
         raise HTTPException(status_code=500, detail=str(e))
 
 
+@router.get("/active", response_model=Dict[str, Any])
+async def get_active_shipments(
+    db: Session = Depends(get_db)
+):
+    """Return active shipments with their latest known location."""
+    tracking_service = TrackingService(db=db)
+    try:
+        shipments = tracking_service.get_active_shipments()
+        return {
+            "success": True,
+            "data": shipments,
+        }
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
 @router.get("/number/{tracking_number}", response_model=TrackingResponse)
 async def track_by_number(tracking_number: str, db: Session = Depends(get_db)):
     """Track a package using its tracking number."""


### PR DESCRIPTION
## Summary
- expose `/track/active` endpoint for current shipment locations
- provide helper in service to gather active shipments
- query new endpoint and stats via Angular service
- implement `TrackingDashboardComponent` with marker clustering and chart
- document dashboard route in README

## Testing
- `pytest -q`
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_6845ec7f7a38832e92a47bd1289d894c