### PR TITLE
Fix OAuth form validation and use lifespan events

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -30,7 +30,7 @@ from ..services.email import send_verification_email, send_password_reset_email
 class OAuth2PasswordRequestForm(BaseOAuth2PasswordRequestForm):
     def __init__(
         self,
-        grant_type: str | None = Form(None, regex="password"),
+        grant_type: str | None = Form(None, pattern="password"),
         username: str = Form(...),
         password: str = Form(...),
         scope: str = Form(""),


### PR DESCRIPTION
## Summary
- replace deprecated `regex` with `pattern` in OAuth2 form
- switch startup/shutdown logic to FastAPI lifespan events

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684615d23b14832eb14d073ebd472c22