### PR TITLE
Add account selector & preferences

### DIFF
--- a/Frontend/src/app/core/services/notification.service.ts
+++ b/Frontend/src/app/core/services/notification.service.ts
@@ -16,6 +16,7 @@ export interface NotificationPreferences {
   addresses: string[];
   preferred_language: string;
   event_settings: { [key: string]: string[] };
+  default_account?: string;
 }
 
 @Injectable({

--- a/Frontend/src/app/features/advanced-shipment-tracking/advanced-shipment-tracking.component.html
+++ b/Frontend/src/app/features/advanced-shipment-tracking/advanced-shipment-tracking.component.html
@@ -8,6 +8,12 @@
     <label>Package Name</label>
     <input formControlName="packageName" />
   </div>
+  <div class="form-group">
+    <label>Account</label>
+    <select [(ngModel)]="selectedAccount" (change)="updateAccount()" name="account">
+      <option *ngFor="let acc of accounts" [value]="acc">{{ acc }}</option>
+    </select>
+  </div>
   <button type="submit" class="btn btn--primary" [disabled]="loading">Track</button>
 </form>
 

--- a/Frontend/src/app/features/shipments/shipments.component.html
+++ b/Frontend/src/app/features/shipments/shipments.component.html
@@ -4,6 +4,9 @@
 </div>
 <div class="filter-box">
   <input type="text" [(ngModel)]="filterText" (ngModelChange)="applyFilter()" placeholder="Filter shipments" />
+  <select [(ngModel)]="selectedAccount" (change)="updateAccount()">
+    <option *ngFor="let acc of accounts" [value]="acc">{{ acc }}</option>
+  </select>
 </div>
 
 <div *ngIf="viewMode === 'list'">

--- a/Frontend/src/app/features/shipments/shipments.component.ts
+++ b/Frontend/src/app/features/shipments/shipments.component.ts
@@ -4,6 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { CalendarModule, CalendarEvent } from 'angular-calendar';
 import { startOfDay } from 'date-fns';
 import { ShipmentService, Shipment } from '../../core/services/shipment.service';
+import { NotificationService } from '../../core/services/notification.service';
 
 @Component({
   selector: 'app-shipments',
@@ -19,11 +20,16 @@ export class ShipmentsComponent implements OnInit {
   filterText = '';
   viewMode: 'list' | 'calendar' = 'list';
   viewDate: Date = new Date();
+  accounts: string[] = ['A001', 'A002'];
+  selectedAccount = '';
 
-  constructor(private shipmentService: ShipmentService) {}
+  constructor(private shipmentService: ShipmentService, private notif: NotificationService) {}
 
   ngOnInit() {
     this.loadShipments();
+    this.notif.getPreferences().subscribe(p => {
+      this.selectedAccount = p.default_account || this.accounts[0];
+    });
   }
 
   loadShipments() {
@@ -52,5 +58,15 @@ export class ShipmentsComponent implements OnInit {
 
   setView(mode: 'list' | 'calendar') {
     this.viewMode = mode;
+  }
+
+  updateAccount() {
+    this.notif.updatePreferences({
+      email_updates: true,
+      addresses: [],
+      preferred_language: 'en',
+      event_settings: {},
+      default_account: this.selectedAccount
+    }).subscribe();
   }
 }

--- a/Frontend/src/app/features/tracking/services/tracking.service.ts
+++ b/Frontend/src/app/features/tracking/services/tracking.service.ts
@@ -13,15 +13,15 @@ export class TrackingService {
 
   constructor(private http: HttpClient) {}
 
-  trackPackage(identifier: string): Observable<TrackingResponse> {
-    return this.http.get<TrackingResponse>(`${this.baseUrl}/${identifier}`);
+  trackPackage(identifier: string, account?: string): Observable<TrackingResponse> {
+    const url = account ? `${this.baseUrl}/${identifier}?account=${account}` : `${this.baseUrl}/${identifier}`;
+    return this.http.get<TrackingResponse>(url);
   }
 
-  trackNumber(trackingNumber: string, packageName?: string): Observable<TrackingResponse> {
-    return this.http.post<TrackingResponse>(`${this.baseUrl}/create`, {
-      id: trackingNumber,
-      description: packageName
-    });
+  trackNumber(trackingNumber: string, packageName?: string, account?: string): Observable<TrackingResponse> {
+    const payload: any = { id: trackingNumber, description: packageName };
+    if (account) payload.account = account;
+    return this.http.post<TrackingResponse>(`${this.baseUrl}/create`, payload);
   }
 
   trackReference(reference: string): Observable<TrackingResponse> {

--- a/backend/app/models/notification.py
+++ b/backend/app/models/notification.py
@@ -55,6 +55,7 @@ class NotificationPreference(BaseModel):
     addresses: List[str] = []
     preferred_language: str = "en"
     event_settings: Dict[str, Any] = Field(default_factory=dict)
+    default_account: Optional[str] = None
 
 
 class NotificationPreferenceResponse(BaseModel):

--- a/backend/app/models/notification_preference.py
+++ b/backend/app/models/notification_preference.py
@@ -9,3 +9,4 @@ class NotificationPreferenceDB(Base):
     addresses = Column(JSON, default=list)
     preferred_language = Column(String, default="en")
     event_settings = Column(JSON, default=dict)
+    default_account = Column(String, nullable=True)

--- a/backend/app/services/fedex_service.py
+++ b/backend/app/services/fedex_service.py
@@ -16,7 +16,7 @@ from ..models.tracking import (
 logger = logging.getLogger(__name__)
 
 class FedExService:
-    def __init__(self, config_path: str | None = None):
+    def __init__(self, account: str | None = None, config_path: str | None = None):
         try:
             if config_path is None:
                 try:
@@ -35,6 +35,8 @@ class FedExService:
                 'client_secret': os.path.expandvars(config['client_secret']),
                 'account_number': os.path.expandvars(config['account_number'])
             }
+            if account:
+                self.cdict['account_number'] = account
             self.payload = {
                 "grant_type": "client_credentials",
                 'client_id': self.cdict['client_id'],
@@ -168,7 +170,8 @@ class FedExService:
                     error=error_msg,
                     metadata={
                         'timestamp': datetime.now().isoformat(),
-                        'tracking_number': tracking_number
+                        'tracking_number': tracking_number,
+                        'account_number': self.cdict['account_number']
                     }
                 )
                 
@@ -185,7 +188,8 @@ class FedExService:
                     'response_time': response.elapsed.total_seconds(),
                     'timestamp': datetime.now().isoformat(),
                     'tracking_number': tracking_number,
-                    'raw_response': tracking_data
+                    'raw_response': tracking_data,
+                    'account_number': self.cdict['account_number']
                 }
             )
 
@@ -198,7 +202,8 @@ class FedExService:
                 error=error_msg,
                 metadata={
                     'timestamp': datetime.now().isoformat(),
-                    'tracking_number': tracking_number
+                    'tracking_number': tracking_number,
+                    'account_number': self.cdict['account_number']
                 }
             )
         except httpx.HTTPStatusError as e:
@@ -210,7 +215,8 @@ class FedExService:
                 error=error_msg,
                 metadata={
                     'timestamp': datetime.now().isoformat(),
-                    'tracking_number': tracking_number
+                    'tracking_number': tracking_number,
+                    'account_number': self.cdict['account_number']
                 }
             )
         except Exception as e:
@@ -222,7 +228,8 @@ class FedExService:
                 error=error_msg,
                 metadata={
                     'timestamp': datetime.now().isoformat(),
-                    'tracking_number': tracking_number
+                    'tracking_number': tracking_number,
+                    'account_number': self.cdict['account_number']
                 }
             )
 

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -283,6 +283,7 @@ class NotificationService:
                     addresses=pref.addresses or [],
                     preferred_language=pref.preferred_language,
                     event_settings=pref.event_settings or {},
+                    default_account=pref.default_account,
                 ),
             )
         except Exception as e:
@@ -330,6 +331,7 @@ class NotificationService:
             pref.addresses = preferences.addresses[:5]
             pref.preferred_language = preferences.preferred_language
             pref.event_settings = preferences.event_settings
+            pref.default_account = preferences.default_account
 
             self.db.commit()
             self.db.refresh(pref)
@@ -340,6 +342,7 @@ class NotificationService:
                     addresses=pref.addresses or [],
                     preferred_language=pref.preferred_language,
                     event_settings=pref.event_settings or {},
+                    default_account=pref.default_account,
                 ),
             )
         except Exception as e:

--- a/backend/app/services/tracking_service.py
+++ b/backend/app/services/tracking_service.py
@@ -12,9 +12,9 @@ from ..models.database import TrackingDB, TrackingEventDB
 logger = logging.getLogger(__name__)
 
 class TrackingService:
-    def __init__(self, db: Session):
+    def __init__(self, db: Session, account: str | None = None):
         self.db = db
-        self.fedex_service = FedExService()
+        self.fedex_service = FedExService(account)
 
     def _validate_tracking_number(self, tracking_number: str) -> bool:
         """

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -96,9 +96,11 @@ def test_update_preferences(db_session):
         addresses=["a@example.com", "b@example.com"],
         preferred_language="fr",
         event_settings={"delivery": ["email"]},
+        default_account="A001",
     )
     service = NotificationService(db_session)
     resp = service.update_preferences(user.id, prefs)
     assert resp.success is True
     assert resp.data.addresses == ["a@example.com", "b@example.com"]
     assert resp.data.preferred_language == "fr"
+    assert resp.data.default_account == "A001"


### PR DESCRIPTION
## Summary
- allow setting a default shipping account
- include account in tracking calls and FedEx metadata
- enable selecting account in shipments and advanced tracking
- update tests for new preference field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845f392b8f8832ebb27486a9d0595cb