### PR TITLE
Add Playwright E2E workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,29 @@
+name: E2E Tests
+
+on:
+  push:
+    paths:
+      - 'Frontend/e2e/**'
+      - '.github/workflows/e2e.yml'
+  pull_request:
+    paths:
+      - 'Frontend/e2e/**'
+      - '.github/workflows/e2e.yml'
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: npm ci
+        working-directory: Frontend
+      - name: Install Playwright browsers
+        run: npx playwright install
+        working-directory: Frontend
+      - name: Run Playwright tests
+        run: npx playwright test
+        working-directory: Frontend


### PR DESCRIPTION
## Summary
- add a GitHub Actions job for Playwright E2E tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68461ac842f4832ea56cd36862cff26e