### PR TITLE
Add help center feature module

### DIFF
--- a/Frontend/src/app/app.routes.ts
+++ b/Frontend/src/app/app.routes.ts
@@ -44,6 +44,13 @@ export const routes: Routes = [
   { path: 'notifications', component: NotificationsComponent, canActivate: [AuthGuard] },
   { path: 'shipments', component: ShipmentsComponent, canActivate: [AuthGuard] },
   { path: 'history', component: HistoryComponent, canActivate: [AuthGuard] },
+  {
+    path: 'help',
+    loadComponent: () =>
+      import('./features/help-center/help-center.component').then(
+        m => m.HelpCenterComponent
+      )
+  },
   // Service routes
   { path: 'services/track-by-mail', component: TrackByMailComponent, canActivate: [AuthGuard] },
   { path: 'services/notifications', component: NotificationOptionsComponent, canActivate: [AuthGuard] },

--- a/Frontend/src/app/features/help-center/help-center.component.html
+++ b/Frontend/src/app/features/help-center/help-center.component.html
@@ -1,0 +1,30 @@
+<section class="help-center">
+  <app-breadcrumb [items]="[{label: 'Home', url: '/home'}, {label: 'Help Center'}]"></app-breadcrumb>
+  <h1>Help Center</h1>
+  <app-simple-tabs [tabs]="tabs" [active]="activeTab" (select)="selectTab($event)"></app-simple-tabs>
+
+  <div [ngSwitch]="activeTab">
+    <div *ngSwitchCase="'advice'" id="advice">
+      <h2>Advice</h2>
+      <p>Find tips on how to get the most from our tracking services.</p>
+    </div>
+
+    <div *ngSwitchCase="'tools'" id="tools">
+      <h2>Tracking Tools</h2>
+      <p>Explore our suite of tracking tools for every need.</p>
+    </div>
+
+    <div *ngSwitchCase="'faq'" id="faq">
+      <h2>Frequently Asked Questions</h2>
+      <div class="faq-item" *ngFor="let f of faqs">
+        <h3 (click)="toggleFaq(f)">{{ f.question }}</h3>
+        <p *ngIf="f.open">{{ f.answer }}</p>
+      </div>
+    </div>
+
+    <div *ngSwitchCase="'contact'" id="contact">
+      <h2>Contact Us</h2>
+      <p>For further assistance email <a href="mailto:support@globex.ma">support@globex.ma</a> or call +212 522-123456.</p>
+    </div>
+  </div>
+</section>

--- a/Frontend/src/app/features/help-center/help-center.component.scss
+++ b/Frontend/src/app/features/help-center/help-center.component.scss
@@ -1,0 +1,8 @@
+.help-center {
+  padding: 1rem;
+}
+
+.faq-item h3 {
+  cursor: pointer;
+  margin-bottom: 0.25rem;
+}

--- a/Frontend/src/app/features/help-center/help-center.component.ts
+++ b/Frontend/src/app/features/help-center/help-center.component.ts
@@ -1,0 +1,41 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { BreadcrumbComponent } from '../../shared/components/breadcrumb/breadcrumb.component';
+import { SimpleTabsComponent, TabItem } from '../../shared/components/simple-tabs/simple-tabs.component';
+
+interface Faq {
+  question: string;
+  answer: string;
+  open?: boolean;
+}
+
+@Component({
+  selector: 'app-help-center',
+  standalone: true,
+  imports: [CommonModule, BreadcrumbComponent, SimpleTabsComponent],
+  templateUrl: './help-center.component.html',
+  styleUrls: ['./help-center.component.scss']
+})
+export class HelpCenterComponent {
+  tabs: TabItem[] = [
+    { id: 'advice', label: 'Advice' },
+    { id: 'tools', label: 'Tracking Tools' },
+    { id: 'faq', label: 'FAQs' },
+    { id: 'contact', label: 'Contact' }
+  ];
+  activeTab = 'advice';
+
+  faqs: Faq[] = [
+    { question: 'Comment suivre mon colis ?', answer: "Entrez votre numéro de suivi dans la barre de recherche en haut de la page pour suivre votre colis en temps réel." },
+    { question: 'Quels sont les délais de livraison ?', answer: 'Les délais de livraison varient selon le service choisi : Express (24h), Standard (2-3 jours), Économique (3-5 jours).' },
+    { question: 'Comment contacter le service client ?', answer: 'Notre service client est disponible 24/7 par téléphone au +212 522-123456 ou par email à support@globex.ma.' }
+  ];
+
+  selectTab(id: string) {
+    this.activeTab = id;
+  }
+
+  toggleFaq(f: Faq) {
+    f.open = !f.open;
+  }
+}

--- a/Frontend/src/app/features/home/home.component.html
+++ b/Frontend/src/app/features/home/home.component.html
@@ -241,7 +241,7 @@
         <i class="fas fa-headset"></i>
         Contact Us
       </a>
-      <a href="/support" class="btn btn--secondary">
+      <a routerLink="/help" class="btn btn--secondary">
         <i class="fas fa-question-circle"></i>
         Help Center
       </a>

--- a/Frontend/src/app/features/tracking/track-result/track-result.component.ts
+++ b/Frontend/src/app/features/tracking/track-result/track-result.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { trigger, transition, style, animate, query, stagger } from '@angular/animations';
 import { CommonModule } from '@angular/common';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { TrackingService, TrackingInfo } from '../services/tracking.service';
 import { TrackingHistoryService } from '../../../core/services/tracking-history.service';
@@ -51,6 +51,7 @@ export class TrackResultComponent implements OnInit, OnDestroy {
 
   constructor(
     private route: ActivatedRoute,
+    private router: Router,
     private trackingService: TrackingService,
     private analytics: AnalyticsService,
     private history: TrackingHistoryService,
@@ -196,7 +197,7 @@ export class TrackResultComponent implements OnInit, OnDestroy {
 
   contactSupport() {
     this.analytics.logAction('contact_support');
-    window.location.href = '/support';
+    this.router.navigate(['/help'], { fragment: 'contact' });
   }
 
   ngOnDestroy() {

--- a/Frontend/src/app/shared/components/breadcrumb/breadcrumb.component.html
+++ b/Frontend/src/app/shared/components/breadcrumb/breadcrumb.component.html
@@ -1,0 +1,11 @@
+<nav class="breadcrumb" *ngIf="items && items.length">
+  <ng-container *ngFor="let item of items; let last = last">
+    <ng-container *ngIf="item.url && !last; else lastItem">
+      <a [routerLink]="item.url">{{ item.label }}</a>
+      <span class="separator">/</span>
+    </ng-container>
+    <ng-template #lastItem>
+      <span class="current">{{ item.label }}</span>
+    </ng-template>
+  </ng-container>
+</nav>

--- a/Frontend/src/app/shared/components/breadcrumb/breadcrumb.component.scss
+++ b/Frontend/src/app/shared/components/breadcrumb/breadcrumb.component.scss
@@ -1,0 +1,12 @@
+.breadcrumb {
+  margin-bottom: 1rem;
+  font-size: 0.9rem;
+}
+
+.separator {
+  margin: 0 0.5rem;
+}
+
+.current {
+  font-weight: bold;
+}

--- a/Frontend/src/app/shared/components/breadcrumb/breadcrumb.component.ts
+++ b/Frontend/src/app/shared/components/breadcrumb/breadcrumb.component.ts
@@ -1,0 +1,18 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+export interface BreadcrumbItem {
+  label: string;
+  url?: string;
+}
+
+@Component({
+  selector: 'app-breadcrumb',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './breadcrumb.component.html',
+  styleUrls: ['./breadcrumb.component.scss']
+})
+export class BreadcrumbComponent {
+  @Input() items: BreadcrumbItem[] = [];
+}

--- a/Frontend/src/app/shared/components/simple-tabs/simple-tabs.component.html
+++ b/Frontend/src/app/shared/components/simple-tabs/simple-tabs.component.html
@@ -1,0 +1,8 @@
+<div class="simple-tabs" *ngIf="tabs.length">
+  <button *ngFor="let tab of tabs"
+          class="tab"
+          [class.active]="tab.id === active"
+          (click)="setActive(tab.id)">
+    {{ tab.label }}
+  </button>
+</div>

--- a/Frontend/src/app/shared/components/simple-tabs/simple-tabs.component.scss
+++ b/Frontend/src/app/shared/components/simple-tabs/simple-tabs.component.scss
@@ -1,0 +1,22 @@
+.simple-tabs {
+  display: flex;
+  margin-bottom: 1rem;
+}
+
+.tab {
+  flex: 1;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  background: #f5f5f5;
+  cursor: pointer;
+  text-align: center;
+}
+
+.tab.active {
+  background: #4d148c;
+  color: #fff;
+}
+
+.tab + .tab {
+  margin-left: 5px;
+}

--- a/Frontend/src/app/shared/components/simple-tabs/simple-tabs.component.ts
+++ b/Frontend/src/app/shared/components/simple-tabs/simple-tabs.component.ts
@@ -1,0 +1,25 @@
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+export interface TabItem {
+  id: string;
+  label: string;
+}
+
+@Component({
+  selector: 'app-simple-tabs',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './simple-tabs.component.html',
+  styleUrls: ['./simple-tabs.component.scss']
+})
+export class SimpleTabsComponent {
+  @Input() tabs: TabItem[] = [];
+  @Input() active = '';
+  @Output() select = new EventEmitter<string>();
+
+  setActive(id: string) {
+    this.active = id;
+    this.select.emit(id);
+  }
+}


### PR DESCRIPTION
## Summary
- add Help Center standalone component and route
- create Breadcrumb and SimpleTabs shared components
- update home page and tracking result to link to Help Center

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684615db923c832e9468ab776bcee5cc