### PR TITLE
Implement Help Center components

### DIFF
--- a/Frontend/src/app/features/help-center/contact-card/contact-card.component.html
+++ b/Frontend/src/app/features/help-center/contact-card/contact-card.component.html
@@ -1,0 +1,6 @@
+<div class="contact-card" role="region">
+  <i *ngIf="icon" [class]="icon" aria-hidden="true"></i>
+  <h3>{{ heading }}</h3>
+  <p>{{ text }}</p>
+  <a *ngIf="link" [href]="link">{{ linkLabel || link }}</a>
+</div>

--- a/Frontend/src/app/features/help-center/contact-card/contact-card.component.scss
+++ b/Frontend/src/app/features/help-center/contact-card/contact-card.component.scss
@@ -1,0 +1,12 @@
+.contact-card {
+  border: 1px solid #ccc;
+  padding: 1rem;
+  border-radius: 4px;
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.contact-card i {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
+}

--- a/Frontend/src/app/features/help-center/contact-card/contact-card.component.ts
+++ b/Frontend/src/app/features/help-center/contact-card/contact-card.component.ts
@@ -1,0 +1,17 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-contact-card',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './contact-card.component.html',
+  styleUrls: ['./contact-card.component.scss']
+})
+export class ContactCardComponent {
+  @Input() icon = '';
+  @Input() heading = '';
+  @Input() text = '';
+  @Input() link = '';
+  @Input() linkLabel = '';
+}

--- a/Frontend/src/app/features/help-center/faq-list/faq-list.component.html
+++ b/Frontend/src/app/features/help-center/faq-list/faq-list.component.html
@@ -1,6 +1,11 @@
 <div class="faq-list">
-  <div class="faq-item" *ngFor="let f of faqs">
-    <h3 (click)="toggleFaq(f)">{{ f.question }}</h3>
-    <p *ngIf="f.open">{{ f.answer }}</p>
+  <div class="faq-item" *ngFor="let f of faqs; let i = index">
+    <button class="faq-question"
+            (click)="toggleFaq(f)"
+            [attr.aria-expanded]="f.open"
+            [attr.aria-controls]="'faq'+i">
+      {{ f.question }}
+    </button>
+    <p [id]="'faq'+i" *ngIf="f.open">{{ f.answer }}</p>
   </div>
 </div>

--- a/Frontend/src/app/features/help-center/faq-list/faq-list.component.scss
+++ b/Frontend/src/app/features/help-center/faq-list/faq-list.component.scss
@@ -1,4 +1,9 @@
-.faq-item h3 {
+.faq-question {
+  background: none;
+  border: 0;
+  color: #4d148c;
   cursor: pointer;
+  font-size: 1rem;
   margin-bottom: 0.25rem;
+  text-align: left;
 }

--- a/Frontend/src/app/features/help-center/help-center.component.html
+++ b/Frontend/src/app/features/help-center/help-center.component.html
@@ -22,7 +22,16 @@
 
     <div *ngSwitchCase="'contact'" id="contact">
       <h2>Contact Us</h2>
-      <p>For further assistance email <a href="mailto:support@globex.ma">support@globex.ma</a> or call +212 522-123456.</p>
+      <app-contact-card
+        icon="fas fa-envelope"
+        heading="Email"
+        text="support@globex.ma"
+        link="mailto:support@globex.ma"></app-contact-card>
+      <app-contact-card
+        icon="fas fa-phone"
+        heading="Phone"
+        text="+212 522-123456"
+        link="tel:+212522123456"></app-contact-card>
     </div>
   </div>
 </section>

--- a/Frontend/src/app/features/help-center/help-center.component.scss
+++ b/Frontend/src/app/features/help-center/help-center.component.scss
@@ -1,3 +1,9 @@
 .help-center {
   padding: 1rem;
 }
+
+#contact app-contact-card {
+  max-width: 300px;
+  margin: 0 auto 1rem;
+  display: block;
+}

--- a/Frontend/src/app/features/help-center/help-center.component.ts
+++ b/Frontend/src/app/features/help-center/help-center.component.ts
@@ -4,6 +4,7 @@ import { BreadcrumbComponent } from '../../shared/components/breadcrumb/breadcru
 import { SimpleTabsComponent, TabItem } from '../../shared/components/simple-tabs/simple-tabs.component';
 import { QuickSearchComponent } from './quick-search/quick-search.component';
 import { FaqListComponent, Faq } from './faq-list/faq-list.component';
+import { ContactCardComponent } from './contact-card/contact-card.component';
 
 @Component({
   selector: 'app-help-center',
@@ -13,7 +14,8 @@ import { FaqListComponent, Faq } from './faq-list/faq-list.component';
     BreadcrumbComponent,
     SimpleTabsComponent,
     QuickSearchComponent,
-    FaqListComponent
+    FaqListComponent,
+    ContactCardComponent
   ],
   templateUrl: './help-center.component.html',
   styleUrls: ['./help-center.component.scss']

--- a/Frontend/src/app/features/help-center/quick-search/quick-search.component.html
+++ b/Frontend/src/app/features/help-center/quick-search/quick-search.component.html
@@ -1,4 +1,4 @@
-<div class="quick-search">
-  <input type="text" [(ngModel)]="query" placeholder="Search help topics...">
-  <button (click)="submit()"><i class="fas fa-search"></i></button>
-</div>
+<form class="quick-search" (ngSubmit)="submit()">
+  <input type="text" [(ngModel)]="query" name="query" placeholder="Search help topics..." aria-label="Search help topics">
+  <button type="submit"><i class="fas fa-search" aria-hidden="true"></i><span class="visually-hidden">Search</span></button>
+</form>

--- a/Frontend/src/app/shared/components/simple-tabs/simple-tabs.component.html
+++ b/Frontend/src/app/shared/components/simple-tabs/simple-tabs.component.html
@@ -1,7 +1,8 @@
-<div class="simple-tabs" *ngIf="tabs.length">
+<div class="simple-tabs" *ngIf="tabs.length" role="tablist">
   <button *ngFor="let tab of tabs"
           class="tab"
-          [class.active]="tab.id === active"
+          role="tab"
+          [attr.aria-selected]="tab.id === active"
           (click)="setActive(tab.id)">
     {{ tab.label }}
   </button>

--- a/Frontend/src/styles.scss
+++ b/Frontend/src/styles.scss
@@ -161,3 +161,4 @@ h1, h2, h3, h4, h5, h6 {
     font-size: 1.5rem;
   }
 }
+\n.visually-hidden { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }


### PR DESCRIPTION
## Summary
- create `contact-card` component for Help Center
- wire up quick search form and FAQ list with accessibility improvements
- display contact cards under the contact tab
- make tab navigation accessible
- add visually hidden utility class

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684632c15aa0832e9b7ae19e82d4e272