### PR TITLE
Update barcode paths and ignore static outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ Frontend/dist/
 
 # Ignore test caches
 .pytest_cache/
+
+# Ignore generated static files
+static/

--- a/backend/app/scripts/generate_barcode.py
+++ b/backend/app/scripts/generate_barcode.py
@@ -1,9 +1,14 @@
+import os
+from pathlib import Path
 import barcode
 from barcode.writer import ImageWriter
-import os
+
+# Resolve the backend directory based on this file's location
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+DEFAULT_OUTPUT_DIR = os.path.join(BACKEND_DIR, "static", "barcodes")
 
 
-def generate_barcode(value: str, output_dir: str = "static/barcodes"):
+def generate_barcode(value: str, output_dir: str = DEFAULT_OUTPUT_DIR):
     """
     Génère un code-barre et sauvegarde l'image
 

--- a/backend/app/services/colis_service.py
+++ b/backend/app/services/colis_service.py
@@ -3,6 +3,7 @@ import logging
 import uuid
 import random
 from datetime import datetime
+from pathlib import Path
 import barcode
 from barcode.writer import ImageWriter
 from sqlalchemy.orm import Session
@@ -13,11 +14,15 @@ from sqlalchemy.sql import func
 
 logger = logging.getLogger(__name__)
 
+# Resolve the backend directory and default barcode folder
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+DEFAULT_BARCODE_FOLDER = os.path.join(BACKEND_DIR, "static", "barcodes")
+
 
 class ColisService:
     def __init__(self, db: Session):
         self.db = db
-        self.barcode_folder = "static/barcodes"
+        self.barcode_folder = DEFAULT_BARCODE_FOLDER
         os.makedirs(self.barcode_folder, exist_ok=True)
 
     def generate_id(self) -> str:


### PR DESCRIPTION
## Summary
- ignore files generated in `static/`
- store barcodes in `backend/static/barcodes` by default
- update barcode generation script and service to use absolute paths

## Testing
- `pip install -r requirements-test.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68461dd64e1c832e83d68839526ce7b2