### PR TITLE
Add notes and pin support in history view

### DIFF
--- a/Frontend/src/app/features/history/history.component.html
+++ b/Frontend/src/app/features/history/history.component.html
@@ -18,14 +18,31 @@
             <span *ngIf="sortAsc">&#9650;</span>
             <span *ngIf="!sortAsc">&#9660;</span>
           </th>
+          <th>Note</th>
+          <th>Pin</th>
           <th></th>
         </tr>
       </thead>
       <tbody>
-        <tr *ngFor="let item of sortedHistory">
+        <tr *ngFor="let item of sortedHistory" [ngClass]="{'pinned-row': item.pinned}">
           <td><a [routerLink]="['/track', item.tracking_number]">{{item.tracking_number}}</a></td>
           <td>{{item.status || '-'}}</td>
           <td>{{item.created_at | date:'short'}}</td>
+          <td>
+            <input type="text"
+                   [(ngModel)]="item.note"
+                   (blur)="save(item)"
+                   aria-label="Note for {{item.tracking_number}}">
+          </td>
+          <td>
+            <button type="button"
+                    class="pin-btn"
+                    [attr.aria-pressed]="item.pinned"
+                    aria-label="Toggle pin for {{item.tracking_number}}"
+                    (click)="togglePin(item)">
+              <span class="material-icons" [ngClass]="{'pinned': item.pinned}">push_pin</span>
+            </button>
+          </td>
           <td>
             <button role="button"
                     tabindex="0"

--- a/Frontend/src/app/features/history/history.component.scss
+++ b/Frontend/src/app/features/history/history.component.scss
@@ -31,3 +31,17 @@
 .sortable {
   cursor: pointer;
 }
+
+.pinned-row {
+  background-color: #fffbeb;
+}
+
+.pin-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.pin-btn .material-icons.pinned {
+  color: #d97706;
+}

--- a/Frontend/src/app/features/history/history.component.ts
+++ b/Frontend/src/app/features/history/history.component.ts
@@ -54,6 +54,18 @@ export class HistoryComponent implements OnInit {
     this.loadHistory();
   }
 
+  save(item: TrackedShipment): void {
+    if (!item.id) return;
+    this.historyService.updateRecord(item.id, { note: item.note ?? null });
+  }
+
+  togglePin(item: TrackedShipment): void {
+    if (!item.id) return;
+    const newVal = !item.pinned;
+    item.pinned = newVal;
+    this.historyService.updateRecord(item.id, { pinned: newVal });
+  }
+
   clear(): void {
     this.historyService.deleteAll();
     this.loadHistory();

--- a/backend/app/api/v1/endpoints/history.py
+++ b/backend/app/api/v1/endpoints/history.py
@@ -9,7 +9,12 @@ from ....services.auth import get_current_active_user
 from ....database import get_db
 from ....models.user import UserDB
 from ....services.tracking_history_service import TrackingHistoryService
-from ....models.tracking_history import TrackedShipment, TrackedShipmentCreate
+from ....models.tracking_history import (
+    TrackedShipment,
+    TrackedShipmentCreate,
+    TrackedShipmentUpdate,
+)
+from fastapi import HTTPException
 
 router = APIRouter()
 
@@ -37,7 +42,22 @@ async def add_history(
         status=shipment.status,
         meta_data=shipment.meta_data,
         note=shipment.note,
+        pinned=shipment.pinned,
     )
+    return record
+
+
+@router.patch("/{record_id}", response_model=TrackedShipment)
+async def update_history(
+    record_id: str,
+    update: TrackedShipmentUpdate,
+    current_user: UserDB = Depends(get_current_active_user),
+    db: Session = Depends(get_db),
+):
+    service = TrackingHistoryService(db)
+    record = service.update_record(record_id, note=update.note, pinned=update.pinned)
+    if not record:
+        raise HTTPException(status_code=404, detail="Record not found")
     return record
 
 
@@ -85,9 +105,15 @@ async def export_history(
 
     out = io.StringIO()
     writer = csv.writer(out)
-    writer.writerow(["created_at", "tracking_number", "status", "note"])
+    writer.writerow(["created_at", "tracking_number", "status", "note", "pinned"])
     for rec in records:
-        writer.writerow([rec.created_at, rec.tracking_number, rec.status, rec.note])
+        writer.writerow([
+            rec.created_at,
+            rec.tracking_number,
+            rec.status,
+            rec.note,
+            rec.pinned,
+        ])
     out.seek(0)
     headers = {"Content-Disposition": "attachment; filename=history.csv"}
     return StreamingResponse(io.BytesIO(out.getvalue().encode()), media_type="text/csv", headers=headers)

--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -158,4 +158,5 @@ class TrackedShipmentDB(Base):
     status = Column(String, nullable=True)
     meta_data = Column(JSON, default=dict)
     note = Column(String, nullable=True)
+    pinned = Column(Boolean, default=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/backend/app/models/tracking_history.py
+++ b/backend/app/models/tracking_history.py
@@ -8,6 +8,12 @@ class TrackedShipmentCreate(BaseModel):
     status: Optional[str] = None
     meta_data: Optional[Dict[str, Any]] = None
     note: Optional[str] = None
+    pinned: Optional[bool] = False
+
+
+class TrackedShipmentUpdate(BaseModel):
+    note: Optional[str] = None
+    pinned: Optional[bool] = None
 
 
 class TrackedShipment(BaseModel):
@@ -16,6 +22,7 @@ class TrackedShipment(BaseModel):
     status: Optional[str] = None
     meta_data: Dict[str, Any] = Field(default_factory=dict)
     note: Optional[str] = None
+    pinned: bool = False
     created_at: datetime
 
     class Config:

--- a/backend/app/services/tracking_history_service.py
+++ b/backend/app/services/tracking_history_service.py
@@ -17,6 +17,7 @@ class TrackingHistoryService:
         status: str | None = None,
         meta_data: dict | None = None,
         note: str | None = None,
+        pinned: bool | None = False,
     ) -> TrackedShipmentDB | None:
         """Persist a search in the user's tracking history."""
         try:
@@ -26,6 +27,7 @@ class TrackingHistoryService:
                 status=status,
                 meta_data=meta_data or {},
                 note=note,
+                pinned=pinned or False,
             )
             self.db.add(record)
             self.db.commit()
@@ -53,3 +55,33 @@ class TrackingHistoryService:
         )
         self.db.commit()
         return count
+
+    def update_record(
+        self,
+        record_id: str,
+        *,
+        note: str | None = None,
+        pinned: bool | None = None,
+    ) -> TrackedShipmentDB | None:
+        """Update a history record."""
+        try:
+            record = (
+                self.db.query(TrackedShipmentDB)
+                .filter(TrackedShipmentDB.id == record_id)
+                .first()
+            )
+            if not record:
+                return None
+
+            if note is not None:
+                record.note = note
+            if pinned is not None:
+                record.pinned = pinned
+
+            self.db.commit()
+            self.db.refresh(record)
+            return record
+        except Exception as e:
+            self.db.rollback()
+            logger.error(f"Failed to update tracking record: {e}")
+            return None

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -15,7 +15,10 @@ from backend.app.database import Base, engine, SessionLocal
 from backend.app.models.database import Base as ModelsBase, TrackedShipmentDB
 from backend.app.services.tracking_history_service import TrackingHistoryService
 from backend.app.api.v1.endpoints import history as history_router
-from backend.app.models.tracking_history import TrackedShipmentCreate
+from backend.app.models.tracking_history import (
+    TrackedShipmentCreate,
+    TrackedShipmentUpdate,
+)
 from backend.app.services import auth
 from backend.app.models.user import UserCreate
 
@@ -43,13 +46,21 @@ def create_user(db, email="user@example.com"):
 
 def test_log_search_stores_fields(db_session):
     service = TrackingHistoryService(db_session)
-    service.log_search(1, "123", status="IN_TRANSIT", meta_data={"a": 1}, note="n")
+    service.log_search(
+        1,
+        "123",
+        status="IN_TRANSIT",
+        meta_data={"a": 1},
+        note="n",
+        pinned=True,
+    )
 
     record = db_session.query(TrackedShipmentDB).first()
     assert record.tracking_number == "123"
     assert record.status == "IN_TRANSIT"
     assert record.meta_data["a"] == 1
     assert record.note == "n"
+    assert record.pinned is True
 
 
 def test_post_history_endpoint(db_session):
@@ -69,3 +80,17 @@ def test_delete_history_endpoint(db_session):
     asyncio.run(history_router.delete_history(user, db_session))
     remaining = service.get_history(user.id)
     assert remaining == []
+
+
+def test_update_history_endpoint(db_session):
+    user = create_user(db_session)
+    service = TrackingHistoryService(db_session)
+    record = service.log_search(user.id, "321")
+
+    update = TrackedShipmentUpdate(note="updated", pinned=True)
+    result = asyncio.run(
+        history_router.update_history(record.id, update, user, db_session)
+    )
+
+    assert result.note == "updated"
+    assert result.pinned is True


### PR DESCRIPTION
## Summary
- allow adding a note and pinning items in tracking history
- highlight pinned rows
- persist note and pin via backend API
- expose PATCH endpoint for history records
- test note and pin functionality

## Testing
- `pytest tests/test_history.py -q`
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845efa900f4832eaa8d3a088dc2d176