### PR TITLE
Add news detail fetch

### DIFF
--- a/Frontend/src/app/features/news/models/news.ts
+++ b/Frontend/src/app/features/news/models/news.ts
@@ -1,0 +1,11 @@
+export interface NewsArticle {
+  id: number;
+  title: string;
+  content: string;
+  image?: string;
+  imageUrl?: string;
+  date?: string | Date;
+  category?: string;
+  summary?: string;
+  slug: string;
+}

--- a/Frontend/src/app/features/news/news-detail.component.html
+++ b/Frontend/src/app/features/news/news-detail.component.html
@@ -1,6 +1,11 @@
-<div class="news-detail" *ngIf="slug">
-  <h2>Article: {{ slug }}</h2>
-  <p>This is a placeholder for the news article with slug <strong>{{ slug }}</strong>.</p>
+<div class="news-detail" *ngIf="article">
+  <h2>{{ article.title }}</h2>
+  <img *ngIf="article.imageUrl" [src]="article.imageUrl" [alt]="article.title" />
+  <div [innerHTML]="article.content"></div>
+</div>
+
+<div class="news-detail" *ngIf="!article && slug">
+  <p>Loading...</p>
 </div>
 
 <div class="news-detail" *ngIf="!slug">

--- a/Frontend/src/app/features/news/news-detail.component.ts
+++ b/Frontend/src/app/features/news/news-detail.component.ts
@@ -2,6 +2,8 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute } from '@angular/router';
 import { Subscription } from 'rxjs';
+import { NewsService } from './services/news.service';
+import { NewsArticle } from './models/news';
 
 @Component({
   selector: 'app-news-detail',
@@ -12,17 +14,26 @@ import { Subscription } from 'rxjs';
 })
 export class NewsDetailComponent implements OnInit, OnDestroy {
   slug: string | null = null;
+  article: NewsArticle | null = null;
   private paramsSub: Subscription | null = null;
+  private articleSub: Subscription | null = null;
 
-  constructor(private route: ActivatedRoute) {}
+  constructor(private route: ActivatedRoute, private newsService: NewsService) {}
 
   ngOnInit() {
     this.paramsSub = this.route.params.subscribe(params => {
       this.slug = params['slug'];
+      if (this.slug) {
+        this.articleSub?.unsubscribe();
+        this.articleSub = this.newsService
+          .getArticle(this.slug)
+          .subscribe(article => (this.article = article));
+      }
     });
   }
 
   ngOnDestroy() {
     this.paramsSub?.unsubscribe();
+    this.articleSub?.unsubscribe();
   }
 }

--- a/Frontend/src/app/features/news/services/news.service.ts
+++ b/Frontend/src/app/features/news/services/news.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../../environments/environment';
+import { NewsArticle } from '../models/news';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class NewsService {
+  private baseUrl = `${environment.apiUrl}/news`;
+
+  constructor(private http: HttpClient) {}
+
+  getArticle(slug: string): Observable<NewsArticle> {
+    return this.http.get<NewsArticle>(`${this.baseUrl}/${slug}`);
+  }
+
+  getArticles(): Observable<NewsArticle[]> {
+    return this.http.get<NewsArticle[]>(this.baseUrl);
+  }
+}


### PR DESCRIPTION
## Summary
- provide a `NewsService` for getting news articles from the backend
- use the service in `NewsDetailComponent`
- show article title, image and content in the detail page

## Testing
- `npm test --prefix Frontend` *(fails: ng not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68460ddffe04832eaa47e367a0f62143