### PR TITLE
Fix lifespan context usage

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 import logging
+from contextlib import asynccontextmanager
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 from dotenv import load_dotenv
@@ -33,6 +34,7 @@ def purge_old_history() -> None:
         db.close()
 
 
+@asynccontextmanager
 async def lifespan(app: FastAPI):
     redis_client = redis.from_url(
         settings.REDIS_URL, encoding="utf8", decode_responses=True


### PR DESCRIPTION
## Summary
- import asynccontextmanager in main module
- decorate lifespan function with @asynccontextmanager

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68461dd7fb00832ebba3cff6c7efca10