### PR TITLE
Add Playwright cross-browser setup

### DIFF
--- a/Frontend/playwright.config.ts
+++ b/Frontend/playwright.config.ts
@@ -6,6 +6,20 @@ const config: PlaywrightTestConfig = {
     headless: true,
     baseURL: 'http://localhost:4200',
   },
+  projects: [
+    {
+      name: 'chromium',
+      use: { browserName: 'chromium' }
+    },
+    {
+      name: 'firefox',
+      use: { browserName: 'firefox' }
+    },
+    {
+      name: 'webkit',
+      use: { browserName: 'webkit' }
+    }
+  ]
 };
 
 export default config;

--- a/Frontend/src/app/features/auth/login/login.component.scss
+++ b/Frontend/src/app/features/auth/login/login.component.scss
@@ -2,10 +2,16 @@
   max-width: 400px;
   margin: 50px auto;
   padding: 20px;
+  box-sizing: border-box;
 }
 
 .form-group {
   margin-bottom: 15px;
+
+  input {
+    width: 100%;
+    box-sizing: border-box;
+  }
 }
 
 .error-message {

--- a/Frontend/src/app/features/shipments/shipments.component.scss
+++ b/Frontend/src/app/features/shipments/shipments.component.scss
@@ -1,8 +1,8 @@
 .toggle-buttons {
   margin-bottom: 1rem;
-  button {
-    margin-right: 0.5rem;
-  }
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
 }
 .shipments-list {
   list-style: none;

--- a/README.md
+++ b/README.md
@@ -98,6 +98,16 @@ npm install
 npm start
 ```
 
+## Supported browsers
+
+The application is tested with Playwright on the following browsers:
+
+- Google Chrome (Chromium)
+- Mozilla Firefox
+- Apple Safari (WebKit)
+
+Other browsers may work but are not officially supported.
+
 ## Setup
 
 After cloning the repository, copy the example environment files:


### PR DESCRIPTION
## Summary
- run Playwright tests on Chromium, Firefox and WebKit
- tweak login layout for better compatibility
- tweak shipments view buttons layout
- document officially supported browsers

## Testing
- `pytest -q`
- `npx playwright test` *(fails: connection refused and missing libs)*

------
https://chatgpt.com/codex/tasks/task_e_6845f3982d8c832e9219b3de4d818e04