### PR TITLE
Implement Angular Help Center

### DIFF
--- a/Frontend/src/app/features/help-center/faq-list/faq-list.component.html
+++ b/Frontend/src/app/features/help-center/faq-list/faq-list.component.html
@@ -1,0 +1,6 @@
+<div class="faq-list">
+  <div class="faq-item" *ngFor="let f of faqs">
+    <h3 (click)="toggleFaq(f)">{{ f.question }}</h3>
+    <p *ngIf="f.open">{{ f.answer }}</p>
+  </div>
+</div>

--- a/Frontend/src/app/features/help-center/faq-list/faq-list.component.scss
+++ b/Frontend/src/app/features/help-center/faq-list/faq-list.component.scss
@@ -1,0 +1,4 @@
+.faq-item h3 {
+  cursor: pointer;
+  margin-bottom: 0.25rem;
+}

--- a/Frontend/src/app/features/help-center/faq-list/faq-list.component.ts
+++ b/Frontend/src/app/features/help-center/faq-list/faq-list.component.ts
@@ -1,0 +1,23 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+export interface Faq {
+  question: string;
+  answer: string;
+  open?: boolean;
+}
+
+@Component({
+  selector: 'app-faq-list',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './faq-list.component.html',
+  styleUrls: ['./faq-list.component.scss']
+})
+export class FaqListComponent {
+  @Input() faqs: Faq[] = [];
+
+  toggleFaq(f: Faq) {
+    f.open = !f.open;
+  }
+}

--- a/Frontend/src/app/features/help-center/help-center.component.html
+++ b/Frontend/src/app/features/help-center/help-center.component.html
@@ -1,6 +1,7 @@
 <section class="help-center">
   <app-breadcrumb [items]="[{label: 'Home', url: '/home'}, {label: 'Help Center'}]"></app-breadcrumb>
   <h1>Help Center</h1>
+  <app-quick-search (search)="onSearch($event)"></app-quick-search>
   <app-simple-tabs [tabs]="tabs" [active]="activeTab" (select)="selectTab($event)"></app-simple-tabs>
 
   <div [ngSwitch]="activeTab">
@@ -16,10 +17,7 @@
 
     <div *ngSwitchCase="'faq'" id="faq">
       <h2>Frequently Asked Questions</h2>
-      <div class="faq-item" *ngFor="let f of faqs">
-        <h3 (click)="toggleFaq(f)">{{ f.question }}</h3>
-        <p *ngIf="f.open">{{ f.answer }}</p>
-      </div>
+      <app-faq-list [faqs]="faqs"></app-faq-list>
     </div>
 
     <div *ngSwitchCase="'contact'" id="contact">

--- a/Frontend/src/app/features/help-center/help-center.component.scss
+++ b/Frontend/src/app/features/help-center/help-center.component.scss
@@ -1,8 +1,3 @@
 .help-center {
   padding: 1rem;
 }
-
-.faq-item h3 {
-  cursor: pointer;
-  margin-bottom: 0.25rem;
-}

--- a/Frontend/src/app/features/help-center/help-center.component.ts
+++ b/Frontend/src/app/features/help-center/help-center.component.ts
@@ -2,17 +2,19 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { BreadcrumbComponent } from '../../shared/components/breadcrumb/breadcrumb.component';
 import { SimpleTabsComponent, TabItem } from '../../shared/components/simple-tabs/simple-tabs.component';
-
-interface Faq {
-  question: string;
-  answer: string;
-  open?: boolean;
-}
+import { QuickSearchComponent } from './quick-search/quick-search.component';
+import { FaqListComponent, Faq } from './faq-list/faq-list.component';
 
 @Component({
   selector: 'app-help-center',
   standalone: true,
-  imports: [CommonModule, BreadcrumbComponent, SimpleTabsComponent],
+  imports: [
+    CommonModule,
+    BreadcrumbComponent,
+    SimpleTabsComponent,
+    QuickSearchComponent,
+    FaqListComponent
+  ],
   templateUrl: './help-center.component.html',
   styleUrls: ['./help-center.component.scss']
 })
@@ -35,7 +37,8 @@ export class HelpCenterComponent {
     this.activeTab = id;
   }
 
-  toggleFaq(f: Faq) {
-    f.open = !f.open;
+  onSearch(query: string) {
+    // For now simply log the query. A real implementation could filter results.
+    console.log('Help search:', query);
   }
 }

--- a/Frontend/src/app/features/help-center/quick-search/quick-search.component.html
+++ b/Frontend/src/app/features/help-center/quick-search/quick-search.component.html
@@ -1,0 +1,4 @@
+<div class="quick-search">
+  <input type="text" [(ngModel)]="query" placeholder="Search help topics...">
+  <button (click)="submit()"><i class="fas fa-search"></i></button>
+</div>

--- a/Frontend/src/app/features/help-center/quick-search/quick-search.component.scss
+++ b/Frontend/src/app/features/help-center/quick-search/quick-search.component.scss
@@ -1,0 +1,21 @@
+.quick-search {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 1rem;
+
+  input {
+    flex: 1;
+    padding: 0.5rem;
+    border: 1px solid #ccc;
+    border-radius: 4px 0 0 4px;
+  }
+
+  button {
+    padding: 0.5rem 1rem;
+    border: 1px solid #4d148c;
+    background: #4d148c;
+    color: #fff;
+    border-radius: 0 4px 4px 0;
+    cursor: pointer;
+  }
+}

--- a/Frontend/src/app/features/help-center/quick-search/quick-search.component.ts
+++ b/Frontend/src/app/features/help-center/quick-search/quick-search.component.ts
@@ -1,0 +1,20 @@
+import { Component, EventEmitter, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+@Component({
+  selector: 'app-quick-search',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './quick-search.component.html',
+  styleUrls: ['./quick-search.component.scss']
+})
+export class QuickSearchComponent {
+  query = '';
+
+  @Output() search = new EventEmitter<string>();
+
+  submit() {
+    this.search.emit(this.query);
+  }
+}


### PR DESCRIPTION
## Summary
- build out help-center feature
- add QuickSearch and FaqList components
- wire them into HelpCenterComponent
- keep navbar and footer links pointing to `/help`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68461a3cd0f8832ea31160eaa99fcc0c