### PR TITLE
Implement full help center page

### DIFF
--- a/Frontend/src/app/features/help-center/contact-card/contact-card.component.scss
+++ b/Frontend/src/app/features/help-center/contact-card/contact-card.component.scss
@@ -4,6 +4,7 @@
   border-radius: 4px;
   text-align: center;
   margin-bottom: 1rem;
+  flex: 1 1 200px;
 }
 
 .contact-card i {

--- a/Frontend/src/app/features/help-center/emergency-notice/emergency-notice.component.html
+++ b/Frontend/src/app/features/help-center/emergency-notice/emergency-notice.component.html
@@ -1,0 +1,7 @@
+<div class="emergency-notice" *ngIf="visible" @fade role="alert">
+  <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
+  <span class="notice-text">{{ message }}</span>
+  <button class="close" (click)="dismiss()" aria-label="Dismiss notification">
+    <i class="fas fa-times" aria-hidden="true"></i>
+  </button>
+</div>

--- a/Frontend/src/app/features/help-center/emergency-notice/emergency-notice.component.scss
+++ b/Frontend/src/app/features/help-center/emergency-notice/emergency-notice.component.scss
@@ -1,0 +1,22 @@
+.emergency-notice {
+  background: #c62828;
+  color: #fff;
+  padding: 0.5rem 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-radius: 4px;
+  margin-bottom: 1rem;
+}
+
+.notice-text {
+  flex: 1;
+  margin-left: 0.5rem;
+}
+
+.close {
+  background: transparent;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+}

--- a/Frontend/src/app/features/help-center/emergency-notice/emergency-notice.component.ts
+++ b/Frontend/src/app/features/help-center/emergency-notice/emergency-notice.component.ts
@@ -1,0 +1,27 @@
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { trigger, transition, style, animate } from '@angular/animations';
+
+@Component({
+  selector: 'app-emergency-notice',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './emergency-notice.component.html',
+  styleUrls: ['./emergency-notice.component.scss'],
+  animations: [
+    trigger('fade', [
+      transition(':enter', [style({ opacity: 0 }), animate('200ms ease-in', style({ opacity: 1 }))]),
+      transition(':leave', [animate('200ms ease-out', style({ opacity: 0 }))])
+    ])
+  ]
+})
+export class EmergencyNoticeComponent {
+  @Input() message = '';
+  @Output() closed = new EventEmitter<void>();
+  visible = true;
+
+  dismiss() {
+    this.visible = false;
+    this.closed.emit();
+  }
+}

--- a/Frontend/src/app/features/help-center/faq-list/faq-list.component.html
+++ b/Frontend/src/app/features/help-center/faq-list/faq-list.component.html
@@ -6,6 +6,6 @@
             [attr.aria-controls]="'faq'+i">
       {{ f.question }}
     </button>
-    <p [id]="'faq'+i" *ngIf="f.open">{{ f.answer }}</p>
+    <p [id]="'faq'+i" *ngIf="f.open" @expand>{{ f.answer }}</p>
   </div>
 </div>

--- a/Frontend/src/app/features/help-center/faq-list/faq-list.component.ts
+++ b/Frontend/src/app/features/help-center/faq-list/faq-list.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { trigger, transition, style, animate } from '@angular/animations';
 
 export interface Faq {
   question: string;
@@ -12,7 +13,13 @@ export interface Faq {
   standalone: true,
   imports: [CommonModule],
   templateUrl: './faq-list.component.html',
-  styleUrls: ['./faq-list.component.scss']
+  styleUrls: ['./faq-list.component.scss'],
+  animations: [
+    trigger('expand', [
+      transition(':enter', [style({ height: 0, opacity: 0 }), animate('200ms ease-out', style({ height: '*', opacity: 1 }))]),
+      transition(':leave', [animate('200ms ease-in', style({ height: 0, opacity: 0 }))])
+    ])
+  ]
 })
 export class FaqListComponent {
   @Input() faqs: Faq[] = [];

--- a/Frontend/src/app/features/help-center/help-center.component.html
+++ b/Frontend/src/app/features/help-center/help-center.component.html
@@ -1,37 +1,42 @@
 <section class="help-center">
   <app-breadcrumb [items]="[{label: 'Home', url: '/home'}, {label: 'Help Center'}]"></app-breadcrumb>
+  <app-emergency-notice *ngIf="showEmergency" [message]="emergencyMessage" (closed)="dismissEmergency()"></app-emergency-notice>
   <h1>Help Center</h1>
   <app-quick-search (search)="onSearch($event)"></app-quick-search>
   <app-simple-tabs [tabs]="tabs" [active]="activeTab" (select)="selectTab($event)"></app-simple-tabs>
 
   <div [ngSwitch]="activeTab">
-    <div *ngSwitchCase="'advice'" id="advice">
+    <div *ngSwitchCase="'advice'" id="advice" @fade>
       <h2>Advice</h2>
       <p>Find tips on how to get the most from our tracking services.</p>
     </div>
 
-    <div *ngSwitchCase="'tools'" id="tools">
+    <div *ngSwitchCase="'tools'" id="tools" @fade>
       <h2>Tracking Tools</h2>
       <p>Explore our suite of tracking tools for every need.</p>
     </div>
 
-    <div *ngSwitchCase="'faq'" id="faq">
+    <div *ngSwitchCase="'faq'" id="faq" @fade>
       <h2>Frequently Asked Questions</h2>
       <app-faq-list [faqs]="faqs"></app-faq-list>
     </div>
 
-    <div *ngSwitchCase="'contact'" id="contact">
+    <div *ngSwitchCase="'contact'" id="contact" class="contact-section" @fade>
       <h2>Contact Us</h2>
-      <app-contact-card
-        icon="fas fa-envelope"
-        heading="Email"
-        text="support@globex.ma"
-        link="mailto:support@globex.ma"></app-contact-card>
-      <app-contact-card
-        icon="fas fa-phone"
-        heading="Phone"
-        text="+212 522-123456"
-        link="tel:+212522123456"></app-contact-card>
+      <div class="card-grid">
+        <app-contact-card
+          icon="fas fa-envelope"
+          heading="Email"
+          text="support@globex.ma"
+          link="mailto:support@globex.ma"
+          linkLabel="Email Us"></app-contact-card>
+        <app-contact-card
+          icon="fas fa-phone"
+          heading="Phone"
+          text="+212 522-123456"
+          link="tel:+212522123456"
+          linkLabel="Call Now"></app-contact-card>
+      </div>
     </div>
   </div>
 </section>

--- a/Frontend/src/app/features/help-center/help-center.component.scss
+++ b/Frontend/src/app/features/help-center/help-center.component.scss
@@ -4,6 +4,12 @@
 
 #contact app-contact-card {
   max-width: 300px;
-  margin: 0 auto 1rem;
-  display: block;
+  margin-bottom: 1rem;
+}
+
+.card-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
 }

--- a/Frontend/src/app/features/help-center/help-center.component.ts
+++ b/Frontend/src/app/features/help-center/help-center.component.ts
@@ -1,10 +1,12 @@
 import { Component } from '@angular/core';
+import { trigger, transition, style, animate } from '@angular/animations';
 import { CommonModule } from '@angular/common';
 import { BreadcrumbComponent } from '../../shared/components/breadcrumb/breadcrumb.component';
 import { SimpleTabsComponent, TabItem } from '../../shared/components/simple-tabs/simple-tabs.component';
 import { QuickSearchComponent } from './quick-search/quick-search.component';
 import { FaqListComponent, Faq } from './faq-list/faq-list.component';
 import { ContactCardComponent } from './contact-card/contact-card.component';
+import { EmergencyNoticeComponent } from './emergency-notice/emergency-notice.component';
 
 @Component({
   selector: 'app-help-center',
@@ -15,7 +17,14 @@ import { ContactCardComponent } from './contact-card/contact-card.component';
     SimpleTabsComponent,
     QuickSearchComponent,
     FaqListComponent,
-    ContactCardComponent
+    ContactCardComponent,
+    EmergencyNoticeComponent
+  ],
+  animations: [
+    trigger('fade', [
+      transition(':enter', [style({ opacity: 0 }), animate('300ms ease-in', style({ opacity: 1 }))]),
+      transition(':leave', [animate('300ms ease-out', style({ opacity: 0 }))])
+    ])
   ],
   templateUrl: './help-center.component.html',
   styleUrls: ['./help-center.component.scss']
@@ -29,6 +38,9 @@ export class HelpCenterComponent {
   ];
   activeTab = 'advice';
 
+  emergencyMessage = 'Severe weather may delay shipments in some areas.';
+  showEmergency = true;
+
   faqs: Faq[] = [
     { question: 'Comment suivre mon colis ?', answer: "Entrez votre numéro de suivi dans la barre de recherche en haut de la page pour suivre votre colis en temps réel." },
     { question: 'Quels sont les délais de livraison ?', answer: 'Les délais de livraison varient selon le service choisi : Express (24h), Standard (2-3 jours), Économique (3-5 jours).' },
@@ -37,6 +49,10 @@ export class HelpCenterComponent {
 
   selectTab(id: string) {
     this.activeTab = id;
+  }
+
+  dismissEmergency() {
+    this.showEmergency = false;
   }
 
   onSearch(query: string) {

--- a/Frontend/src/app/features/help-center/quick-search/quick-search.component.html
+++ b/Frontend/src/app/features/help-center/quick-search/quick-search.component.html
@@ -1,4 +1,4 @@
-<form class="quick-search" (ngSubmit)="submit()">
+<form class="quick-search" role="search" (ngSubmit)="submit()">
   <input type="text" [(ngModel)]="query" name="query" placeholder="Search help topics..." aria-label="Search help topics">
   <button type="submit"><i class="fas fa-search" aria-hidden="true"></i><span class="visually-hidden">Search</span></button>
 </form>

--- a/Frontend/src/app/features/help-center/quick-search/quick-search.component.ts
+++ b/Frontend/src/app/features/help-center/quick-search/quick-search.component.ts
@@ -15,6 +15,9 @@ export class QuickSearchComponent {
   @Output() search = new EventEmitter<string>();
 
   submit() {
-    this.search.emit(this.query);
+    const q = this.query.trim();
+    if (q) {
+      this.search.emit(q);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- build EmergencyNoticeComponent for important alerts
- enhance QuickSearchComponent, FAQ animations and contact cards
- style HelpCenterComponent with tab animations
- update /help page templates

## Testing
- `npm test --prefix Frontend` *(fails: ng not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684638e97cbc832e93f74a45d2352fc0