### PR TITLE
Add shipment CRUD UI with tests

### DIFF
--- a/Frontend/src/app/app.routes.ts
+++ b/Frontend/src/app/app.routes.ts
@@ -21,6 +21,8 @@ import { ResendVerificationComponent } from './features/auth/resend-verification
 import { NewsDetailComponent } from './features/news/news-detail.component';
 import { HistoryComponent } from './features/history/history.component';
 import { ShipmentsComponent } from './features/shipments/shipments.component';
+import { AddShipmentComponent } from './features/shipments/add-shipment.component';
+import { EditShipmentComponent } from './features/shipments/edit-shipment.component';
 import { NotFoundComponent } from './shared/not-found.component';
 
 // Assuming you might have other standalone components or lazy-loaded routes
@@ -43,6 +45,8 @@ export const routes: Routes = [
   { path: 'fedex-track/:identifier', component: FedexTrackResultComponent, canActivate: [AuthGuard] },
   { path: 'notifications', component: NotificationsComponent, canActivate: [AuthGuard] },
   { path: 'shipments', component: ShipmentsComponent, canActivate: [AuthGuard] },
+  { path: 'shipments/new', component: AddShipmentComponent, canActivate: [AuthGuard] },
+  { path: 'shipments/:id/edit', component: EditShipmentComponent, canActivate: [AuthGuard] },
   { path: 'history', component: HistoryComponent, canActivate: [AuthGuard] },
   // Service routes
   { path: 'services/track-by-mail', component: TrackByMailComponent, canActivate: [AuthGuard] },

--- a/Frontend/src/app/core/services/shipment.service.ts
+++ b/Frontend/src/app/core/services/shipment.service.ts
@@ -11,6 +11,17 @@ export interface Shipment {
   created_at: string;
 }
 
+export interface ShipmentCreate {
+  id: string;
+  description?: string;
+}
+
+export interface ShipmentUpdate {
+  description?: string;
+  status?: string;
+  estimated_delivery?: string;
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -21,5 +32,21 @@ export class ShipmentService {
 
   getShipments(): Observable<Shipment[]> {
     return this.http.get<Shipment[]>(this.baseUrl);
+  }
+
+  createShipment(data: ShipmentCreate): Observable<Shipment> {
+    return this.http.post<Shipment>(this.baseUrl, data);
+  }
+
+  updateShipment(id: string, data: ShipmentUpdate): Observable<Shipment> {
+    return this.http.put<Shipment>(`${this.baseUrl}/${id}`, data);
+  }
+
+  deleteShipment(id: string): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl}/${id}`);
+  }
+
+  getShipment(id: string): Observable<Shipment> {
+    return this.http.get<Shipment>(`${this.baseUrl}/${id}`);
   }
 }

--- a/Frontend/src/app/features/shipments/add-shipment.component.html
+++ b/Frontend/src/app/features/shipments/add-shipment.component.html
@@ -1,0 +1,12 @@
+<h2>Add Shipment</h2>
+<form [formGroup]="form" (ngSubmit)="submit()" class="ship-form">
+  <div class="form-group">
+    <label>ID</label>
+    <input formControlName="id" />
+  </div>
+  <div class="form-group">
+    <label>Description</label>
+    <input formControlName="description" />
+  </div>
+  <button type="submit" class="btn btn--primary">Save</button>
+</form>

--- a/Frontend/src/app/features/shipments/add-shipment.component.scss
+++ b/Frontend/src/app/features/shipments/add-shipment.component.scss
@@ -1,0 +1,6 @@
+.ship-form {
+  max-width: 400px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}

--- a/Frontend/src/app/features/shipments/add-shipment.component.spec.ts
+++ b/Frontend/src/app/features/shipments/add-shipment.component.spec.ts
@@ -1,0 +1,42 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { of } from 'rxjs';
+
+import { AddShipmentComponent } from './add-shipment.component';
+import { ShipmentService } from '../../core/services/shipment.service';
+
+describe('AddShipmentComponent', () => {
+  let component: AddShipmentComponent;
+  let fixture: ComponentFixture<AddShipmentComponent>;
+  let service: jasmine.SpyObj<ShipmentService>;
+  let router: jasmine.SpyObj<Router>;
+
+  beforeEach(async () => {
+    service = jasmine.createSpyObj('ShipmentService', ['createShipment']);
+    router = jasmine.createSpyObj('Router', ['navigate']);
+
+    await TestBed.configureTestingModule({
+      imports: [AddShipmentComponent],
+      providers: [
+        { provide: ShipmentService, useValue: service },
+        { provide: Router, useValue: router }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AddShipmentComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should call service on submit', () => {
+    service.createShipment.and.returnValue(of({} as any));
+    component.form.patchValue({ id: 'X', description: 'Y' });
+    component.submit();
+    expect(service.createShipment).toHaveBeenCalledWith({ id: 'X', description: 'Y' });
+    expect(router.navigate).toHaveBeenCalledWith(['/shipments']);
+  });
+});

--- a/Frontend/src/app/features/shipments/add-shipment.component.ts
+++ b/Frontend/src/app/features/shipments/add-shipment.component.ts
@@ -1,0 +1,33 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { RouterModule, Router } from '@angular/router';
+import { ShipmentService, ShipmentCreate } from '../../core/services/shipment.service';
+
+@Component({
+  selector: 'app-add-shipment',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, RouterModule],
+  templateUrl: './add-shipment.component.html',
+  styleUrls: ['./add-shipment.component.scss']
+})
+export class AddShipmentComponent implements OnInit {
+  form: FormGroup;
+
+  constructor(private fb: FormBuilder, private service: ShipmentService, private router: Router) {
+    this.form = this.fb.group({
+      id: ['', Validators.required],
+      description: ['']
+    });
+  }
+
+  ngOnInit(): void {}
+
+  submit() {
+    if (this.form.invalid) return;
+    const payload: ShipmentCreate = this.form.value;
+    this.service.createShipment(payload).subscribe(() => {
+      this.router.navigate(['/shipments']);
+    });
+  }
+}

--- a/Frontend/src/app/features/shipments/edit-shipment.component.html
+++ b/Frontend/src/app/features/shipments/edit-shipment.component.html
@@ -1,0 +1,12 @@
+<h2>Edit Shipment</h2>
+<form [formGroup]="form" (ngSubmit)="submit()" class="ship-form">
+  <div class="form-group">
+    <label>Description</label>
+    <input formControlName="description" />
+  </div>
+  <div class="form-group">
+    <label>Status</label>
+    <input formControlName="status" />
+  </div>
+  <button type="submit" class="btn btn--primary">Save</button>
+</form>

--- a/Frontend/src/app/features/shipments/edit-shipment.component.scss
+++ b/Frontend/src/app/features/shipments/edit-shipment.component.scss
@@ -1,0 +1,6 @@
+.ship-form {
+  max-width: 400px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}

--- a/Frontend/src/app/features/shipments/edit-shipment.component.spec.ts
+++ b/Frontend/src/app/features/shipments/edit-shipment.component.spec.ts
@@ -1,0 +1,45 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { of } from 'rxjs';
+
+import { EditShipmentComponent } from './edit-shipment.component';
+import { ShipmentService } from '../../core/services/shipment.service';
+
+describe('EditShipmentComponent', () => {
+  let component: EditShipmentComponent;
+  let fixture: ComponentFixture<EditShipmentComponent>;
+  let service: jasmine.SpyObj<ShipmentService>;
+  let router: jasmine.SpyObj<Router>;
+
+  beforeEach(async () => {
+    service = jasmine.createSpyObj('ShipmentService', ['getShipment', 'updateShipment']);
+    router = jasmine.createSpyObj('Router', ['navigate']);
+
+    await TestBed.configureTestingModule({
+      imports: [EditShipmentComponent],
+      providers: [
+        { provide: ShipmentService, useValue: service },
+        { provide: Router, useValue: router },
+        { provide: ActivatedRoute, useValue: { snapshot: { paramMap: new Map([['id', '123']]) } } }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(EditShipmentComponent);
+    component = fixture.componentInstance;
+    service.getShipment.and.returnValue(of({ id: '123', description: 'd', status: 's', created_at: '', estimated_delivery: '' } as any));
+    fixture.detectChanges();
+  });
+
+  it('should create and load shipment', () => {
+    expect(component).toBeTruthy();
+    expect(service.getShipment).toHaveBeenCalledWith('123');
+  });
+
+  it('should call update on submit', () => {
+    service.updateShipment.and.returnValue(of({} as any));
+    component.form.patchValue({ description: 'x', status: 'y' });
+    component.submit();
+    expect(service.updateShipment).toHaveBeenCalled();
+    expect(router.navigate).toHaveBeenCalledWith(['/shipments']);
+  });
+});

--- a/Frontend/src/app/features/shipments/edit-shipment.component.ts
+++ b/Frontend/src/app/features/shipments/edit-shipment.component.ts
@@ -1,0 +1,49 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { ShipmentService, ShipmentUpdate } from '../../core/services/shipment.service';
+
+@Component({
+  selector: 'app-edit-shipment',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, RouterModule],
+  templateUrl: './edit-shipment.component.html',
+  styleUrls: ['./edit-shipment.component.scss']
+})
+export class EditShipmentComponent implements OnInit {
+  form: FormGroup;
+  shipmentId = '';
+
+  constructor(
+    private fb: FormBuilder,
+    private service: ShipmentService,
+    private route: ActivatedRoute,
+    private router: Router
+  ) {
+    this.form = this.fb.group({
+      description: ['', Validators.required],
+      status: ['']
+    });
+  }
+
+  ngOnInit(): void {
+    this.shipmentId = this.route.snapshot.paramMap.get('id') || '';
+    if (this.shipmentId) {
+      this.service.getShipment(this.shipmentId).subscribe(s => {
+        this.form.patchValue({
+          description: s.description,
+          status: s.status
+        });
+      });
+    }
+  }
+
+  submit() {
+    if (this.form.invalid) return;
+    const update: ShipmentUpdate = this.form.value;
+    this.service.updateShipment(this.shipmentId, update).subscribe(() => {
+      this.router.navigate(['/shipments']);
+    });
+  }
+}

--- a/Frontend/src/app/features/shipments/shipments.component.html
+++ b/Frontend/src/app/features/shipments/shipments.component.html
@@ -1,6 +1,7 @@
 <div class="toggle-buttons">
   <button (click)="setView('list')" [disabled]="viewMode === 'list'">List</button>
   <button (click)="setView('calendar')" [disabled]="viewMode === 'calendar'">Calendar</button>
+  <a routerLink="/shipments/new" class="btn btn--primary">Add</a>
 </div>
 <div class="filter-box">
   <input type="text" [(ngModel)]="filterText" (ngModelChange)="applyFilter()" placeholder="Filter shipments" />
@@ -14,6 +15,7 @@
     <li *ngFor="let s of filtered">
       <strong>{{ s.description || s.id }}</strong>
       <span>- {{ s.status }} - {{ s.estimated_delivery | date:'mediumDate' }}</span>
+      <a [routerLink]="['/shipments', s.id, 'edit']">Edit</a>
     </li>
   </ul>
 </div>

--- a/tests/test_colis.py
+++ b/tests/test_colis.py
@@ -14,7 +14,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from backend.app.database import Base, engine, SessionLocal
 from backend.app.models.database import Base as ModelsBase
-from backend.app.models.colis import ColisCreate
+from backend.app.models.colis import ColisCreate, ColisUpdate
 from backend.app.services.colis_service import ColisService
 from backend.app.api.v1.endpoints import colis as colis_router
 
@@ -41,6 +41,23 @@ def setup_colis(db, monkeypatch, colis_id="TESTDEL"):
     service = ColisService(db)
     service.create_colis(ColisCreate(id=colis_id, description="d"))
     return service.get_colis_by_id, colis_id
+
+
+def test_create_colis(db_session, monkeypatch):
+    monkeypatch.setattr(ColisService, "generate_codebar_image", lambda self, v: "dummy.png")
+    create = ColisCreate(id="NEWID", description="hello")
+    resp = asyncio.run(colis_router.create_colis(create, db_session))
+    assert resp.id == "NEWID"
+    service = ColisService(db_session)
+    assert service.get_colis_by_id("NEWID") is not None
+
+
+def test_update_colis(db_session, monkeypatch):
+    get_colis, colis_id = setup_colis(db_session, monkeypatch)
+    update = ColisUpdate(description="updated")
+    resp = asyncio.run(colis_router.update_colis(colis_id, update, db_session))
+    assert resp.description == "updated"
+    assert get_colis(colis_id).description == "updated"
 
 
 def test_delete_colis_success(db_session, monkeypatch):

--- a/tests/test_twofa.py
+++ b/tests/test_twofa.py
@@ -15,6 +15,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from backend.app.database import Base, engine, SessionLocal
 from backend.app.models.user import UserCreate
+from backend.app.services import auth  # Ensure RefreshTokenDB is registered
 
 @pytest.fixture
 def db_session():


### PR DESCRIPTION
## Summary
- extend `ShipmentService` with CRUD calls
- add new components for creating and editing shipments
- expose routes and UI links for the new forms
- cover new UI logic with unit tests
- ensure backend tests create/update shipments

## Testing
- `npm test --silent -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684616962b44832eab86c639a7275eee