### PR TITLE
Ignore pytest cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ backend/venv/
 # Ignore frontend dependencies and build outputs
 Frontend/node_modules/
 Frontend/dist/
+
+# Ignore test caches
+.pytest_cache/


### PR DESCRIPTION
## Summary
- ignore `.pytest_cache/` files

## Testing
- `pip install -r requirements-test.txt`
- `pytest -q` *(fails: Invalid or missing TOTP code)*

------
https://chatgpt.com/codex/tasks/task_e_6845fe4bf834832eab0b8417050cf172