### PR TITLE
Implement history item deletion

### DIFF
--- a/Frontend/src/app/core/services/tracking-history.service.spec.ts
+++ b/Frontend/src/app/core/services/tracking-history.service.spec.ts
@@ -1,0 +1,46 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { TrackingHistoryService } from './tracking-history.service';
+import { AuthService } from './auth.service';
+import { of } from 'rxjs';
+import { environment } from '../../../environments/environment';
+
+describe('TrackingHistoryService', () => {
+  let service: TrackingHistoryService;
+  let http: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        TrackingHistoryService,
+        { provide: AuthService, useValue: { isLoggedIn: () => of(true) } }
+      ]
+    });
+    service = TestBed.inject(TrackingHistoryService);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    http.verify();
+    localStorage.removeItem('trackingHistory');
+  });
+
+  it('removeIdentifier should delete entry locally and call backend', () => {
+    const now = new Date().toISOString();
+    localStorage.setItem('trackingHistory', JSON.stringify([
+      { id: '1', tracking_number: '111', created_at: now },
+      { id: '2', tracking_number: '222', created_at: now }
+    ]));
+
+    service.removeIdentifier('1');
+
+    const req = http.expectOne(`${environment.apiUrl}/history/1`);
+    expect(req.request.method).toBe('DELETE');
+    req.flush({});
+
+    const remaining = JSON.parse(localStorage.getItem('trackingHistory') || '[]');
+    expect(remaining.length).toBe(1);
+    expect(remaining[0].id).toBe('2');
+  });
+});

--- a/Frontend/src/app/core/services/tracking-history.service.ts
+++ b/Frontend/src/app/core/services/tracking-history.service.ts
@@ -60,8 +60,13 @@ export class TrackingHistoryService {
   }
 
   removeIdentifier(id: string): void {
-    const history = this.getHistory().filter(item => item.tracking_number !== id);
+    const history = this.getHistory().filter(item => item.id !== id && item.tracking_number !== id);
     localStorage.setItem(this.storageKey, JSON.stringify(history));
+
+    this.http.delete(`${environment.apiUrl}/history/${id}`).subscribe({
+      next: () => {},
+      error: () => {}
+    });
   }
 
   clear(): void {

--- a/Frontend/src/app/features/history/history.component.html
+++ b/Frontend/src/app/features/history/history.component.html
@@ -38,9 +38,9 @@
             <button role="button"
                     tabindex="0"
                     aria-label="Delete {{item.tracking_number}} from history"
-                    (click)="delete(item.tracking_number)"
-                    (keydown.enter)="delete(item.tracking_number)"
-                    (keydown.space)="delete(item.tracking_number)">Delete</button>
+                    (click)="delete(item.id!)"
+                    (keydown.enter)="delete(item.id!)"
+                    (keydown.space)="delete(item.id!)">Delete</button>
           </td>
         </tr>
       </tbody>

--- a/Frontend/src/app/features/history/history.component.ts
+++ b/Frontend/src/app/features/history/history.component.ts
@@ -51,7 +51,7 @@ export class HistoryComponent implements OnInit {
 
   delete(id: string): void {
     this.historyService.removeIdentifier(id);
-    this.loadHistory();
+    this.history = this.history.filter(h => h.id !== id);
   }
 
   togglePinned(item: TrackedShipment): void {

--- a/backend/app/api/v1/endpoints/history.py
+++ b/backend/app/api/v1/endpoints/history.py
@@ -76,6 +76,20 @@ async def delete_history(
     return {"deleted": deleted}
 
 
+@router.delete("/{history_id}")
+async def delete_history_item(
+    history_id: str,
+    current_user: UserDB = Depends(get_current_active_user),
+    db: Session = Depends(get_db),
+):
+    """Delete a single history item."""
+    service = TrackingHistoryService(db)
+    deleted = service.delete_history_item(current_user.id, history_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="History item not found")
+    return {"deleted": deleted}
+
+
 @router.get("/export")
 async def export_history(
     format: str = "csv",

--- a/backend/app/services/tracking_history_service.py
+++ b/backend/app/services/tracking_history_service.py
@@ -86,3 +86,21 @@ class TrackingHistoryService:
             self.db.rollback()
             logger.error(f"Failed to update history item: {e}")
             return None
+
+    def delete_history_item(self, user_id: int, record_id: str) -> bool:
+        """Delete a single history item for the given user."""
+        try:
+            count = (
+                self.db.query(TrackedShipmentDB)
+                .filter(
+                    TrackedShipmentDB.user_id == user_id,
+                    TrackedShipmentDB.id == record_id,
+                )
+                .delete()
+            )
+            self.db.commit()
+            return count > 0
+        except Exception as e:
+            self.db.rollback()
+            logger.error(f"Failed to delete history item: {e}")
+            return False

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -71,6 +71,17 @@ def test_delete_history_endpoint(db_session):
     assert remaining == []
 
 
+def test_delete_single_history_item(db_session):
+    user = create_user(db_session)
+    service = TrackingHistoryService(db_session)
+    rec1 = service.log_search(user.id, "1")
+    service.log_search(user.id, "2")
+
+    asyncio.run(history_router.delete_history_item(rec1.id, user, db_session))
+    remaining = [r.tracking_number for r in service.get_history(user.id)]
+    assert remaining == ["2"]
+
+
 def test_update_history_endpoint(db_session):
     user = create_user(db_session)
     payload = TrackedShipmentCreate(tracking_number="UPD", status="X")


### PR DESCRIPTION
## Summary
- support deleting individual history items in backend service & API
- call new endpoint from Angular TrackingHistoryService
- update HistoryComponent to use id-based deletion
- add unit tests for backend deletion and local storage logic

## Testing
- `pytest tests/test_history.py::test_delete_single_history_item -q`
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: Found 1 load error)*

------
https://chatgpt.com/codex/tasks/task_e_6845f3010ff0832eb5ea55f4ff07c15f