### PR TITLE
Use shared test DB fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import pytest
+
+# Ensure required environment variables for backend configuration
+os.environ.setdefault('DATABASE_URL', 'sqlite:///:memory:')
+os.environ.setdefault('FEDEX_CLIENT_ID', 'dummy')
+os.environ.setdefault('FEDEX_CLIENT_SECRET', 'dummy')
+os.environ.setdefault('FEDEX_ACCOUNT_NUMBER', 'dummy')
+os.environ.setdefault('SECRET_KEY', 'testsecret')
+
+# Allow tests to import backend modules when executed directly
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from backend.app.database import Base, engine, SessionLocal
+try:
+    from backend.app.models.database import Base as ModelsBase
+except Exception:  # pragma: no cover - optional models package
+    ModelsBase = None
+
+
+@pytest.fixture
+def db_session():
+    """Provide a fresh in-memory database session for each test."""
+    Base.metadata.drop_all(bind=engine)
+    if ModelsBase is not None:
+        ModelsBase.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    if ModelsBase is not None:
+        ModelsBase.metadata.create_all(bind=engine)
+
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -15,20 +15,10 @@ os.environ.setdefault('SECRET_KEY', 'testsecret')
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
-from backend.app.database import Base, engine, SessionLocal
 from backend.app.models.user import UserCreate
 from pydantic import ValidationError
 from backend.app.services import auth
 
-@pytest.fixture
-def db_session():
-    Base.metadata.drop_all(bind=engine)
-    Base.metadata.create_all(bind=engine)
-    db = SessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()
 
 def setup_user(db):
     return auth.create_user(db, UserCreate(email='u@example.com', full_name='U', password='Password1'))

--- a/tests/test_colis.py
+++ b/tests/test_colis.py
@@ -12,23 +12,11 @@ os.environ.setdefault('SECRET_KEY', 'testsecret')
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
-from backend.app.database import Base, engine, SessionLocal
 from backend.app.models.database import Base as ModelsBase
 from backend.app.models.colis import ColisCreate
 from backend.app.services.colis_service import ColisService
 from backend.app.api.v1.endpoints import colis as colis_router
 
-@pytest.fixture
-def db_session():
-    Base.metadata.drop_all(bind=engine)
-    ModelsBase.metadata.drop_all(bind=engine)
-    Base.metadata.create_all(bind=engine)
-    ModelsBase.metadata.create_all(bind=engine)
-    db = SessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()
 
 
 def setup_colis(db, monkeypatch, colis_id="TESTDEL"):

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -13,7 +13,6 @@ os.environ.setdefault('SECRET_KEY', 'testsecret')
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
-from backend.app.database import Base, engine, SessionLocal
 from backend.app.models.database import Base as ModelsBase, NotificationDB
 from backend.app.api.v1.endpoints import notifications as notifications_router
 from backend.app.models.notification import (
@@ -27,17 +26,6 @@ from backend.app.models.user import UserCreate, UserRole
 from backend.app.services import auth
 
 
-@pytest.fixture
-def db_session():
-    Base.metadata.drop_all(bind=engine)
-    ModelsBase.metadata.drop_all(bind=engine)
-    Base.metadata.create_all(bind=engine)
-    ModelsBase.metadata.create_all(bind=engine)
-    db = SessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()
 
 
 def create_user_with_role(db, role: UserRole):

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -13,24 +13,12 @@ os.environ.setdefault('SECRET_KEY', 'testsecret')
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
-from backend.app.database import Base, engine, SessionLocal
 from backend.app.models.database import Base as ModelsBase, ColisDB
 from backend.app.services.colis_service import ColisService
 from backend.app.models.colis import ColisCreate
 from backend.app.models.tracking import TrackingResponse
 from backend.app.api.v1.endpoints import tracking as tracking_router
 
-@pytest.fixture
-def db_session():
-    Base.metadata.drop_all(bind=engine)
-    ModelsBase.metadata.drop_all(bind=engine)
-    Base.metadata.create_all(bind=engine)
-    ModelsBase.metadata.create_all(bind=engine)
-    db = SessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()
 
 
 def setup_colis(db, monkeypatch, colis_id="123456789012"):

--- a/tests/test_twofa.py
+++ b/tests/test_twofa.py
@@ -13,18 +13,8 @@ os.environ.setdefault('SECRET_KEY', 'testsecret')
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
-from backend.app.database import Base, engine, SessionLocal
 from backend.app.models.user import UserCreate
 
-@pytest.fixture
-def db_session():
-    Base.metadata.drop_all(bind=engine)
-    Base.metadata.create_all(bind=engine)
-    db = SessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()
 
 
 # Copied from tests.test_auth to avoid external dependencies

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -17,22 +17,10 @@ os.environ.setdefault('FEDEX_WEBHOOK_SECRET', 'hooksecret')
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
-from backend.app.database import Base, engine, SessionLocal
 from backend.app.models.database import Base as ModelsBase
 from backend.app.routers import webhook as webhook_router
 
 
-@pytest.fixture
-def db_session():
-    Base.metadata.drop_all(bind=engine)
-    ModelsBase.metadata.drop_all(bind=engine)
-    Base.metadata.create_all(bind=engine)
-    ModelsBase.metadata.create_all(bind=engine)
-    db = SessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()
 
 
 def make_request(payload: bytes, signature: str | None = None) -> Request:


### PR DESCRIPTION
## Summary
- add `tests/conftest.py` that initializes a fresh in-memory DB for each test
- remove duplicated `db_session` fixtures from test modules

## Testing
- `pytest tests/test_twofa.py::test_setup_2fa_returns_secret -q`
- `pytest tests/test_auth.py::test_login_returns_tokens -q`
- `pytest tests/test_webhook.py::test_webhook_no_signature_allowed -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684615dbf4e8832ebce83d2ab98a8799