### PR TITLE
Add pinned history feature

### DIFF
--- a/Frontend/src/app/features/history/history.component.html
+++ b/Frontend/src/app/features/history/history.component.html
@@ -13,6 +13,8 @@
         <tr>
           <th>Tracking #</th>
           <th>Status</th>
+          <th>Note</th>
+          <th>Pin</th>
           <th (click)="toggleSort()" class="sortable">
             Date
             <span *ngIf="sortAsc">&#9650;</span>
@@ -25,6 +27,12 @@
         <tr *ngFor="let item of sortedHistory">
           <td><a [routerLink]="['/track', item.tracking_number]">{{item.tracking_number}}</a></td>
           <td>{{item.status || '-'}}</td>
+          <td><input [(ngModel)]="item.note" (change)="updateNote(item)"></td>
+          <td>
+            <button (click)="togglePinned(item)">
+              {{item.pinned ? '★' : '☆'}}
+            </button>
+          </td>
           <td>{{item.created_at | date:'short'}}</td>
           <td>
             <button role="button"

--- a/Frontend/src/app/features/history/history.component.ts
+++ b/Frontend/src/app/features/history/history.component.ts
@@ -54,6 +54,17 @@ export class HistoryComponent implements OnInit {
     this.loadHistory();
   }
 
+  togglePinned(item: TrackedShipment): void {
+    if (!item.id) { return; }
+    item.pinned = !item.pinned;
+    this.historyService.updateEntry(item.id, undefined, item.pinned);
+  }
+
+  updateNote(item: TrackedShipment): void {
+    if (!item.id) { return; }
+    this.historyService.updateEntry(item.id, item.note ?? null, undefined);
+  }
+
   clear(): void {
     this.historyService.deleteAll();
     this.loadHistory();

--- a/backend/app/api/v1/endpoints/tracking.py
+++ b/backend/app/api/v1/endpoints/tracking.py
@@ -94,6 +94,7 @@ async def create_package(
                     colis_data.id,
                     status=response.data.status if response.data else None,
                     meta_data=response.metadata,
+                    pinned=False,
                 )
             except Exception:
                 pass
@@ -190,6 +191,7 @@ async def track_package(
                     identifier,
                     status=response.data.status if response.data else None,
                     meta_data=response.metadata,
+                    pinned=False,
                 )
             except Exception:
                 pass

--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -158,4 +158,5 @@ class TrackedShipmentDB(Base):
     status = Column(String, nullable=True)
     meta_data = Column(JSON, default=dict)
     note = Column(String, nullable=True)
+    pinned = Column(Boolean, default=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/backend/app/models/tracking_history.py
+++ b/backend/app/models/tracking_history.py
@@ -8,6 +8,7 @@ class TrackedShipmentCreate(BaseModel):
     status: Optional[str] = None
     meta_data: Optional[Dict[str, Any]] = None
     note: Optional[str] = None
+    pinned: Optional[bool] = False
 
 
 class TrackedShipment(BaseModel):
@@ -16,7 +17,13 @@ class TrackedShipment(BaseModel):
     status: Optional[str] = None
     meta_data: Dict[str, Any] = Field(default_factory=dict)
     note: Optional[str] = None
+    pinned: bool = False
     created_at: datetime
 
     class Config:
         from_attributes = True
+
+
+class TrackedShipmentUpdate(BaseModel):
+    note: Optional[str] = None
+    pinned: Optional[bool] = None

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -15,7 +15,7 @@ from backend.app.database import Base, engine, SessionLocal
 from backend.app.models.database import Base as ModelsBase, TrackedShipmentDB
 from backend.app.services.tracking_history_service import TrackingHistoryService
 from backend.app.api.v1.endpoints import history as history_router
-from backend.app.models.tracking_history import TrackedShipmentCreate
+from backend.app.models.tracking_history import TrackedShipmentCreate, TrackedShipmentUpdate
 from backend.app.services import auth
 from backend.app.models.user import UserCreate
 
@@ -69,3 +69,17 @@ def test_delete_history_endpoint(db_session):
     asyncio.run(history_router.delete_history(user, db_session))
     remaining = service.get_history(user.id)
     assert remaining == []
+
+
+def test_update_history_endpoint(db_session):
+    user = create_user(db_session)
+    payload = TrackedShipmentCreate(tracking_number="UPD", status="X")
+    created = asyncio.run(history_router.add_history(payload, user, db_session))
+
+    update = TrackedShipmentUpdate(note="new note", pinned=True)
+    updated = asyncio.run(
+        history_router.update_history(created.id, update, user, db_session)
+    )
+
+    assert updated.note == "new note"
+    assert updated.pinned is True


### PR DESCRIPTION
## Summary
- allow history entries to be pinned
- enable editing notes for history entries via PATCH endpoint
- Angular UI lets users pin/unpin and edit notes
- tests verify new API behaviour

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845efa5c4bc832e954b2f7eda4c2476