### PR TITLE
Update README test instructions

### DIFF
--- a/Frontend/README.md
+++ b/Frontend/README.md
@@ -6,4 +6,10 @@ The image builds the Angular code from the `Frontend` directory, then serves the
 
 ## Unit tests
 
-Run `npm test` to execute the Angular unit tests. Karma launches Chrome by default, so a local Chrome (or Chromium) installation is required. On headless systems you can set the `CHROME_BIN` environment variable to the path of a Chrome executable, such as the binary provided by the `chromium-browser` package.
+Run `npm test` to execute the Angular unit tests. Karma normally launches the system Chrome. In CI you can instead use Playwright's bundled Chromium with `--no-sandbox` or set `CHROME_BIN` to the path of that bundled executable.
+
+```bash
+npx playwright install chromium
+export CHROME_BIN=$(pwd)/node_modules/playwright-core/.local-browsers/chromium-*/chrome-linux/chrome
+CI=true npm test -- --watch=false --browsers=ChromeHeadless --no-sandbox
+```

--- a/README.md
+++ b/README.md
@@ -165,9 +165,18 @@ pytest
 ```
 
 Angular unit tests are executed with Karma via `npm test` in the `Frontend`
-directory. Karma requires a local Chrome (or Chromium) installation. On headless
-systems you can set the `CHROME_BIN` environment variable to the path of a
-Chrome executable.
+directory. Karma launches Chrome so a local installation is normally
+required. On CI systems you can either run Playwright's bundled Chromium with
+`--no-sandbox` or set `CHROME_BIN` to the path of that bundled Chrome
+executable.
+
+Example using Playwright's browser:
+
+```bash
+npx playwright install chromium
+export CHROME_BIN=$(pwd)/node_modules/playwright-core/.local-browsers/chromium-*/chrome-linux/chrome
+CI=true npm test -- --watch=false --browsers=ChromeHeadless --no-sandbox
+```
 
 ## Password requirements
 


### PR DESCRIPTION
## Summary
- document using Playwright’s Chromium for unit tests in CI
- show how to run `npm test` without a system Chrome

## Testing
- `pytest -q`
- `npm test -- --watch=false`

------
https://chatgpt.com/codex/tasks/task_e_68463d3e46f0832ea38877cf2a860de1