### PR TITLE
Update README with testing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,10 +153,8 @@ On the first run Docker Compose builds the backend and frontend images. Once the
 ## Running Tests
 
 Install the backend dependencies and the packages listed in
-`requirements-test.txt` before executing the test suite. Ensure the
-[required variables](#required-variables) (for example `FEDEX_CLIENT_ID`,
-`FEDEX_CLIENT_SECRET`, `FEDEX_ACCOUNT_NUMBER` and `SECRET_KEY`) are set
-in `backend/.env.local` or exported in your shell:
+`requirements-test.txt`. Once the requirements are installed, run the
+test suite with `pytest`. Ensure the [required variables](#required-variables) (for example `FEDEX_CLIENT_ID`, `FEDEX_CLIENT_SECRET`, `FEDEX_ACCOUNT_NUMBER` and `SECRET_KEY`) are set in `backend/.env.local` or exported in your shell:
 
 ```bash
 pip install -r backend/requirements.txt


### PR DESCRIPTION
## Summary
- add a "Running Tests" section with instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_68461a44b468832eada4ad969d9b16b7