### PR TITLE
Make frontend API URL configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 # Example environment variables for the frontend
 GOOGLE_MAPS_API_KEY=your-google-maps-key
+API_URL=http://localhost:8000/api/v1

--- a/Frontend/Dockerfile
+++ b/Frontend/Dockerfile
@@ -1,6 +1,10 @@
 # Build Angular app
 FROM node:20 AS build
 WORKDIR /app
+ARG GOOGLE_MAPS_API_KEY
+ARG API_URL
+ENV GOOGLE_MAPS_API_KEY=${GOOGLE_MAPS_API_KEY}
+ENV API_URL=${API_URL}
 COPY package*.json ./
 RUN npm ci
 COPY . ./

--- a/Frontend/src/environments/environment.prod.ts
+++ b/Frontend/src/environments/environment.prod.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: true,
-  apiUrl: 'https://api.example.com/api/v1',
+  apiUrl: (process as any).env.API_URL || 'https://api.example.com/api/v1',
   googleMapsApiKey: (process as any).env.GOOGLE_MAPS_API_KEY || ''
 };

--- a/Frontend/src/environments/environment.ts
+++ b/Frontend/src/environments/environment.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: false,
-  apiUrl: 'http://127.0.0.1:8000/api/v1',
+  apiUrl: (process as any).env.API_URL || 'http://127.0.0.1:8000/api/v1',
   googleMapsApiKey: (process as any).env.GOOGLE_MAPS_API_KEY || ''
 };

--- a/Frontend/webpack.config.js
+++ b/Frontend/webpack.config.js
@@ -5,7 +5,8 @@ module.exports = {
   plugins: [
     new Dotenv({
       path: path.resolve(__dirname, '../.env'),
-      systemvars: true
+      systemvars: true,
+      allowlist: ['GOOGLE_MAPS_API_KEY', 'API_URL']
     })
   ]
 };

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Both `backend/.env` and `backend/.env.local` are ignored by Git. Store your secr
 `HISTORY_RETENTION_DAYS` sets how many days of tracking history to keep. Old records older than this value are purged automatically (default: `30`).
 
 The frontend needs a Google Maps API key. Set `GOOGLE_MAPS_API_KEY` in a `.env` file at the project root or export it in your shell before running the Angular app.
+`API_URL` controls the backend base URL used by the frontend and defaults to `http://localhost:8000/api/v1`.
 
 ## Required variables
 
@@ -52,7 +53,7 @@ Follow these steps to run the project locally:
    ```
 
    Update `backend/.env.local` with your FedEx credentials and a `SECRET_KEY`.
-   Set `GOOGLE_MAPS_API_KEY` in `.env` for the frontend.
+   Set `GOOGLE_MAPS_API_KEY` and optionally `API_URL` in `.env` for the frontend.
 3. **Install backend dependencies and start the API**:
 
    ```bash
@@ -92,7 +93,7 @@ uvicorn app.main:app --reload
 
 ## Running the Frontend
 
-Install the Node modules, ensure `GOOGLE_MAPS_API_KEY` is defined, and start Angular:
+Install the Node modules, ensure `GOOGLE_MAPS_API_KEY` and `API_URL` are defined, and start Angular:
 
 ```bash
 cd Frontend
@@ -136,7 +137,7 @@ pytest
 Create the environment files before starting the containers:
 
 - `backend/.env.local` &ndash; copy from `backend/.env.example` and provide the required backend secrets.
-- `.env` &ndash; copy from `.env.example` and set `GOOGLE_MAPS_API_KEY` for the frontend.
+- `.env` &ndash; copy from `.env.example` and set `GOOGLE_MAPS_API_KEY` and `API_URL` for the frontend.
 
 From the project root run:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
     build:
       context: ./Frontend
       dockerfile: Dockerfile
+      args:
+        API_URL: http://backend:8000/api/v1
     ports:
       - "4200:80"
     depends_on:


### PR DESCRIPTION
## Summary
- allow overriding `apiUrl` via `process.env.API_URL` in environments
- expose `API_URL` from webpack
- pass `API_URL` during Docker build
- document new variable and provide example value

## Testing
- `npm -w Frontend --workspaces=false test --silent --if-present`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684635df26dc832ead7edc8c27a64f48