### PR TITLE
Update README with Chrome unit test note

### DIFF
--- a/Frontend/README.md
+++ b/Frontend/README.md
@@ -3,3 +3,7 @@
 This directory contains the Dockerfile used to build and serve the Angular application for production.
 
 The image builds the Angular code from the `Frontend` directory, then serves the compiled files with Nginx. It is referenced by `docker-compose.yml` to run the production frontend.
+
+## Unit tests
+
+Run `npm test` to execute the Angular unit tests. Karma launches Chrome by default, so a local Chrome (or Chromium) installation is required. On headless systems you can set the `CHROME_BIN` environment variable to the path of a Chrome executable, such as the binary provided by the `chromium-browser` package.

--- a/README.md
+++ b/README.md
@@ -161,6 +161,11 @@ pip install -r requirements-test.txt
 pytest
 ```
 
+Angular unit tests are executed with Karma via `npm test` in the `Frontend`
+directory. Karma requires a local Chrome (or Chromium) installation. On headless
+systems you can set the `CHROME_BIN` environment variable to the path of a
+Chrome executable.
+
 ## Password requirements
 
 User registration requires a strong password. The password must be at least 8


### PR DESCRIPTION
## Summary
- note that Angular unit tests require Chrome in Frontend/README
- document Karma/Chrome requirement in main README

## Testing
- `npm test -- --watch=false` *(fails: ng not found)*
- `pytest -k nothing -vv` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6845fe4e1578832e84d43a407704ce24