### PR TITLE
Add PostgreSQL to compose setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Create the environment files before starting the containers:
 
 - `backend/.env.local` &ndash; copy from `backend/.env.example` and provide the required backend secrets.
 - `.env` &ndash; copy from `.env.example` and set `GOOGLE_MAPS_API_KEY` for the frontend.
+The Compose stack also starts a `db` service based on PostgreSQL. Database files are stored in the `db-data` volume so data persists between runs.
 
 From the project root run:
 
@@ -149,6 +150,7 @@ On the first run Docker Compose builds the backend and frontend images. Once the
 - Backend: http://localhost:8000
 - Frontend: http://localhost:4200
 - Redis: localhost:6379
+- Database: localhost:5432 (data in `db-data` volume)
 
 ## Running Tests
 

--- a/backend/.env.local
+++ b/backend/.env.local
@@ -1,0 +1,39 @@
+# Example environment configuration for the backend
+
+# FedEx API credentials and settings
+FEDEX_AUTH_URL=https://apis-sandbox.fedex.com/oauth/token
+FEDEX_CLIENT_ID=your-fedex-client-id
+FEDEX_CLIENT_SECRET=your-fedex-client-secret
+FEDEX_ACCOUNT_NUMBER=your-fedex-account-number
+# Optional base URL for FedEx API
+FEDEX_BASE_URL=https://apis-sandbox.fedex.com
+# Secret used to verify FedEx webhook signatures
+FEDEX_WEBHOOK_SECRET=your-fedex-webhook-secret
+
+# Google OAuth credentials
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+GOOGLE_REDIRECT_URI=http://localhost:8000/api/v1/auth/google/callback
+
+# JWT configuration
+ACCESS_TOKEN_EXPIRE_MINUTES=30
+# SECRET_KEY must be set for the application to start
+SECRET_KEY=your-secret-key
+
+# Database connection
+DATABASE_URL=postgresql://postgres:postgres@db:5432/tracking_app
+
+# Server configuration
+HOST=0.0.0.0
+PORT=8000
+DEBUG=True
+
+# History retention period
+HISTORY_RETENTION_DAYS=30
+
+# CORS configuration
+FRONTEND_URL=http://localhost:4200
+
+# Email configuration
+SMTP_USERNAME=your-smtp-username
+SMTP_PASSWORD=your-smtp-password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,3 +24,16 @@ services:
     image: redis:7-alpine
     ports:
       - "6379:6379"
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: tracking_app
+    ports:
+      - "5432:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+
+volumes:
+  db-data:


### PR DESCRIPTION
## Summary
- add PostgreSQL `db` service with persistent volume
- point backend `.env.local` to new database
- document the database service in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684635dbea68832ea9140094bcce75ad