### PR TITLE
Add extra packages for running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,17 @@ On the first run Docker Compose builds the backend and frontend images. Once the
 - Frontend: http://localhost:4200
 - Redis: localhost:6379
 
+## Running Tests
+
+Install the backend dependencies and the packages listed in
+`requirements-test.txt` before executing the test suite:
+
+```bash
+pip install -r backend/requirements.txt
+pip install -r requirements-test.txt
+pytest
+```
+
 ## Password requirements
 
 User registration requires a strong password. The password must be at least 8

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,28 @@
 # Packages required only for running the test suite
 pytest==8.3.5
+
+# Additional libraries imported by the tests
+fastapi==0.110.0
+uvicorn==0.27.1
+sqlalchemy==2.0.29
+psycopg2-binary==2.9.9
+python-jose[cryptography]==3.3.0
+passlib[bcrypt]==1.7.4
+pydantic==2.6.3
+pydantic-settings==2.1.0
+email-validator==2.1.1
+python-multipart==0.0.9
+requests==2.31.0
+python-dotenv==1.0.1
+pyyaml==6.0.1
+authlib==1.2.1
+httpx==0.27.0
+python-barcode==0.15.1
+pillow==10.3.0
+pytz==2024.1
+itsdangerous==2.2.0
+fastapi-limiter==0.1.6
+redis>=4.2.0
+pyotp==2.9.0
+pyzbar==0.1.9
+reportlab==4.0.6


### PR DESCRIPTION
## Summary
- list all dependencies needed by tests in `requirements-test.txt`
- document installing `requirements-test.txt` before running tests

## Testing
- `pip install -r backend/requirements.txt`
- `pip install -r requirements-test.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845f69c0268832eb82b3796a4a7538c