### PR TITLE
Use color variables in FedEx design

### DIFF
--- a/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.scss
+++ b/Frontend/src/app/features/tracking/fedex-track-result/fedex-track-result.component.scss
@@ -53,7 +53,7 @@
 }
 
 .text-white {
-  color: #ffffff;
+  color: var(--white);
 }
 
 .px-6 {
@@ -141,15 +141,15 @@
 
 /* Summary card styling */
 .summary-card {
-  background: #ffffff;
+  background: var(--white);
   border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow);
   overflow: hidden;
 }
 
 .summary-header {
   background: #4d148c;
-  color: #ffffff;
+  color: var(--white);
   padding: 0.75rem 1rem;
   display: flex;
   justify-content: space-between;
@@ -158,7 +158,7 @@
 
 .summary-details {
   padding: 1rem;
-  color: #333;
+  color: var(--text-dark);
 }
 
 .summary-actions {
@@ -170,7 +170,7 @@
 
 .summary-actions button {
   background: #ff6600;
-  color: #ffffff;
+  color: var(--white);
   border: none;
   padding: 0.5rem 0.75rem;
   border-radius: 4px;
@@ -197,7 +197,7 @@
   height: 100%;
   background: #4d148c;
   width: 0;
-  transition: width 0.3s ease;
+  transition: width var(--transition);
   border-radius: 2px;
 }
 
@@ -220,7 +220,7 @@
   height: 2rem;
   border-radius: 50%;
   background: #e5e7eb;
-  color: #ffffff;
+  color: var(--white);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -261,7 +261,7 @@
   height: 1.25rem;
   border-radius: 50%;
   background: #ff6600;
-  color: #fff;
+  color: var(--white);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/Frontend/src/styles.scss
+++ b/Frontend/src/styles.scss
@@ -11,6 +11,10 @@
   --primary-orange-dark: #190900;
   --text-color: #333;
   --text-light: #d6d6d6;
+  --white: #ffffff;
+  --text-dark: #333;
+  --shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  --transition: 0.3s ease;
   --light-gray: #f5f5f5;
   --border-color: #e0e0e0;
   --success-green: #28a745;


### PR DESCRIPTION
## Summary
- define theme variables like `--white` and `--transition` in the global stylesheet
- reuse those variables in the FedEx tracking result page

## Testing
- `npm test` *(fails: No binary for Chrome browser)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68463d3e4bcc832eb47d15a8ee32c29a