### PR TITLE
Add FedEx webhook endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The `.env.local` file should include values for `FEDEX_CLIENT_ID`,
 required secrets.
 
 Optionally set `FEDEX_BASE_URL` to override the default `https://apis-sandbox.fedex.com`.
+Set `FEDEX_WEBHOOK_SECRET` if you enable signed webhooks in your FedEx account.
 
 Both `backend/.env` and `backend/.env.local` are ignored by Git. Store your secrets in `backend/.env.local` so they are not committed and are automatically loaded by the backend.
 
@@ -166,6 +167,14 @@ curl -X POST http://localhost:8000/api/v1/auth/resend-verification \
 
 L'interface Angular propose un formulaire accessible à l'adresse
 `/auth/resend-verification` pour effectuer cette action.
+
+## FedEx Webhook Setup
+
+Configure a FedEx webhook so that shipment updates are sent to
+`/webhook/fedex` on your backend. When enabling signature verification in
+the FedEx dashboard, set the same secret in `FEDEX_WEBHOOK_SECRET` inside
+`backend/.env.local`. FedEx will send events as POST requests and the
+application will refresh the tracking information automatically.
 
 ## License
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -7,6 +7,8 @@ FEDEX_CLIENT_SECRET=your-fedex-client-secret
 FEDEX_ACCOUNT_NUMBER=your-fedex-account-number
 # Optional base URL for FedEx API
 FEDEX_BASE_URL=https://apis-sandbox.fedex.com
+# Secret used to verify FedEx webhook signatures
+FEDEX_WEBHOOK_SECRET=your-fedex-webhook-secret
 
 # Google OAuth credentials
 GOOGLE_CLIENT_ID=your-google-client-id

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -52,6 +52,7 @@ class Settings(BaseSettings):
     FEDEX_CLIENT_ID: str
     FEDEX_CLIENT_SECRET: str
     FEDEX_ACCOUNT_NUMBER: str
+    FEDEX_WEBHOOK_SECRET: str | None = os.environ.get("FEDEX_WEBHOOK_SECRET")
     
     class Config:
         case_sensitive = True

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,6 +8,7 @@ import redis.asyncio as redis
 
 from .config import settings
 from .routers import auth, google_auth
+from .routers import webhook
 from .api.v1.api import api_router
 
 # Chargement des variables d'environnement
@@ -52,6 +53,7 @@ async def shutdown() -> None:
 app.include_router(auth.router, prefix=settings.API_V1_STR)
 app.include_router(google_auth.router, prefix=settings.API_V1_STR)
 app.include_router(api_router)
+app.include_router(webhook.router)
 
 @app.get("/")
 async def root():

--- a/backend/app/routers/webhook.py
+++ b/backend/app/routers/webhook.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, Request, HTTPException, Depends
+from sqlalchemy.orm import Session
+import hmac
+import hashlib
+import secrets
+import json
+
+from ..config import settings
+from ..database import get_db
+from ..services.tracking_service import TrackingService
+
+router = APIRouter(prefix="/webhook", tags=["webhook"])
+
+@router.post("/fedex")
+async def fedex_webhook(request: Request, db: Session = Depends(get_db)):
+    """Handle FedEx webhook notifications."""
+    body_bytes = await request.body()
+    signature = request.headers.get("X-Fedex-Signature")
+    secret = settings.FEDEX_WEBHOOK_SECRET
+    if signature and secret:
+        digest = hmac.new(secret.encode(), body_bytes, hashlib.sha256).hexdigest()
+        if not secrets.compare_digest(digest, signature):
+            raise HTTPException(status_code=400, detail="Invalid signature")
+
+    try:
+        payload = json.loads(body_bytes.decode())
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid JSON payload")
+
+    tracking_number = (
+        payload.get("tracking_number")
+        or payload.get("trackingNumber")
+        or payload.get("TrackNo")
+    )
+    if tracking_number:
+        service = TrackingService(db)
+        service.track_single_package(tracking_number)
+
+    return {"success": True}


### PR DESCRIPTION
## Summary
- add `/webhook/fedex` endpoint for FedEx callbacks
- verify optional webhook signature using `FEDEX_WEBHOOK_SECRET`
- expose FEDEX webhook secret in config and env example
- document FedEx webhook setup in README

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845f3944420832e81219b1ddd5266cd