### PR TITLE
Add news API and integrate frontend

### DIFF
--- a/Frontend/src/app/features/home/home.component.ts
+++ b/Frontend/src/app/features/home/home.component.ts
@@ -9,6 +9,7 @@ import { TrackingService } from '../tracking/services/tracking.service';
 import { TrackingHistoryService } from '../../core/services/tracking-history.service';
 import { NotificationService } from '../../core/services/notification.service';
 import { AnalyticsService } from '../../core/services/analytics.service';
+import { NewsService } from '../news/services/news.service';
 import { Subject, Observable } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { BrowserCodeReader, IScannerControls, BrowserMultiFormatReader } from '@zxing/browser';
@@ -150,7 +151,8 @@ export class HomeComponent implements OnInit, OnDestroy {
     private trackingService: TrackingService,
     private notificationService: NotificationService,
     private analytics: AnalyticsService,
-    private history: TrackingHistoryService
+    private history: TrackingHistoryService,
+    private newsService: NewsService
   ) {
     this.trackingForm = this.fb.group({
       trackingNumber: ['', [Validators.required, Validators.pattern('^[A-Z0-9]{10,}$')]],
@@ -188,41 +190,10 @@ export class HomeComponent implements OnInit, OnDestroy {
   }
 
   private initializeNews(): void {
-    this.news = [
-      {
-        id: 1,
-        title: "Nouveau service de livraison express",
-        content: "Nous lançons notre nouveau service de livraison express en 24h sur tout le territoire marocain.",
-        image: "assets/images/news/express.jpg",
-        imageUrl: "assets/images/news/express.jpg",
-        date: new Date("2024-03-15"),
-        category: "Services",
-        summary: "Un nouveau service de livraison express pour une livraison plus rapide...",
-        slug: "nouveau-service-express"
-      },
-      {
-        id: 2,
-        title: "Expansion de notre réseau de distribution",
-        content: "Nous ouvrons 5 nouvelles agences dans les principales villes du Maroc pour mieux vous servir.",
-        image: "assets/images/news/expansion.jpg",
-        imageUrl: "assets/images/news/expansion.jpg",
-        date: new Date("2024-03-10"),
-        category: "Développement",
-        summary: "Nous étendons notre réseau de distribution à de nouvelles villes...",
-        slug: "expansion-reseau"
-      },
-      {
-        id: 3,
-        title: "Partenariat stratégique avec les leaders du e-commerce",
-        content: "Nous renforçons notre présence dans le e-commerce avec de nouveaux partenariats stratégiques.",
-        image: "assets/images/news/partnership.jpg",
-        imageUrl: "assets/images/news/partnership.jpg",
-        date: new Date("2024-03-05"),
-        category: "Partenariats",
-        summary: "Nous annonçons un nouveau partenariat pour améliorer nos services...",
-        slug: "partenariat-ecommerce"
-      }
-    ];
+    this.newsService
+      .getArticles()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(articles => (this.news = articles));
   }
 
   private initializeLocations(): void {

--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter
-from .endpoints import tracking, notifications, colis, history
+from .endpoints import tracking, notifications, colis, history, news
 
 api_router = APIRouter(prefix="/api/v1")
 
@@ -25,4 +25,10 @@ api_router.include_router(
     history.router,
     prefix="/history",
     tags=["history"]
+)
+
+api_router.include_router(
+    news.router,
+    prefix="/news",
+    tags=["news"]
 )

--- a/backend/app/api/v1/endpoints/__init__.py
+++ b/backend/app/api/v1/endpoints/__init__.py
@@ -1,3 +1,3 @@
-from . import notifications, tracking, colis, history
+from . import notifications, tracking, colis, history, news
 
-__all__ = ["notifications", "tracking", "colis", "history"]
+__all__ = ["notifications", "tracking", "colis", "history", "news"]

--- a/backend/app/api/v1/endpoints/news.py
+++ b/backend/app/api/v1/endpoints/news.py
@@ -1,0 +1,22 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from ....database import get_db
+from ....services.news_service import NewsArticleService
+from ....models.news import NewsArticle
+
+router = APIRouter()
+
+
+@router.get("/", response_model=list[NewsArticle])
+def list_articles(db: Session = Depends(get_db), skip: int = 0, limit: int = 10):
+    service = NewsArticleService(db)
+    return service.get_articles(skip=skip, limit=limit)
+
+
+@router.get("/{slug}", response_model=NewsArticle)
+def get_article(slug: str, db: Session = Depends(get_db)):
+    service = NewsArticleService(db)
+    article = service.get_article(slug)
+    if not article:
+        raise HTTPException(status_code=404, detail="Article not found")
+    return article

--- a/backend/app/models/news.py
+++ b/backend/app/models/news.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+from pydantic import BaseModel
+from typing import Optional
+from datetime import datetime
+from sqlalchemy import Column, Integer, String, Text, DateTime
+from sqlalchemy.sql import func
+from ..database import Base
+
+
+class NewsArticleDB(Base):
+    __tablename__ = "news_articles"
+
+    id = Column(Integer, primary_key=True, index=True)
+    title = Column(String, nullable=False)
+    slug = Column(String, unique=True, index=True)
+    content = Column(Text, nullable=False)
+    image_url = Column(String, nullable=True)
+    date = Column(DateTime(timezone=True), server_default=func.now())
+    category = Column(String, nullable=True)
+    summary = Column(String, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+
+class NewsArticleBase(BaseModel):
+    title: str
+    slug: str
+    content: str
+    image_url: Optional[str] = None
+    date: Optional[datetime] = None
+    category: Optional[str] = None
+    summary: Optional[str] = None
+
+
+class NewsArticleCreate(NewsArticleBase):
+    pass
+
+
+class NewsArticleUpdate(BaseModel):
+    title: Optional[str] = None
+    slug: Optional[str] = None
+    content: Optional[str] = None
+    image_url: Optional[str] = None
+    date: Optional[datetime] = None
+    category: Optional[str] = None
+    summary: Optional[str] = None
+
+
+class NewsArticle(NewsArticleBase):
+    id: int
+
+    class Config:
+        from_attributes = True

--- a/backend/app/services/news_service.py
+++ b/backend/app/services/news_service.py
@@ -1,0 +1,45 @@
+from sqlalchemy.orm import Session
+from typing import List, Optional
+from ..models.news import NewsArticleDB, NewsArticleCreate, NewsArticleUpdate
+
+
+class NewsArticleService:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def create_article(self, article: NewsArticleCreate) -> NewsArticleDB:
+        db_article = NewsArticleDB(**article.dict())
+        self.db.add(db_article)
+        self.db.commit()
+        self.db.refresh(db_article)
+        return db_article
+
+    def get_article(self, slug: str) -> Optional[NewsArticleDB]:
+        return self.db.query(NewsArticleDB).filter(NewsArticleDB.slug == slug).first()
+
+    def get_articles(self, skip: int = 0, limit: int = 100) -> List[NewsArticleDB]:
+        return (
+            self.db.query(NewsArticleDB)
+            .order_by(NewsArticleDB.date.desc())
+            .offset(skip)
+            .limit(limit)
+            .all()
+        )
+
+    def update_article(self, article_id: int, updates: NewsArticleUpdate) -> Optional[NewsArticleDB]:
+        article = self.db.query(NewsArticleDB).filter(NewsArticleDB.id == article_id).first()
+        if not article:
+            return None
+        for key, value in updates.dict(exclude_unset=True).items():
+            setattr(article, key, value)
+        self.db.commit()
+        self.db.refresh(article)
+        return article
+
+    def delete_article(self, article_id: int) -> bool:
+        article = self.db.query(NewsArticleDB).filter(NewsArticleDB.id == article_id).first()
+        if not article:
+            return False
+        self.db.delete(article)
+        self.db.commit()
+        return True


### PR DESCRIPTION
## Summary
- implement `/news` API router with list and detail endpoints
- add `NewsArticleDB` SQLAlchemy model with CRUD service
- wire new router into API
- fetch news from backend in the home page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68461694db80832e89444043ca346be4