### PR TITLE
Add delivery status class for history

### DIFF
--- a/Frontend/src/app/features/history/history.component.html
+++ b/Frontend/src/app/features/history/history.component.html
@@ -35,7 +35,7 @@
       <tbody>
         <tr *ngFor="let item of sortedHistory">
           <td><a [routerLink]="['/track', item.tracking_number]">{{item.tracking_number}}</a></td>
-          <td>{{item.status || '-'}}</td>
+          <td [ngClass]="getStatusClass(item)">{{item.status || '-'}}</td>
           <td><input [(ngModel)]="item.note" (change)="updateNote(item)"></td>
           <td>
             <button (click)="togglePinned(item)">

--- a/Frontend/src/app/features/history/history.component.scss
+++ b/Frontend/src/app/features/history/history.component.scss
@@ -58,3 +58,10 @@
   white-space: nowrap;
   border: 0;
 }
+
+.delivered {
+  color: green;
+  &::before {
+    content: '✔ ';
+  }
+}

--- a/Frontend/src/app/features/history/history.component.ts
+++ b/Frontend/src/app/features/history/history.component.ts
@@ -86,4 +86,8 @@ export class HistoryComponent implements OnInit {
       window.URL.revokeObjectURL(url);
     });
   }
+
+  getStatusClass(item: TrackedShipment): string {
+    return (item.status || '').toLowerCase().includes('delivered') ? 'delivered' : '';
+  }
 }


### PR DESCRIPTION
## Summary
- highlight delivered shipments in the history table
- display class using `[ngClass]` in the template
- style delivered rows with a green checkmark

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npx tsc -p tsconfig.app.json` *(fails: Cannot find module '@angular/core')*

------
https://chatgpt.com/codex/tasks/task_e_6845f696e5e8832eb3448b520b10d6a1